### PR TITLE
stat_tracking: fix AttributeError on second update() call caused by in-place np.stack overwrite

### DIFF
--- a/flow_grpo/flow_grpo/stat_tracking.py
+++ b/flow_grpo/flow_grpo/stat_tracking.py
@@ -20,13 +20,13 @@ class PerPromptStatTracker:
             self.stats[prompt].extend(prompt_rewards)
             self.history_prompts.add(hash(prompt))  # Add hash of prompt to history_prompts
         for prompt in unique:
-            self.stats[prompt] = np.stack(self.stats[prompt])
+            prompt_history = np.array(self.stats[prompt])
             prompt_rewards = rewards[prompts == prompt]  # Fix: Recalculate prompt_rewards for each prompt
-            mean = np.mean(self.stats[prompt], axis=0, keepdims=True)
+            mean = np.mean(prompt_history, axis=0, keepdims=True)
             if self.global_std:
                 std = np.std(rewards, axis=0, keepdims=True) + 1e-4  # Use global std of all rewards
             else:
-                std = np.std(self.stats[prompt], axis=0, keepdims=True) + 1e-4
+                std = np.std(prompt_history, axis=0, keepdims=True) + 1e-4
             if type=='grpo':
                 advantages[prompts == prompt] = (prompt_rewards - mean) / std
             elif type=='rwr':


### PR DESCRIPTION
## What

`PerPromptStatTracker.update()` crashes with `AttributeError: 'numpy.ndarray'
object has no attribute 'extend'` on any call after the first when the same
prompt key is seen again.

## Root Cause

The second `for` loop in `update()` overwrites `self.stats[prompt]` with the
result of `np.stack(...)`, converting the stored value from a `list` to a
`numpy.ndarray`. On the next call, the first `for` loop tries to call
`.extend()` on that ndarray, which does not exist on that type.

```python
# before — mutates self.stats[prompt] to ndarray
self.stats[prompt] = np.stack(self.stats[prompt])
```

## Fix

Compute the stacked array into a local variable `prompt_history` instead of
overwriting `self.stats[prompt]`, so the list is preserved across calls.

```python
# after — self.stats[prompt] stays a list
prompt_history = np.array(self.stats[prompt])
```

All downstream mean/std calculations use `prompt_history`; no values change.

## Impact

- Affects all training scripts that rely on cross-call reward history
  accumulation (`train_sd3.py`, `train_flux.py`, `train_flux_fast.py`, etc.)
- The built-in `main()` smoke test only calls `update()` once before `clear()`,
  so the bug was not caught locally
- One-line change, zero behaviour delta