### PR TITLE
fix qwen image 2gpu example param

### DIFF
--- a/scripts/run-diffusion-grpo-ocr-2gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-ocr-2gpu-flowgrpo-aligned.sh
@@ -49,7 +49,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --hf-checkpoint Qwen/Qwen-Image \
   --prompt-data "${DATASETS_DIR}/flowgrpo_ocr/train.jsonl" \
   --input-key input \
-  --rollout-batch-size 16 \
+  --rollout-batch-size 32 \
   --n-samples-per-prompt 16 \
   --num-rollout 100000 \
   --diffusion-microgroup-size 16 \

--- a/scripts/run-diffusion-grpo-pickscore-2gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-2gpu-flowgrpo-aligned.sh
@@ -52,7 +52,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --hf-checkpoint Qwen/Qwen-Image \
   --prompt-data "${DATASETS_DIR}/flowgrpo_pickscore/train.jsonl" \
   --input-key input \
-  --rollout-batch-size 16 \
+  --rollout-batch-size 32 \
   --n-samples-per-prompt 16 \
   --num-rollout 100000 \
   --diffusion-microgroup-size 16 \


### PR DESCRIPTION
<img width="1800" height="1114" alt="image" src="https://github.com/user-attachments/assets/fd3ee5df-2f3a-4760-8b31-4b5b0347cbf8" />

fix 2gpu hyperparam, previous 2gpu param can be unstable due to the small rollout-batch-size
purple: 2gpu before fix, blue: 2gpu after fix, green: 4gpu verified baseline curve