### PR TITLE
feat: deterministic training actor

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from argparse import Namespace
 from collections import defaultdict
@@ -22,12 +23,61 @@ from miles.utils.timer import Timer, inverse_timer, timer
 from miles.utils.tracking_utils import init_tracking
 
 from . import checkpoint
+from .arguments import deterministic_capable_flash_fns
 from .configs.train_pipeline_config import get_train_pipeline_config
 from .diffusion_update_weight_utils import DiffusionUpdateWeightFromTensor, DiffusionUpdateWeightFromTensorLoRA
 from .lr_scheduler import get_lr_scheduler
 from .parallel import create_fsdp_parallel_state
 
 logger = logging.getLogger(__name__)
+
+
+def _enable_deterministic_training(args: Namespace) -> None:
+    """Train-actor deterministic mode (mirrors VeOmni's enable_full_determinism).
+
+    NCCL_DETERMINISTIC / CUBLAS_WORKSPACE_CONFIG are injected at actor spawn (see
+    actor_group) because NCCL/cuBLAS read them before this runs. Here we set the
+    torch-runtime knobs plus the flash-attn kernel knob that torch's global flag
+    can't reach. validate_attention_args has already rejected backends we cannot
+    make deterministic; see it for the support matrix.
+    """
+    # deterministic cuDNN algorithms; no need to disable cuDNN outright.
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    # warn_only=True to keep training runnable — ops lacking a deterministic impl
+    # warn instead of crashing. Trade-off: the SDPA (native) backward only switches
+    # to its deterministic path under warn_only=False (deterministicAlgorithms() &&
+    # !warnOnly; see aten attention_backward.cu), so here it only warns and stays
+    # nondeterministic. Under this mode only the flash backend (patched below) is
+    # guaranteed deterministic.
+    torch.use_deterministic_algorithms(True, warn_only=True)
+
+    # flash-attn is a separate CUDA extension (not torch SDPA), so torch's flag
+    # can't reach it and diffusers neither forwards deterministic= nor reads
+    # FLASH_ATTENTION_DETERMINISTIC — we patch it on directly.
+    backend = args.fsdp_attention_backend
+    if backend is not None and "flash" in backend.lower():
+        _enable_deterministic_flash_attention()
+
+
+def _enable_deterministic_flash_attention() -> None:
+    """Wrap diffusers' flash entry points so they run with deterministic=True.
+
+    diffusers never forwards deterministic to flash-attn, so we patch the module
+    globals it dispatches through. Only the backward differs, so the flash forward
+    (and train/rollout consistency) is unchanged. The set of patchable functions
+    is already validated up front by load_fsdp_args. Idempotent across re-inits.
+    """
+    import diffusers.models.attention_dispatch as ad
+
+    if getattr(ad, "_miles_deterministic_flash_patched", False):
+        return
+
+    names = deterministic_capable_flash_fns()
+    for name in names:
+        setattr(ad, name, functools.partial(getattr(ad, name), deterministic=True))
+    ad._miles_deterministic_flash_patched = True
+    logger.info("Enabled deterministic flash attention backward for: %s", ", ".join(names))
 
 
 class FSDPTrainRayActor(TrainRayActor):
@@ -40,6 +90,9 @@ class FSDPTrainRayActor(TrainRayActor):
     @with_defer(lambda: Timer().start("train_wait"))
     def init(self, args: Namespace, role: str, with_ref: bool = False) -> int:  # type: ignore[override]
         super().init(args, role, with_ref)
+
+        if args.deterministic_mode:
+            _enable_deterministic_training(args)
 
         self.parallel_state = create_fsdp_parallel_state(args)
         torch.manual_seed(args.seed)
@@ -77,6 +130,9 @@ class FSDPTrainRayActor(TrainRayActor):
             model = pipeline.transformer
             self.scheduler = pipeline.scheduler
             del pipeline
+
+        if args.fsdp_attention_backend is not None:
+            model.set_attention_backend(args.fsdp_attention_backend)
 
         self.train_pipeline_config = get_train_pipeline_config(args.diffusion_model)
 

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -33,42 +33,23 @@ logger = logging.getLogger(__name__)
 
 
 def _enable_deterministic_training(args: Namespace) -> None:
-    """Train-actor deterministic mode (mirrors VeOmni's enable_full_determinism).
-
-    NCCL_DETERMINISTIC / CUBLAS_WORKSPACE_CONFIG are injected at actor spawn (see
-    actor_group) because NCCL/cuBLAS read them before this runs. Here we set the
-    torch-runtime knobs plus the flash-attn kernel knob that torch's global flag
-    can't reach. validate_attention_args has already rejected backends we cannot
-    make deterministic; see it for the support matrix.
-    """
-    # deterministic cuDNN algorithms; no need to disable cuDNN outright.
+    """Train-actor deterministic mode. NCCL/CUBLAS env is set at spawn (actor_group);
+    here we set the torch-runtime knobs."""
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-    # warn_only=False is required, not just stricter: the SDPA (native) backward
-    # only takes its deterministic path when deterministicAlgorithms() && !warnOnly
-    # (see aten attention_backward.cu) — with warn_only=True it silently keeps the
-    # fast nondeterministic kernel. So warn_only=True would make this mode a no-op on
-    # any SDPA/native backend. The cost is that a truly nondeterministic op raises
-    # instead of warning; validated on Qwen-Image (B200) that real training does not
-    # hit one, and that two 4-step runs are then bit-identical (metrics + weights).
+    # warn_only=False is required: SDPA's deterministic backward is gated on
+    # !warnOnly (aten attention_backward.cu), so warn_only=True is a no-op on native.
     torch.use_deterministic_algorithms(True, warn_only=False)
 
-    # flash-attn is a separate CUDA extension (not torch SDPA), so torch's flag
-    # can't reach it and diffusers neither forwards deterministic= nor reads
-    # FLASH_ATTENTION_DETERMINISTIC — we patch it on directly.
+    # flash-attn is a separate CUDA extension torch's flag can't reach; patch it on.
     backend = args.fsdp_attention_backend
     if backend is not None and "flash" in backend.lower():
         _enable_deterministic_flash_attention()
 
 
 def _enable_deterministic_flash_attention() -> None:
-    """Wrap diffusers' flash entry points so they run with deterministic=True.
-
-    diffusers never forwards deterministic to flash-attn, so we patch the module
-    globals it dispatches through. Only the backward differs, so the flash forward
-    (and train/rollout consistency) is unchanged. The set of patchable functions
-    is already validated up front by load_fsdp_args. Idempotent across re-inits.
-    """
+    """Patch diffusers' flash globals to run deterministic=True (backward only;
+    forward unchanged). Idempotent."""
     import diffusers.models.attention_dispatch as ad
 
     if getattr(ad, "_miles_deterministic_flash_patched", False):

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -44,13 +44,14 @@ def _enable_deterministic_training(args: Namespace) -> None:
     # deterministic cuDNN algorithms; no need to disable cuDNN outright.
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-    # warn_only=True to keep training runnable — ops lacking a deterministic impl
-    # warn instead of crashing. Trade-off: the SDPA (native) backward only switches
-    # to its deterministic path under warn_only=False (deterministicAlgorithms() &&
-    # !warnOnly; see aten attention_backward.cu), so here it only warns and stays
-    # nondeterministic. Under this mode only the flash backend (patched below) is
-    # guaranteed deterministic.
-    torch.use_deterministic_algorithms(True, warn_only=True)
+    # warn_only=False is required, not just stricter: the SDPA (native) backward
+    # only takes its deterministic path when deterministicAlgorithms() && !warnOnly
+    # (see aten attention_backward.cu) — with warn_only=True it silently keeps the
+    # fast nondeterministic kernel. So warn_only=True would make this mode a no-op on
+    # any SDPA/native backend. The cost is that a truly nondeterministic op raises
+    # instead of warning; validated on Qwen-Image (B200) that real training does not
+    # hit one, and that two 4-step runs are then bit-identical (metrics + weights).
+    torch.use_deterministic_algorithms(True, warn_only=False)
 
     # flash-attn is a separate CUDA extension (not torch SDPA), so torch's flag
     # can't reach it and diffusers neither forwards deterministic= nor reads

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -53,11 +53,8 @@ class FSDPArgs:
         "gloo"  # CPU backend for FSDP CPU offload (e.g., "gloo"). Set to None to disable hybrid backend.
     )
 
-    # Train-actor deterministic mode. Turns on process-global torch determinism
-    # (use_deterministic_algorithms + cudnn.deterministic + CUBLAS_WORKSPACE_CONFIG)
-    # and, for attention backends torch's global flag can't reach, the per-backend
-    # knob (flash-attn's deterministic=). See validate_attention_args for the
-    # backend support matrix. Name kept identical to Megatron's.
+    # Train-actor deterministic mode; see validate_attention_args for the backend
+    # support matrix. Name kept identical to Megatron's.
     deterministic_mode: bool = False
 
     # Context Parallelism
@@ -93,25 +90,14 @@ def parse_fsdp_cli(extra_args_provider=None):
     return args
 
 
-# ---------------------------------------------------------------------------
-# Deterministic-mode attention support matrix. KEEP THIS IN SYNC when adding a
-# backend: torch.use_deterministic_algorithms only governs torch-native ops, so
-# a custom attention kernel that is not listed here runs a nondeterministic
-# backward *silently* under deterministic mode.
-#
-#   native / _native_* (torch SDPA) : deterministic backward via torch's global flag
-#                                      — but only with warn_only=False (see actor
-#                                      _enable_deterministic_training and aten
-#                                      attention_backward.cu). Nothing else to do.
-#   flash* / _flash_3* (flash-attn) : flash-attn's per-call `deterministic=` is NOT
-#                                      reached by torch's global flag and diffusers
-#                                      never forwards it -> we monkey-patch it on.
-#   sage* / xformers / flex / aiter : custom kernels opaque to torch's flag with no
-#                                      deterministic hook here -> refuse (validate).
-# ---------------------------------------------------------------------------
+# Deterministic-mode attention support matrix — KEEP IN SYNC. torch's flag only
+# governs torch-native ops, so an unlisted custom kernel runs nondeterministic
+# silently under deterministic mode.
+#   native / _native_*  (SDPA)      : torch's flag (needs warn_only=False)
+#   flash* / _flash_3*  (flash-attn): patch deterministic= on (flag can't reach it)
+#   sage / xformers / flex / aiter  : opaque to torch, no hook -> reject (validate)
 
-# diffusers' flash backends dispatch through these module globals; the FA3
-# custom op reads them at call time too.
+# diffusers dispatches flash through these module globals (FA3 op reads them too).
 _FLASH_ATTN_DISPATCH_FNS = (
     "flash_attn_func",
     "flash_attn_varlen_func",

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -32,6 +32,10 @@ class FSDPArgs:
 
     attn_implementation: str = "flash_attention_2"
 
+    # DiT attention backend, passed to diffusers set_attention_backend (e.g.
+    # "flash", "sage", "native"). None keeps the diffusers default.
+    fsdp_attention_backend: str | None = None
+
     # Logging
     wandb_project: str = "miles-fsdp"
     wandb_run_name: str | None = None
@@ -49,7 +53,12 @@ class FSDPArgs:
         "gloo"  # CPU backend for FSDP CPU offload (e.g., "gloo"). Set to None to disable hybrid backend.
     )
 
-    deterministic_mode: bool = False  # This name must be the same as Megatron's
+    # Train-actor deterministic mode. Turns on process-global torch determinism
+    # (use_deterministic_algorithms + cudnn.deterministic + CUBLAS_WORKSPACE_CONFIG)
+    # and, for attention backends torch's global flag can't reach, the per-backend
+    # knob (flash-attn's deterministic=). See validate_attention_args for the
+    # backend support matrix. Name kept identical to Megatron's.
+    deterministic_mode: bool = False
 
     # Context Parallelism
     context_parallel_size: int = 1  # Context Parallelism size
@@ -84,6 +93,80 @@ def parse_fsdp_cli(extra_args_provider=None):
     return args
 
 
+# ---------------------------------------------------------------------------
+# Deterministic-mode attention support matrix. KEEP THIS IN SYNC when adding a
+# backend: torch.use_deterministic_algorithms only governs torch-native ops, so
+# a custom attention kernel that is not listed here runs a nondeterministic
+# backward *silently* under deterministic mode.
+#
+#   native / _native_* (torch SDPA) : its deterministic backward needs
+#                                      warn_only=False; under the warn_only=True we
+#                                      use, torch WARNS and stays nondeterministic
+#                                      (loud, not silent — acceptable). See actor
+#                                      _enable_deterministic_training.
+#   flash* / _flash_3* (flash-attn) : flash-attn's per-call `deterministic=` is NOT
+#                                      reached by torch's global flag and diffusers
+#                                      never forwards it -> we monkey-patch it on.
+#   sage* / xformers / flex / aiter : custom kernels opaque to torch's flag with no
+#                                      deterministic hook here -> refuse (validate).
+# ---------------------------------------------------------------------------
+
+# diffusers' flash backends dispatch through these module globals; the FA3
+# custom op reads them at call time too.
+_FLASH_ATTN_DISPATCH_FNS = (
+    "flash_attn_func",
+    "flash_attn_varlen_func",
+    "flash_attn_3_func",
+    "flash_attn_3_varlen_func",
+)
+
+
+def deterministic_capable_flash_fns():
+    """diffusers flash entry points whose signature accepts a `deterministic` arg."""
+    import inspect
+
+    import diffusers.models.attention_dispatch as ad
+
+    out = []
+    for name in _FLASH_ATTN_DISPATCH_FNS:
+        fn = getattr(ad, name, None)
+        if fn is None:
+            continue
+        try:
+            if "deterministic" in inspect.signature(fn).parameters:
+                out.append(name)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def validate_attention_args(args):
+    """Fail fast (driver-side, before any actor launches) on deterministic-mode misconfig."""
+    if not getattr(args, "deterministic_mode", False):
+        return
+    backend = args.fsdp_attention_backend
+    name = "" if backend is None else backend.lower()
+    # torch SDPA (diffusers default / native): torch's global determinism covers it.
+    if backend is None or "native" in name:
+        return
+    # flash-attn: torch's global flag can't reach it; we patch its deterministic= on.
+    if "flash" in name:
+        if not deterministic_capable_flash_fns():
+            raise RuntimeError(
+                "deterministic_mode with a flash attention backend, but no diffusers "
+                "flash entry point exposes a deterministic argument (is flash-attn "
+                "installed and recent enough?)."
+            )
+        return
+    # Anything else is a custom kernel we can neither cover via torch nor patch.
+    raise ValueError(
+        f"deterministic_mode cannot guarantee a deterministic backward for attention "
+        f"backend '{backend}': it is a custom kernel opaque to "
+        f"torch.use_deterministic_algorithms with no deterministic hook here. Use a "
+        f"flash (flash/_flash_3) or native (SDPA) backend."
+    )
+
+
 def load_fsdp_args(extra_args_provider=None):
     args = parse_fsdp_cli(extra_args_provider)
     if args.config:
@@ -92,4 +175,5 @@ def load_fsdp_args(extra_args_provider=None):
         for k, v in data.items():
             if not hasattr(args, k):
                 setattr(args, k, v)
+    validate_attention_args(args)
     return args

--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -99,11 +99,10 @@ def parse_fsdp_cli(extra_args_provider=None):
 # a custom attention kernel that is not listed here runs a nondeterministic
 # backward *silently* under deterministic mode.
 #
-#   native / _native_* (torch SDPA) : its deterministic backward needs
-#                                      warn_only=False; under the warn_only=True we
-#                                      use, torch WARNS and stays nondeterministic
-#                                      (loud, not silent — acceptable). See actor
-#                                      _enable_deterministic_training.
+#   native / _native_* (torch SDPA) : deterministic backward via torch's global flag
+#                                      — but only with warn_only=False (see actor
+#                                      _enable_deterministic_training and aten
+#                                      attention_backward.cu). Nothing else to do.
 #   flash* / _flash_3* (flash-attn) : flash-attn's per-call `deterministic=` is NOT
 #                                      reached by torch's global flag and diffusers
 #                                      never forwards it -> we monkey-patch it on.

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -55,6 +55,15 @@ class RayTrainGroup:
             "NVTE_FP8_BLOCK_SCALING_FP32_SCALES": "1",
             **self.args.train_env_vars,
         }
+
+        if getattr(self.args, "deterministic_mode", False):
+            # NCCL reads NCCL_DETERMINISTIC at init_process_group and cuBLAS reads
+            # CUBLAS_WORKSPACE_CONFIG at handle creation — both happen inside the
+            # actor's super().init()/first matmul, so they must be in the process
+            # env at spawn, not set from within the actor. The torch-runtime knobs
+            # (use_deterministic_algorithms, cudnn) are set in the actor instead.
+            env_vars.setdefault("NCCL_DETERMINISTIC", "1")
+            env_vars.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
         # Let Ray set CUDA_VISIBLE_DEVICES per actor to avoid all ranks
         # sharing GPU0. (Old --diffusion-train branch removed.)
 

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -61,7 +61,9 @@ class RayTrainGroup:
             # init_process_group and cuBLAS at first matmul, both before the actor
             # runs. torch-runtime knobs are set in the actor instead.
             env_vars.setdefault("NCCL_DETERMINISTIC", "1")
-            env_vars.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+            # :4096:8 (not :16:8) so cuBLASLT isn't workspace-limited; both are
+            # deterministic, this one avoids the perf hit. ~32 MiB/handle.
+            env_vars.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
         # Let Ray set CUDA_VISIBLE_DEVICES per actor to avoid all ranks
         # sharing GPU0. (Old --diffusion-train branch removed.)
 

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -57,11 +57,9 @@ class RayTrainGroup:
         }
 
         if getattr(self.args, "deterministic_mode", False):
-            # NCCL reads NCCL_DETERMINISTIC at init_process_group and cuBLAS reads
-            # CUBLAS_WORKSPACE_CONFIG at handle creation — both happen inside the
-            # actor's super().init()/first matmul, so they must be in the process
-            # env at spawn, not set from within the actor. The torch-runtime knobs
-            # (use_deterministic_algorithms, cudnn) are set in the actor instead.
+            # Must be in the process env at spawn: NCCL reads it at
+            # init_process_group and cuBLAS at first matmul, both before the actor
+            # runs. torch-runtime knobs are set in the actor instead.
             env_vars.setdefault("NCCL_DETERMINISTIC", "1")
             env_vars.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")
         # Let Ray set CUDA_VISIBLE_DEVICES per actor to avoid all ranks

--- a/tests/fast/backends/test_fsdp_deterministic_args.py
+++ b/tests/fast/backends/test_fsdp_deterministic_args.py
@@ -1,0 +1,49 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+import pytest
+
+from miles.backends.fsdp_utils import arguments as fsdp_args
+
+
+def _args(deterministic_mode, fsdp_attention_backend):
+    return Namespace(deterministic_mode=deterministic_mode, fsdp_attention_backend=fsdp_attention_backend)
+
+
+class TestValidateAttentionArgs:
+    def test_disabled_is_noop(self):
+        # deterministic_mode off -> no validation, any backend is accepted
+        fsdp_args.validate_attention_args(_args(False, "sage"))
+
+    @pytest.mark.parametrize("backend", [None, "native", "_native_efficient", "NATIVE"])
+    def test_native_backends_ok(self, backend):
+        # torch's global flag covers SDPA/native
+        fsdp_args.validate_attention_args(_args(True, backend))
+
+    @pytest.mark.parametrize("backend", ["sage", "xformers", "flex", "aiter"])
+    def test_custom_kernels_rejected(self, backend):
+        # opaque to torch's flag, no hook -> refuse rather than run nondeterministic
+        with pytest.raises(ValueError):
+            fsdp_args.validate_attention_args(_args(True, backend))
+
+    def test_flash_rejected_when_no_capable_fn(self, monkeypatch):
+        monkeypatch.setattr(fsdp_args, "deterministic_capable_flash_fns", lambda: [])
+        with pytest.raises(RuntimeError):
+            fsdp_args.validate_attention_args(_args(True, "flash"))
+
+    def test_flash_ok_when_capable(self, monkeypatch):
+        monkeypatch.setattr(fsdp_args, "deterministic_capable_flash_fns", lambda: ["flash_attn_func"])
+        fsdp_args.validate_attention_args(_args(True, "_flash_3"))  # no raise
+
+
+def test_fsdp_args_expose_new_flags():
+    import dataclasses
+
+    from miles.backends.fsdp_utils.arguments import FSDPArgs
+
+    names = {f.name for f in dataclasses.fields(FSDPArgs)}
+    assert "fsdp_attention_backend" in names
+    assert "deterministic_mode" in names


### PR DESCRIPTION
## What

Two new FSDP training args for the diffusion GRPO actor:

- **`--fsdp-attention-backend`** — forwarded to diffusers `set_attention_backend` on the trained DiT (diffusers vocabulary: `flash`, `_flash_3`, `sage`, `native`, …). Distinct from rollout's existing `--sglang-attention-backend` (sglang vocabulary: `fa`, `torch_sdpa`, `sage_attn`, …); set both to align train/rollout attention. Invalid names raise with the full valid list from diffusers.
- **`--deterministic-mode`** — reproducible single-step forward+backward. Turns on process-global torch determinism (`use_deterministic_algorithms(warn_only=False)` + `cudnn.deterministic` + `CUBLAS_WORKSPACE_CONFIG` / `NCCL_DETERMINISTIC`) and, for flash backends torch's flag can't reach, a flash-attn `deterministic=True` patch.

## Why `warn_only=False`

SDPA's deterministic backward is gated on `deterministicAlgorithms() && !warnOnly` (aten `attention_backward.cu`) — `warn_only=True` silently keeps the fast nondeterministic kernel, making the mode a **no-op on native/SDPA**. `warn_only=False` instead raises on a genuinely nondeterministic op (none hit in real training — see below).

## Support matrix (deterministic mode)

| backend                                | mechanism                            | status                 |
| -------------------------------------- | ------------------------------------ | ---------------------- |
| `native` / `_native_*` (SDPA)          | torch flag (needs `warn_only=False`) | ✅                      |
| `flash` / `_flash_3`                   | flash-attn `deterministic=` patch    | ✅                      |
| `sage` / `xformers` / `flex` / `aiter` | opaque to torch, no hook             | ❌ rejected at validate |

## Validation

### End-to-end (real training) — settings

|             |                                                              |
| ----------- | ------------------------------------------------------------ |
| hardware    | 1× node, 2× NVIDIA B200                                      |
| model       | `Qwen/Qwen-Image` (DiT, LoRA r=64 α=128)                     |
| task        | GRPO, OCR reward (`flowgrpo_ocr`)                            |
| parallel    | FSDP, `--colocate` (rollout+train share GPUs), `--offload-train` |
| precision   | master fp32 · reduce fp32 · forward bf16                     |
| attention   | SDPA / native (this image is FA4-only → no diffusers flash)  |
| rollout     | batch 4 × 4 samples = 16 items · 10 diffusion steps · res 512 · guidance 4.0 |
| schedule    | 2 rollouts × 2 steps/rollout = **4 optim steps**             |
| determinism | `--deterministic-mode` · `--seed 42` (`warn_only=False`)     |
| procedure   | run **twice**, identical config, compare metrics + saved weights |

### End-to-end — results (run 1 vs run 2, per optim step)

| step | policy_loss   | grad_norm    | adv_abs_mean | Δ (run1−run2) |
| ---- | ------------- | ------------ | ------------ | ------------- |
| 1    | -5.997717e-06 | 4.503624e-03 | 6.823028e-01 | **0**         |
| 2    | 5.792826e-07  | 1.174459e-04 | 8.997401e-02 | **0**         |
| 3    | 1.251698e-06  | 2.287022e-03 | 7.514393e-01 | **0**         |
| 4    | 1.877546e-06  | 1.499712e-03 | 2.163234e-01 | **0**         |

- all 4-step core metrics **byte-identical** — `metrics sha256: 3150b5f5… == 3150b5f5…`
- trained weights **bit-identical** — DCP checkpoints, 1440 tensors, `max|Δ| = 0.0`
- `warn_only=False` did **not** hit a nondeterministic op on the real DiT

<img width="1696" height="960" alt="determinism_proof" src="https://github.com/user-attachments/assets/a24d4a75-0d21-4afe-a646-c039d5f05a8f" />

<!-- attach determinism_proof.png here -->

### Isolated ablation — why `warn_only=False` (synthetic SDPA fwd+bwd, same seed ×2)

| config                                                | grad sha256 (run A / run B) | deterministic? |
| ----------------------------------------------------- | --------------------------- | -------------- |
| `use_deterministic_algorithms(True, warn_only=False)` | `1f1013ac == 1f1013ac`      | ✅              |
| `use_deterministic_algorithms(True, warn_only=True)`  | `288cb2ae ≠ 2c08320f`       | ❌ (only warns) |
| off (control)                                         | differ                      | ❌              |

Confirms the aten gate: `warn_only=True` leaves SDPA on its fast nondeterministic backward.

**Pending:** a 4-GPU pair — 2-GPU all-reduce is a single exchange and can't expose nondeterministic cross-rank reduces; 4 ranks are the real `NCCL_DETERMINISTIC` test.

## Files

- `miles/backends/fsdp_utils/arguments.py` — args + `validate_attention_args` (driver-side fail-fast) + support matrix
- `miles/backends/fsdp_utils/actor.py` — `_enable_deterministic_training` + flash patch + `set_attention_backend` wiring
- `miles/ray/actor_group.py` — spawn-time `NCCL_DETERMINISTIC` / `CUBLAS_WORKSPACE_CONFIG`
- `tests/fast/backends/test_fsdp_deterministic_args.py` — unit tests for `validate_attention_args`

## Checklist

- [x] `pre-commit run --all-files` passes — ruff / black / isort / autoflake all green
- [x] Added tests — `test_fsdp_deterministic_args.py` covers `validate_attention_args` (off = no-op; native/flash accepted; sage/xformers/flex/aiter rejected)
- [x] `pytest -x` green — 12 passed
- [x] `python3 train_diffusion.py --help` still parses — flags are auto-generated; the end-to-end run launched fine
- [x] CLI reference docs — n/a (miles-diffusion has no CLI reference doc)
- [x] No new example added — n/a

_Note: the box was FA4-only (no diffusers flash), so validation exercised the SDPA/native path; shipped `CUBLAS_WORKSPACE_CONFIG=:4096:8` (validated with `:16:8` — both are deterministic)._