### PR TITLE
fsdp: fix CheckpointError under gradient checkpointing (float buffers vs mixed precision)

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -692,6 +692,15 @@ def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
         "mesh": mesh,
     }
 
+    if args.gradient_checkpointing:
+        # MixedPrecisionPolicy does not cast buffers; a buffer above param_dtype
+        # makes the ckpt recompute dtype-diverge from the forward and abort.
+        for module in model.modules():
+            for name, buf in module.named_buffers(recurse=False):
+                if buf.is_floating_point() and buf.dtype != param_dtype:
+                    persistent = name not in module._non_persistent_buffers_set
+                    module.register_buffer(name, buf.to(param_dtype), persistent=persistent)
+
     for module in modules:
         fully_shard(module, **fsdp_kwargs)
 


### PR DESCRIPTION
## Problem

Enabling `--gradient-checkpointing` for Wan2.2 training aborts in the first backward:

```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Recomputed values
for the following tensors have different metadata than during the forward pass.
tensor at position 17:
saved metadata:      {'shape': ..., 'dtype': torch.bfloat16, 'device': cuda:0}
recomputed metadata: {'shape': ..., 'dtype': torch.float32,  'device': cuda:0}
```

## Root cause

Three facts interact:

1. diffusers' `WanRotaryPosEmbed` registers `freqs_cos` / `freqs_sin` as **fp32 buffers** (computed in fp64, stored via `.float()`).
2. FSDP2's `MixedPrecisionPolicy` casts **parameters** (and module forward inputs) to `param_dtype`, but **never buffers** — FSDP1's `buffer_dtype` has no FSDP2 equivalent. So the freqs tables are the only fp32 tensors in an otherwise bf16 model.
3. The rotary embedding is computed **outside** the checkpointed transformer blocks and passed in as an input. During the original forward, FSDP's input-cast hook converts it to bf16 before the block body runs; during the backward **recompute**, that cast is not applied symmetrically, so the same intermediate tensors come out fp32. Non-reentrant checkpointing strictly compares recomputed tensor metadata against the forward pass and aborts.

The hazard is not Wan-specific: `SD3Transformer2DModel` also registers an fp32 buffer (`pos_embed.pos_embed`); `QwenImageTransformer2DModel` registers no float buffers (which is why current Qwen recipes run checkpointing without issue).

## Reproduction

Standalone, single GPU, no miles involvement — a tiny `WanTransformer3DModel` under `fully_shard` + checkpointing:

<details><summary>repro script</summary>

```python
import os, torch, torch.distributed as dist
from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard

os.environ.setdefault("MASTER_ADDR", "127.0.0.1"); os.environ.setdefault("MASTER_PORT", "29617")
dist.init_process_group("nccl", rank=0, world_size=1); torch.cuda.set_device(0)

model = WanTransformer3DModel(
    patch_size=(1, 2, 2), num_attention_heads=2, attention_head_dim=24,
    in_channels=16, out_channels=16, text_dim=32, freq_dim=64, ffn_dim=96,
    num_layers=2, cross_attn_norm=True, qk_norm="rms_norm_across_heads",
    rope_max_seq_len=64,
)
model.train(); model.enable_gradient_checkpointing(); model.to(0)

mp = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
for m in model.modules():
    if m.__class__.__name__ in model._no_split_modules:
        fully_shard(m, mp_policy=mp)
fully_shard(model, mp_policy=mp)

out = model(
    hidden_states=torch.randn(1, 16, 1, 8, 8, device=0, dtype=torch.bfloat16),
    timestep=torch.tensor([500.0], device=0, dtype=torch.bfloat16),
    encoder_hidden_states=torch.randn(1, 16, 32, device=0, dtype=torch.bfloat16),
    return_dict=False,
)[0]
out.float().pow(2).mean().backward()   # -> CheckpointError
```

</details>

Observed: `CheckpointError`, with the rope-freqs-derived tensors saved as bf16 in the forward but recomputed as fp32 — matching the crash seen in real Wan2.2 4-GPU training.

## Fix

In `apply_fsdp2`, when `args.gradient_checkpointing` is set, re-register every floating-point buffer at `param_dtype` (persistence preserved). Both checkpoint passes then see identical dtypes: casting an already-bf16 buffer is a no-op for FSDP's input hook, so the forward/recompute asymmetry has nothing left to diverge on.

Numerics: rope output is `type_as`'d back to the activation dtype regardless, so the pin only moves bf16 rounding from after the cos/sin multiply to before it. A Wan-specific variant of this pin was previously validated end-to-end on a Wan2.2 dual-expert 2-GPU smoke: 2 train steps with checkpointing ON, zero CheckpointError, `log_prob_mean_abs_diff` ≈ 1.1e-5 (bf16 noise floor). The cast is gated on `gradient_checkpointing` so non-checkpointed runs keep bit-identical behavior, and Qwen-Image recipes are unaffected either way (no float buffers).

## Verification

Same tiny-model setup driven through this branch's real `apply_fsdp2`:

```
pre-fix path  (cast skipped):  CheckpointError reproduced (saved bf16 / recomputed fp32)
fixed path    (cast applied):  freqs_cos dtype -> torch.bfloat16, backward OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
