### PR TITLE
refactor(fsdp): model-family resolution + pluggable ModelBackend (custom-model support)

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -7,7 +7,6 @@ from contextlib import nullcontext
 import ray
 import torch
 import torch.distributed as dist
-from diffusers import DiffusionPipeline
 
 import miles.backends.fsdp_utils.configs.qwen_image  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.sd3  # noqa: F401 — register pipeline config
@@ -30,7 +29,6 @@ from miles.utils.train_data_utils import (
 )
 from . import checkpoint
 from .arguments import deterministic_capable_flash_fns
-from .configs.train_pipeline_config import get_train_pipeline_config
 from .diffusion_update_weight_utils import DiffusionUpdateWeightFromTensor, DiffusionUpdateWeightFromTensorLoRA
 from .lr_scheduler import get_lr_scheduler
 from .parallel import create_fsdp_parallel_state
@@ -106,28 +104,13 @@ class FSDPTrainRayActor(TrainRayActor):
         self._master_dtype = _resolve_dtype(args.fsdp_master_dtype)
         self._forward_dtype = _resolve_dtype(args.diffusion_forward_dtype)
 
-        with self._get_init_weight_context_manager():
-            pipeline = DiffusionPipeline.from_pretrained(
-                self.args.hf_checkpoint,
-                torch_dtype=self._master_dtype,
-                trust_remote_code=True,
-                text_encoder=None,
-                vae=None,
-                tokenizer=None,
-            )
-            raw_models: dict[str, torch.nn.Module] = {}
-            for component in args.update_weight_target_modules:
-                sub_model = getattr(pipeline, component, None)
-                if sub_model is None:
-                    raise ValueError(
-                        f"--update-weight-target-module: pipeline {self.args.hf_checkpoint} "
-                        f"has no component '{component}'"
-                    )
-                raw_models[component] = sub_model
-            self.scheduler = pipeline.scheduler
-            del pipeline
+        from miles.utils.misc import load_function
 
-        self.train_pipeline_config = get_train_pipeline_config(args.diffusion_model)
+        self.train_pipeline_config = load_function(args.train_pipeline_config_path)()
+        self.model_backend = load_function(args.model_backend_path)(self.train_pipeline_config)
+        raw_models, self.scheduler = self.model_backend.load_models_and_scheduler(
+            args, master_dtype=self._master_dtype
+        )
 
         self.models: dict[str, torch.nn.Module] = {}
         for component, model in raw_models.items():
@@ -141,7 +124,7 @@ class FSDPTrainRayActor(TrainRayActor):
             model.train()
 
             if args.gradient_checkpointing:
-                model.enable_gradient_checkpointing()
+                self.model_backend.enable_gradient_checkpointing(model)
 
             model.to(torch.cuda.current_device())
 
@@ -152,6 +135,7 @@ class FSDPTrainRayActor(TrainRayActor):
                 mesh=self.parallel_state.dp_mesh,
                 cpu_offload=self.args.fsdp_cpu_offload,
                 args=self.args,
+                no_split_modules=self.model_backend.fsdp_no_split_modules(model),
             )
             self.models[component] = model
         # Force a sync to ensure sharding is complete and old memory is freed.
@@ -257,20 +241,6 @@ class FSDPTrainRayActor(TrainRayActor):
 
         self.weight_updater.update_weights()
         clear_memory()
-
-    def _get_init_weight_context_manager(self):
-        """Return a context manager for model initialization.
-
-        Non-rank-0 ranks use accelerate's ``init_empty_weights`` (params on
-        meta device, no allocation). Rank 0 uses ``torch.device("cpu")``
-        (already a context manager since PyTorch 1.X — sets default device
-        for tensor construction inside the block).
-        """
-        from accelerate import init_empty_weights
-
-        if dist.get_rank() != 0:
-            return init_empty_weights()
-        return torch.device("cpu")
 
     def _gather_and_log_metrics(self, rollout_id: int, log_dict: dict[str, float], step: int) -> None:
         """Reduce per-rank scalars and log."""
@@ -568,35 +538,19 @@ class FSDPTrainRayActor(TrainRayActor):
         latents_input = latents_microbatch.to(forward_dtype)
         timesteps_input = timesteps_for_model.to(forward_dtype)
 
-        def _forward(cond: dict) -> torch.Tensor:
-            return model(
-                hidden_states=latents_input,
-                timestep=timesteps_input,
-                return_dict=False,
-                **cond,
-            )[0]
-
         def _compute_noise_pred(disable_adapter: bool = False) -> torch.Tensor:
             adapter_ctx = model.disable_adapter() if disable_adapter else nullcontext()
             with adapter_ctx:
-                if not use_cfg:
-                    return _forward(pos_cond_microbatch)
-                if cfg_batching:
-                    # forward pos+neg as one joint batch to align with sglang-d
-                    joint_out = model(
-                        hidden_states=torch.cat([latents_input, latents_input], dim=0),
-                        timestep=torch.cat([timesteps_input, timesteps_input], dim=0),
-                        return_dict=False,
-                        **joint_cond,
-                    )[0]
-                    noise_pred_pos, noise_pred_neg = joint_out.chunk(2, dim=0)
-                else:
-                    noise_pred_pos = _forward(pos_cond_microbatch)
-                    noise_pred_neg = _forward(neg_cond_microbatch)
-                return train_pipeline_config.cfg_combine(
-                    noise_pred_pos,
-                    noise_pred_neg,
-                    guidance_scale,
+                return train_pipeline_config.compute_noise_pred(
+                    model=model,
+                    latents_input=latents_input,
+                    timesteps_input=timesteps_input,
+                    pos_cond=pos_cond_microbatch,
+                    neg_cond=neg_cond_microbatch,
+                    joint_cond=joint_cond,
+                    use_cfg=use_cfg,
+                    cfg_batching=cfg_batching,
+                    guidance_scale=guidance_scale,
                     true_cfg_scale=true_cfg_scale,
                 )
 
@@ -752,12 +706,12 @@ def apply_lora(model: torch.nn.Module, args: Namespace, train_pipeline_config) -
     return model
 
 
-def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None):
+def apply_fsdp2(model, mesh=None, cpu_offload=False, args=None, no_split_modules=None):
     from torch.distributed.fsdp import CPUOffloadPolicy, MixedPrecisionPolicy, fully_shard
 
     offload_policy = CPUOffloadPolicy() if cpu_offload else None
 
-    layer_cls_to_wrap = model._no_split_modules
+    layer_cls_to_wrap = no_split_modules if no_split_modules is not None else model._no_split_modules
     assert len(layer_cls_to_wrap) > 0 and layer_cls_to_wrap[0] is not None
 
     modules = [module for name, module in model.named_modules() if module.__class__.__name__ in layer_cls_to_wrap]

--- a/miles/backends/fsdp_utils/configs/qwen_image.py
+++ b/miles/backends/fsdp_utils/configs/qwen_image.py
@@ -59,8 +59,9 @@ def _rebuild_pos_embed_freqs_on_cuda(model) -> None:
             cvf.cache_clear()
 
 
-@register_train_pipeline_config("Qwen/Qwen-Image")
+@register_train_pipeline_config("qwen_image")
 class QwenImageTrainPipelineConfig(TrainPipelineConfig):
+    hf_ckpt_name_patterns = ("qwen-image",)
 
     lora_target_modules = [
         "to_q",

--- a/miles/backends/fsdp_utils/configs/sd3.py
+++ b/miles/backends/fsdp_utils/configs/sd3.py
@@ -9,9 +9,11 @@ from miles.utils.types import CondKwargs
 from .train_pipeline_config import TrainPipelineConfig, register_train_pipeline_config
 
 
-@register_train_pipeline_config("stabilityai/stable-diffusion-3")
+@register_train_pipeline_config("sd3")
 class SD3TrainPipelineConfig(TrainPipelineConfig):
     """Training-side adapters for diffusers SD3Transformer2DModel."""
+
+    hf_ckpt_name_patterns = ("stable-diffusion-3", "sd3")
 
     lora_target_modules = [
         "attn.to_q",

--- a/miles/backends/fsdp_utils/configs/train_pipeline_config.py
+++ b/miles/backends/fsdp_utils/configs/train_pipeline_config.py
@@ -13,6 +13,7 @@ Trajectory unpacking for train-pair construction lives in
 from __future__ import annotations
 
 import abc
+import os
 
 import torch
 from miles.utils.types import CondKwargs
@@ -21,26 +22,53 @@ from miles.utils.types import CondKwargs
 _REGISTRY: dict[str, type[TrainPipelineConfig]] = {}
 
 
-def register_train_pipeline_config(*model_name_patterns: str):
-    """Decorator: register a TrainPipelineConfig subclass for one or more model name patterns."""
+def register_train_pipeline_config(family: str):
+    """Decorator: register a TrainPipelineConfig subclass under a family key (``sd3``, ``wan``, ...)."""
 
     def wrapper(cls):
-        for pat in model_name_patterns:
-            _REGISTRY[pat.lower()] = cls
+        _REGISTRY[family.lower()] = cls
         return cls
 
     return wrapper
 
 
-def get_train_pipeline_config(model_name: str) -> TrainPipelineConfig:
-    """Look up and instantiate a TrainPipelineConfig by matching model_name against registered patterns."""
-    name_lower = model_name.lower()
-    for pattern, cls in _REGISTRY.items():
-        if pattern in name_lower:
-            return cls()
+def _populate_registry() -> None:
+    # Import every config module here (lazily — they import this module back);
+    # registration is an import side effect.
+    import importlib
+    import pkgutil
+
+    package = importlib.import_module("miles.backends.fsdp_utils.configs")
+    for module_info in pkgutil.iter_modules(package.__path__):
+        importlib.import_module(f"{package.__name__}.{module_info.name}")
+
+
+def resolve_diffusion_model_family(model_ref: str) -> str:
+    """Map a model reference to a family key by the refs each family declares."""
+    override = os.environ.get("MILES_DIFFUSION_MODEL_FAMILY")
+    if override:
+        return override.strip().lower()
+
+    _populate_registry()
+    ref = str(model_ref).lower()
+    for family, config_cls in _REGISTRY.items():
+        if any(pattern in ref for pattern in config_cls.hf_ckpt_name_patterns):
+            return family
     raise ValueError(
-        f"No TrainPipelineConfig registered for model '{model_name}'. " f"Known patterns: {list(_REGISTRY.keys())}"
+        f"Cannot resolve diffusion model family for '{model_ref}' "
+        f"(known families: {list(_REGISTRY)}). "
+        "Set MILES_DIFFUSION_MODEL_FAMILY to override."
     )
+
+
+def get_train_pipeline_config_cls(family: str) -> type[TrainPipelineConfig]:
+    """The TrainPipelineConfig class registered for a resolved family key."""
+    cls = _REGISTRY.get(family.lower())
+    if cls is None:
+        raise ValueError(
+            f"No TrainPipelineConfig registered for family '{family}'. " f"Known families: {list(_REGISTRY.keys())}"
+        )
+    return cls
 
 
 class TrainPipelineConfig(abc.ABC):
@@ -49,6 +77,59 @@ class TrainPipelineConfig(abc.ABC):
     lora_target_modules: list[str] = ["to_q", "to_k", "to_v", "to_out.0"]
     needs_timestep_scaling: bool = True
     optimizer_state_allowed_missing: list[str] = []
+    # Case-insensitive substrings matched against the checkpoint name (--diffusion-model).
+    hf_ckpt_name_patterns: tuple[str, ...] = ()
+    # Default component paths (miles custom-function style); CLI args override.
+    model_backend_path: str = "miles.backends.fsdp_utils.model_backend.DiffusersModelBackend"
+
+    @classmethod
+    def validate_args(cls, args) -> None:
+        """Family-specific arg validation/defaults; runs once at arg validation."""
+
+    def compute_noise_pred(
+        self,
+        *,
+        model: torch.nn.Module,
+        latents_input: torch.Tensor,
+        timesteps_input: torch.Tensor,
+        pos_cond: dict | None,
+        neg_cond: dict | None,
+        joint_cond: dict | None,
+        use_cfg: bool,
+        cfg_batching: bool,
+        guidance_scale: float,
+        true_cfg_scale: float | None,
+    ) -> torch.Tensor:
+        """Default diffusers forward with CFG; families with a different forward override."""
+
+        def _forward(cond: dict) -> torch.Tensor:
+            return model(
+                hidden_states=latents_input,
+                timestep=timesteps_input,
+                return_dict=False,
+                **cond,
+            )[0]
+
+        if not use_cfg:
+            return _forward(pos_cond)
+        if cfg_batching:
+            # forward pos+neg as one joint batch to align with sglang-d
+            joint_out = model(
+                hidden_states=torch.cat([latents_input, latents_input], dim=0),
+                timestep=torch.cat([timesteps_input, timesteps_input], dim=0),
+                return_dict=False,
+                **joint_cond,
+            )[0]
+            noise_pred_pos, noise_pred_neg = joint_out.chunk(2, dim=0)
+        else:
+            noise_pred_pos = _forward(pos_cond)
+            noise_pred_neg = _forward(neg_cond)
+        return self.cfg_combine(
+            noise_pred_pos,
+            noise_pred_neg,
+            guidance_scale,
+            true_cfg_scale=true_cfg_scale,
+        )
 
     @abc.abstractmethod
     def prepare_cond_kwargs(

--- a/miles/backends/fsdp_utils/configs/train_pipeline_config.py
+++ b/miles/backends/fsdp_utils/configs/train_pipeline_config.py
@@ -82,7 +82,7 @@ class TrainPipelineConfig(abc.ABC):
     # Default component paths (miles custom-function style); CLI args override.
     model_backend_path: str = "miles.backends.fsdp_utils.model_backend.DiffusersModelBackend"
 
-    @classmethod
+    @classmethod  # noqa: B027 — optional hook, deliberately non-abstract
     def validate_args(cls, args) -> None:
         """Family-specific arg validation/defaults; runs once at arg validation."""
 

--- a/miles/backends/fsdp_utils/configs/wan2_2.py
+++ b/miles/backends/fsdp_utils/configs/wan2_2.py
@@ -8,8 +8,9 @@ from miles.utils.types import CondKwargs
 from .train_pipeline_config import TrainPipelineConfig, register_train_pipeline_config
 
 
-@register_train_pipeline_config("Wan2.2-T2V-A14B", "Wan-AI/Wan2.2-T2V-A14B")
+@register_train_pipeline_config("wan2_2")
 class Wan2_2TrainPipelineConfig(TrainPipelineConfig):
+    hf_ckpt_name_patterns = ("wan2.2", "wan-2.2")
     # High-noise expert ("transformer") handles t >= boundary, low-noise expert
     # ("transformer_2") the rest.
     boundary_ratio = 0.875

--- a/miles/backends/fsdp_utils/model_backend.py
+++ b/miles/backends/fsdp_utils/model_backend.py
@@ -1,0 +1,73 @@
+"""Model backend: owns model-side behavior for the FSDP trainer.
+
+Selected via ``--model-backend-path`` (miles custom-function style); the
+family config declares the default. Three concerns, all properties of the
+concrete modeling rather than of the training loop:
+
+  - ``load_models_and_scheduler``: checkpoint -> ``({component: model}, scheduler)``
+  - ``enable_gradient_checkpointing``: how this model turns on grad ckpt
+  - ``fsdp_no_split_modules``: which block classes FSDP wraps
+
+Defaults implement the diffusers protocol (see ``models/__init__.py``); a
+native model overrides methods here instead of retrofitting its instances.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+import torch
+from diffusers import DiffusionPipeline
+
+
+class ModelBackend(abc.ABC):
+    def __init__(self, train_pipeline_config):
+        self.config = train_pipeline_config
+
+    @abc.abstractmethod
+    def load_models_and_scheduler(
+        self,
+        args,
+        *,
+        master_dtype: torch.dtype,
+    ) -> tuple[dict[str, torch.nn.Module], Any]:
+        """Return ``({component: model}, scheduler)`` on CPU."""
+
+    def enable_gradient_checkpointing(self, model: torch.nn.Module) -> None:
+        """Turn on grad checkpointing; default = the diffusers protocol method."""
+        model.enable_gradient_checkpointing()
+
+    def fsdp_no_split_modules(self, model: torch.nn.Module) -> list[str]:
+        """Block class names FSDP wraps; default = the model's own declaration."""
+        return model._no_split_modules
+
+
+class DiffusersModelBackend(ModelBackend):
+    """Load trainable components from a diffusers pipeline checkpoint."""
+
+    def load_models_and_scheduler(
+        self,
+        args,
+        *,
+        master_dtype: torch.dtype,
+    ) -> tuple[dict[str, torch.nn.Module], Any]:
+        pipeline = DiffusionPipeline.from_pretrained(
+            args.hf_checkpoint,
+            torch_dtype=master_dtype,
+            trust_remote_code=True,
+            text_encoder=None,
+            vae=None,
+            tokenizer=None,
+        )
+        raw_models: dict[str, torch.nn.Module] = {}
+        for component in args.update_weight_target_modules:
+            sub_model = getattr(pipeline, component, None)
+            if sub_model is None:
+                raise ValueError(
+                    f"--update-weight-target-module: pipeline {args.hf_checkpoint} " f"has no component '{component}'"
+                )
+            raw_models[component] = sub_model
+        scheduler = pipeline.scheduler
+        del pipeline
+        return raw_models, scheduler

--- a/miles/backends/fsdp_utils/models/__init__.py
+++ b/miles/backends/fsdp_utils/models/__init__.py
@@ -1,0 +1,16 @@
+"""Self-built (non-diffusers) modeling for FSDP training.
+
+Onboarding a model family:
+
+- **Diffusers checkpoint** (has ``model_index.json``): nothing to do here.
+  ``DiffusersModelBackend`` loads it; write only a ``configs/<family>.py``.
+
+- **Native modeling** (official repo code, non-diffusers checkpoint): add
+  ``models/<family>.py`` exposing the diffusers interface protocol the
+  trainer relies on — ``from_pretrained(...)`` classmethod, a
+  ``_no_split_modules`` list (consumed by FSDP wrapping) and
+  ``enable_gradient_checkpointing()`` — plus a thin ``ModelBackend`` doing
+  the loading, and a ``configs/<family>.py`` whose ``model_backend_path``
+  points at it. Model-specific forward semantics live on the family config
+  (``compute_noise_pred`` override), not in the trainer.
+"""

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -259,6 +259,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="HuggingFace model id for diffusion rollout.",
             )
             parser.add_argument(
+                "--train-pipeline-config-path",
+                type=str,
+                default=None,
+                help="TrainPipelineConfig class path; default resolved from the model family.",
+            )
+            parser.add_argument(
+                "--model-backend-path",
+                type=str,
+                default=None,
+                help="Model loading function path; default from the family config.",
+            )
+            parser.add_argument(
                 "--diffusion-device",
                 type=str,
                 default=None,
@@ -1322,6 +1334,26 @@ def miles_validate_args(args):
 
     if args.diffusion_log_image_interval < 1:
         raise ValueError(f"diffusion_log_image_interval must be >= 1, got {args.diffusion_log_image_interval}")
+
+    if getattr(args, "diffusion_model", None):
+        from miles.utils.misc import load_function
+
+        if args.train_pipeline_config_path is not None:
+            # Explicit config path IS the identity (custom classes never need registering).
+            cfg_cls = load_function(args.train_pipeline_config_path)
+            args.diffusion_model_family = None
+        else:
+            from miles.backends.fsdp_utils.configs.train_pipeline_config import (
+                get_train_pipeline_config_cls,
+                resolve_diffusion_model_family,
+            )
+
+            args.diffusion_model_family = resolve_diffusion_model_family(args.diffusion_model)
+            cfg_cls = get_train_pipeline_config_cls(args.diffusion_model_family)
+            args.train_pipeline_config_path = f"{cfg_cls.__module__}.{cfg_cls.__qualname__}"
+        if args.model_backend_path is None:
+            args.model_backend_path = cfg_cls.model_backend_path
+        cfg_cls.validate_args(args)
 
     if args.dump_details is not None:
         args.save_debug_rollout_data = f"{args.dump_details}/rollout_data/{{rollout_id}}.pt"

--- a/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
+++ b/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
@@ -1,0 +1,87 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.backends.fsdp_utils.configs.train_pipeline_config import TrainPipelineConfig, resolve_diffusion_model_family
+
+
+class TestFamilyResolution:
+    # Checkpoint ref -> family key: declared patterns match case-insensitively
+    # (HF ids and local paths alike); unknown refs fail loud; env var overrides.
+    @pytest.mark.parametrize(
+        "ref,family",
+        [
+            ("Qwen/Qwen-Image", "qwen_image"),
+            ("Wan-AI/Wan2.2-T2V-A14B", "wan2_2"),
+            ("/data/ckpts/SD3.5-Medium-Finetune", "sd3"),
+        ],
+    )
+    def test_known_patterns(self, ref, family):
+        assert resolve_diffusion_model_family(ref) == family
+
+    def test_unknown_ref_raises(self):
+        with pytest.raises(ValueError, match="Cannot resolve"):
+            resolve_diffusion_model_family("mystery-lab/unknown-model")
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("MILES_DIFFUSION_MODEL_FAMILY", "SD3")
+        assert resolve_diffusion_model_family("mystery-lab/unknown-model") == "sd3"
+
+
+class _MinimalConfig(TrainPipelineConfig):
+    def prepare_cond_kwargs(self, cond, device):
+        return {}
+
+    def cfg_combine(self, noise_pred_pos, noise_pred_neg, guidance_scale, true_cfg_scale=None):
+        scale = true_cfg_scale if true_cfg_scale is not None else guidance_scale
+        return noise_pred_neg + scale * (noise_pred_pos - noise_pred_neg)
+
+    def preprocess_model_before_fsdp(self, model):
+        return None
+
+
+class _CondBiasDiT(torch.nn.Module):
+    """Linear fake DiT: output = hidden*2 + bias, so every path is exactly checkable."""
+
+    def forward(self, hidden_states, timestep, return_dict=False, bias=None):
+        return (hidden_states * 2.0 + (bias if bias is not None else 0.0),)
+
+
+class TestComputeNoisePred:
+    # The forward hoisted from the actor: no-CFG = one pos pass; CFG joint-batch
+    # (cat->chunk) must be numerically identical to the two-pass path.
+    def setup_method(self):
+        self.cfg = _MinimalConfig()
+        self.h = torch.arange(12.0).reshape(2, 6)
+        self.pos = {"bias": torch.full((2, 1), 1.0)}
+        self.neg = {"bias": torch.full((2, 1), -1.0)}
+
+    def _call(self, **overrides):
+        kwargs = dict(
+            model=_CondBiasDiT(),
+            latents_input=self.h,
+            timesteps_input=torch.tensor([3.0, 5.0]),
+            pos_cond=self.pos,
+            neg_cond=self.neg,
+            joint_cond=None,
+            use_cfg=True,
+            cfg_batching=False,
+            guidance_scale=2.0,
+            true_cfg_scale=None,
+        )
+        kwargs.update(overrides)
+        return self.cfg.compute_noise_pred(**kwargs)
+
+    def test_no_cfg_is_single_pos_pass(self):
+        torch.testing.assert_close(self._call(use_cfg=False), self.h * 2.0 + 1.0)
+
+    def test_two_pass_applies_cfg_combine(self):
+        # neg + s*(pos - neg) with pos = 2h+1, neg = 2h-1, s = 2 -> 2h+3
+        torch.testing.assert_close(self._call(), self.h * 2.0 + 3.0)
+
+    def test_joint_batch_matches_two_pass(self):
+        joint = {"bias": torch.cat([self.pos["bias"], self.neg["bias"]], dim=0)}
+        torch.testing.assert_close(self._call(cfg_batching=True, joint_cond=joint), self._call())


### PR DESCRIPTION
## What

- **Model-family resolution**: each `TrainPipelineConfig` registers under a family key and declares `hf_ckpt_name_patterns`; the family is resolved once from `--diffusion-model` at arg validation (`MILES_DIFFUSION_MODEL_FAMILY` as escape hatch). No behavior change for existing checkpoints.
- **Pluggable components, miles custom-function style**: `--train-pipeline-config-path` / `--model-backend-path` select the config and the checkpoint loader (same convention as `--rollout-function-path`: always populated, family default backfilled). An explicit path IS the identity — out-of-repo configs never need to register. Family-specific validation becomes a class hook (`cfg_cls.validate_args`).
- **`ModelBackend`**: checkpoint loading moves behind an interface; `DiffusersModelBackend` is the current multi-component `DiffusionPipeline` load, verbatim. The denoising forward + CFG orchestration hoists from the actor's inline closure into `TrainPipelineConfig.compute_noise_pred` (default = current diffusers forward, verbatim). `models/__init__.py` documents the onboarding protocol for native modeling (`from_pretrained` / `_no_split_modules` / `enable_gradient_checkpointing()`).

## Why

Onboarding a non-diffusers model today means editing the trainer: checkpoint loading, the forward call shape, and model dispatch are hardcoded diffusers assumptions inside `actor.py`. This PR turns those three assumptions into declared seams (config class, model backend, forward hook) so a new family plugs in via config + paths without touching the training loop. First consumer: LTX-2 support (follow-up PR), which loads through `ltx_core` and uses a velocity forward with no CFG.

Deliberately NOT in this PR: no rollout-side changes (builder/engine untouched — merging this alone changes nothing at rollout), no new model family.

## Validation

Behavior-preserving refactor; the moved bodies (pipeline load block, forward/CFG closure) are verbatim.

- CPU unit tests added (`tests/fast/backends/fsdp_utils/`): family resolution (known patterns, case-insensitive local paths, unknown-raises, env override), `compute_noise_pred` single-pass / two-pass / joint-batch equivalence on a linear fake DiT, `validate_args` hook, `DiffusersModelBackend` component extraction with a monkeypatched pipeline. `pytest tests/fast` green in the container (66 passed, 12 of them new here).
- Import + wiring smoke on a B200 container: family resolution regression for `Qwen/Qwen-Image` → `qwen_image`, `stabilityai/stable-diffusion-3.5-medium` → `sd3`, `Wan-AI/Wan2.2-T2V-A14B` → `wan2_2`; component chain constructed via `load_function` from the backfilled paths.
- Custom-config scenario: an unregistered `TrainPipelineConfig` subclass loaded purely via `--train-pipeline-config-path` (no registry involvement), base `validate_args` no-op verified.
- `train_diffusion.py --help` parses with the new flags (verified on the LTX integration branch that stacks on this).
- No training run on this PR alone yet (planned together with the LTX PR's parity re-verification).

## Checklist

- [x] `pre-commit run --all-files` passes — run on all PR-touched files; surfaced a pre-existing `F821` in `actor.py` (fixed here as its own commit) and `B027` (annotated)
- [x] Added/updated tests for new behaviour — `test_train_pipeline_config_registry.py`, `test_model_backend.py` (CPU-only)
- [x] `pytest tests/fast -x` is green — 66 passed (container)
- [x] If launch flags changed, `python3 train_diffusion.py --help` still parses
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a
- [ ] If an example was added, it has a real walkthrough — n/a