### PR TITLE
refactor(fsdp): pluggable SdeStepBackend (custom stochastic dynamics …

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -486,6 +486,7 @@ class FSDPTrainRayActor(TrainRayActor):
         latents_microbatch = _stack("latent")  # (bsz, *latent_dims)
         next_latents_microbatch = _stack("next_latent")  # (bsz, *latent_dims)
         timesteps_microbatch = _stack("timestep")  # (bsz,) -- per-pair timestep is scalar
+        next_timesteps_microbatch = _stack("next_timestep")  # (bsz,) -- next rollout timestep (0 at terminal)
         log_prob_old_microbatch = _stack("log_prob_old")  # (bsz,) -- per-pair log_prob is scalar
 
         advantage = torch.tensor(  # (bsz,)
@@ -611,6 +612,7 @@ class FSDPTrainRayActor(TrainRayActor):
         _, log_prob_new_microbatch, prev_sample_mean_new, std_dev_t_new = self.sde_backend.sde_step_logprob(
             noise_pred_microbatch.float(),
             timesteps_microbatch,
+            next_timesteps_microbatch,
             latents_microbatch.float(),
             prev_sample=next_latents_microbatch.float(),
             noise_level=noise_level,
@@ -633,6 +635,7 @@ class FSDPTrainRayActor(TrainRayActor):
                 _, _, prev_sample_mean_ref, _ = self.sde_backend.sde_step_logprob(
                     ref_noise_pred_microbatch.float(),
                     timesteps_microbatch,
+                    next_timesteps_microbatch,
                     latents_microbatch.float(),
                     prev_sample=next_latents_microbatch.float(),
                     noise_level=noise_level,

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -167,7 +167,10 @@ class FSDPTrainRayActor(TrainRayActor):
         sde_backend_path = args.sde_step_backend_path or (
             "miles.backends.fsdp_utils.sde_step_backend.DiffusersSdeStepBackend"
         )
-        self.sde_backend = load_function(sde_backend_path)(self.train_pipeline_config, self.scheduler)
+        self.sde_backend = load_function(sde_backend_path)(
+            self.scheduler,
+            sde_timestep_divisor=getattr(self.train_pipeline_config, "sde_timestep_divisor", 1.0),
+        )
 
         if args.optimizer == "adam":
             self.optimizer = torch.optim.AdamW(

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -19,7 +19,6 @@ from miles.utils.distributed_utils import get_gloo_group
 from miles.utils.memory_utils import clear_memory, print_memory
 from miles.utils.metric_utils import compute_rollout_step
 from miles.utils.profile_utils import TrainProfiler
-from miles.utils.sde_log_prob import sde_step_with_logprob
 from miles.utils.timer import Timer, inverse_timer, timer
 from miles.utils.tracking_utils import init_tracking
 from miles.utils.train_data_utils import (
@@ -162,6 +161,13 @@ class FSDPTrainRayActor(TrainRayActor):
             self.model = next(iter(self.models.values()))
         else:
             self.model = torch.nn.ModuleDict(self.models)
+
+        from miles.utils.misc import load_function
+
+        sde_backend_path = args.sde_step_backend_path or (
+            "miles.backends.fsdp_utils.sde_step_backend.DiffusersSdeStepBackend"
+        )
+        self.sde_backend = load_function(sde_backend_path)(self.train_pipeline_config, self.scheduler)
 
         if args.optimizer == "adam":
             self.optimizer = torch.optim.AdamW(
@@ -602,8 +608,7 @@ class FSDPTrainRayActor(TrainRayActor):
 
         noise_pred_microbatch = _compute_noise_pred()
 
-        _, log_prob_new_microbatch, prev_sample_mean_new, std_dev_t_new = sde_step_with_logprob(
-            self.scheduler,
+        _, log_prob_new_microbatch, prev_sample_mean_new, std_dev_t_new = self.sde_backend.sde_step_logprob(
             noise_pred_microbatch.float(),
             timesteps_microbatch,
             latents_microbatch.float(),
@@ -625,8 +630,7 @@ class FSDPTrainRayActor(TrainRayActor):
             with torch.no_grad():
                 ref_noise_pred_microbatch = _compute_noise_pred(disable_adapter=True)
                 # TODO: unify sde_step_with_logprob with rollout and trainer forward paths.
-                _, _, prev_sample_mean_ref, _ = sde_step_with_logprob(
-                    self.scheduler,
+                _, _, prev_sample_mean_ref, _ = self.sde_backend.sde_step_logprob(
                     ref_noise_pred_microbatch.float(),
                     timesteps_microbatch,
                     latents_microbatch.float(),

--- a/miles/backends/fsdp_utils/sde_step_backend.py
+++ b/miles/backends/fsdp_utils/sde_step_backend.py
@@ -22,9 +22,12 @@ import torch
 
 
 class SdeStepBackend(abc.ABC):
-    def __init__(self, train_pipeline_config, scheduler):
-        self.config = train_pipeline_config
+    def __init__(self, scheduler=None, *, sde_timestep_divisor: float = 1.0):
+        # Primitive params only (no train pipeline config) so the rollout process — which has
+        # no train pipeline — can load and construct the same backend for shared stepping.
+        # The dynamics is encoded by the concrete subclass, not passed in.
         self.scheduler = scheduler
+        self.sde_timestep_divisor = sde_timestep_divisor
 
     @abc.abstractmethod
     def resolve_sigmas(

--- a/miles/backends/fsdp_utils/sde_step_backend.py
+++ b/miles/backends/fsdp_utils/sde_step_backend.py
@@ -27,8 +27,12 @@ class SdeStepBackend(abc.ABC):
         self.scheduler = scheduler
 
     @abc.abstractmethod
-    def resolve_sigmas(self, timesteps: torch.Tensor, *, ndim: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """σ-locating layer: map trajectory timesteps to (sigma, sigma_next), broadcast to ndim."""
+    def resolve_sigmas(
+        self, timesteps: torch.Tensor, next_timesteps: torch.Tensor, *, ndim: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Map the pair's own (timestep, next_timestep) — the actual rollout values, not a
+        positional index — to (sigma, sigma_next), broadcast to ndim. Families with a linear
+        timestep<->σ relation resolve from the values directly, off the scheduler."""
 
     @abc.abstractmethod
     def prev_sample_mean_and_std(
@@ -65,6 +69,7 @@ class SdeStepBackend(abc.ABC):
         self,
         model_output: torch.Tensor,
         timesteps: torch.Tensor,
+        next_timesteps: torch.Tensor,
         sample: torch.Tensor,
         *,
         prev_sample: torch.Tensor,
@@ -73,7 +78,7 @@ class SdeStepBackend(abc.ABC):
         model_output = model_output.float()
         sample = sample.float()
         prev_sample = prev_sample.float()
-        sigma, sigma_prev = self.resolve_sigmas(timesteps, ndim=sample.ndim)
+        sigma, sigma_prev = self.resolve_sigmas(timesteps, next_timesteps, ndim=sample.ndim)
         prev_mean, noise_std, std_dev_t = self.prev_sample_mean_and_std(
             model_output, sample, sigma, sigma_prev, noise_level=noise_level
         )
@@ -83,7 +88,12 @@ class SdeStepBackend(abc.ABC):
 class DiffusersSdeStepBackend(SdeStepBackend):
     """Flow-matching SDE over diffusers scheduler sigmas (current default)."""
 
-    def resolve_sigmas(self, timesteps: torch.Tensor, *, ndim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def resolve_sigmas(
+        self, timesteps: torch.Tensor, next_timesteps: torch.Tensor, *, ndim: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Diffusers σ needs the scheduler's (shifted) timestep->σ map; look it up by the
+        # actual rollout timestep value, then take the neighbouring σ (scheduler is filled
+        # from the rollout snapshot, so +1 lands on the recorded next step / terminal 0).
         step_index = [self.scheduler.index_for_timestep(t) for t in timesteps]
         prev_step_index = [s + 1 for s in step_index]
         view = (-1, *([1] * (ndim - 1)))

--- a/miles/backends/fsdp_utils/sde_step_backend.py
+++ b/miles/backends/fsdp_utils/sde_step_backend.py
@@ -1,0 +1,109 @@
+"""SDE step backend: scores a recorded (x_t -> x_{t+1}) transition for training.
+
+Layered to mirror sgl-d's ``flow_sde_sampling`` stages, so the dynamics kernel
+can eventually be shared with the rollout engine (SAMPLE mode draws noise
+around the same mean; SCORE mode — this trainer — scores the recorded
+residual):
+
+  - ``prev_sample_mean_and_std``: the deterministic dynamics kernel
+  - ``log_prob``: Gaussian scoring of ``prev_sample - prev_mean``
+  - ``sde_step_logprob``: the SCORE-mode composition the trainer calls
+
+Selected via ``--sde-step-backend-path`` (miles custom-function style); a
+model family with its own dynamics overrides the two layers, not the trainer.
+"""
+
+from __future__ import annotations
+
+import abc
+import math
+
+import torch
+
+
+class SdeStepBackend(abc.ABC):
+    def __init__(self, train_pipeline_config, scheduler):
+        self.config = train_pipeline_config
+        self.scheduler = scheduler
+
+    @abc.abstractmethod
+    def resolve_sigmas(self, timesteps: torch.Tensor, *, ndim: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """σ-locating layer: map trajectory timesteps to (sigma, sigma_next), broadcast to ndim."""
+
+    @abc.abstractmethod
+    def prev_sample_mean_and_std(
+        self,
+        model_output: torch.Tensor,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_prev: torch.Tensor,
+        *,
+        noise_level: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return ``(prev_mean, noise_std, std_dev_t)``.
+
+        ``noise_std`` is the Gaussian std of the transition (drives log_prob);
+        ``std_dev_t`` is the diffusion-scale factor reported to the trainer
+        (KL denominator) — flow-SDE keeps them distinct, CPS has them equal.
+        """
+
+    def log_prob(
+        self,
+        prev_sample: torch.Tensor,
+        prev_mean: torch.Tensor,
+        noise_std: torch.Tensor,
+    ) -> torch.Tensor:
+        """Gaussian log-density of the recorded transition, mean over non-batch dims."""
+        log_prob = (
+            -((prev_sample.detach() - prev_mean) ** 2) / (2 * noise_std**2)
+            - torch.log(noise_std)
+            - torch.log(torch.sqrt(2 * torch.as_tensor(math.pi)))
+        )
+        return log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+
+    def sde_step_logprob(
+        self,
+        model_output: torch.Tensor,
+        timesteps: torch.Tensor,
+        sample: torch.Tensor,
+        *,
+        prev_sample: torch.Tensor,
+        noise_level: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        model_output = model_output.float()
+        sample = sample.float()
+        prev_sample = prev_sample.float()
+        sigma, sigma_prev = self.resolve_sigmas(timesteps, ndim=sample.ndim)
+        prev_mean, noise_std, std_dev_t = self.prev_sample_mean_and_std(
+            model_output, sample, sigma, sigma_prev, noise_level=noise_level
+        )
+        return prev_sample, self.log_prob(prev_sample, prev_mean, noise_std), prev_mean, std_dev_t
+
+
+class DiffusersSdeStepBackend(SdeStepBackend):
+    """Flow-matching SDE over diffusers scheduler sigmas (current default)."""
+
+    def resolve_sigmas(self, timesteps: torch.Tensor, *, ndim: int) -> tuple[torch.Tensor, torch.Tensor]:
+        step_index = [self.scheduler.index_for_timestep(t) for t in timesteps]
+        prev_step_index = [s + 1 for s in step_index]
+        view = (-1, *([1] * (ndim - 1)))
+        return self.scheduler.sigmas[step_index].view(view), self.scheduler.sigmas[prev_step_index].view(view)
+
+    def prev_sample_mean_and_std(
+        self,
+        model_output: torch.Tensor,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_prev: torch.Tensor,
+        *,
+        noise_level: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sigma_max = self.scheduler.sigmas[1].item()
+        dt = sigma_prev - sigma
+
+        std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * noise_level
+        prev_mean = (
+            sample * (1 + std_dev_t**2 / (2 * sigma) * dt)
+            + model_output * (1 + std_dev_t**2 * (1 - sigma) / (2 * sigma)) * dt
+        )
+        return prev_mean, std_dev_t * torch.sqrt(-1 * dt), std_dev_t

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -354,6 +354,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="rollout_sde_type for POST /rollout/generate.",
             )
             parser.add_argument(
+                "--sde-step-backend-path",
+                type=str,
+                default=None,
+                help="SdeStepBackend class path; default = flow-matching SDE over scheduler sigmas.",
+            )
+            parser.add_argument(
                 "--diffusion-sde-window-size",
                 type=int,
                 default=0,

--- a/miles/utils/train_data_utils.py
+++ b/miles/utils/train_data_utils.py
@@ -168,6 +168,9 @@ class RolloutTrainDataConverter:
         latents = all_latents[:-1]
         next_latents = all_latents[1:]
         timesteps = traj.timesteps.to(device, dtype=torch.float32)
+        # The step after the last has no recorded timestep -> terminal (σ=0, timestep 0),
+        # so the SDE step reads σ_next from the actual next rollout timestep, not a lookup.
+        next_timesteps = torch.cat([timesteps[1:], timesteps.new_zeros(1)])
 
         sde_idx = (sample.train_metadata or {}).get("sde_step_indices")
         assert sde_idx is not None, "SDE step indices are required for training"
@@ -176,6 +179,9 @@ class RolloutTrainDataConverter:
             "latent": latents[idx],
             "next_latent": next_latents[idx],
             "timestep": timesteps[idx],
+            # Carry the actual next-step timestep so the SDE step resolves σ_next from a
+            # rollout value, never assuming train/rollout scheduler positional alignment.
+            "next_timestep": next_timesteps[idx],
             "log_prob_old": rollout_log_probs[idx],
         }, idx
 

--- a/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
@@ -2,8 +2,6 @@ from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
 
-from types import SimpleNamespace
-
 import torch
 
 from miles.backends.fsdp_utils.sde_step_backend import DiffusersSdeStepBackend
@@ -28,7 +26,7 @@ class TestDiffusersSdeStepBackend:
         nt = sched.sigmas[[3, 6]]  # per-pair next timestep (ignored by the diffusers +1 path)
         v, x, nxt = (torch.randn(2, 4, 6) for _ in range(3))
 
-        backend = DiffusersSdeStepBackend(SimpleNamespace(), sched)
+        backend = DiffusersSdeStepBackend(sched)
         got = backend.sde_step_logprob(v, t, nt, x, prev_sample=nxt, noise_level=0.7)
         want = sde_step_with_logprob(sched, v, t, x, prev_sample=nxt, noise_level=0.7)
         for g, w in zip(got, want, strict=True):

--- a/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
@@ -19,8 +19,8 @@ class _FakeScheduler:
 
 
 class TestDiffusersSdeStepBackend:
-    # The layered backend (mean/std kernel + Gaussian log_prob) must reproduce the
-    # monolithic sde_step_with_logprob bit-for-bit — that's the whole refactor contract.
+    # The layered backend (sigma resolution + mean/std kernel + Gaussian log_prob) must
+    # reproduce the monolithic sde_step_with_logprob bit-for-bit — the refactor contract.
     def test_matches_monolithic_reference(self):
         torch.manual_seed(0)
         sched = _FakeScheduler()

--- a/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
@@ -19,16 +19,17 @@ class _FakeScheduler:
 
 
 class TestDiffusersSdeStepBackend:
-    # The layered backend (sigma resolution + mean/std kernel + Gaussian log_prob) must
+    # The layered backend (σ resolution + mean/std kernel + Gaussian log_prob) must
     # reproduce the monolithic sde_step_with_logprob bit-for-bit — the refactor contract.
     def test_matches_monolithic_reference(self):
         torch.manual_seed(0)
         sched = _FakeScheduler()
-        t = sched.sigmas[[2, 5]]
+        t = sched.sigmas[[2, 5]]  # per-pair timestep
+        nt = sched.sigmas[[3, 6]]  # per-pair next timestep (ignored by the diffusers +1 path)
         v, x, nxt = (torch.randn(2, 4, 6) for _ in range(3))
 
         backend = DiffusersSdeStepBackend(SimpleNamespace(), sched)
-        got = backend.sde_step_logprob(v, t, x, prev_sample=nxt, noise_level=0.7)
+        got = backend.sde_step_logprob(v, t, nt, x, prev_sample=nxt, noise_level=0.7)
         want = sde_step_with_logprob(sched, v, t, x, prev_sample=nxt, noise_level=0.7)
         for g, w in zip(got, want, strict=True):
             torch.testing.assert_close(g, w, rtol=0.0, atol=0.0)

--- a/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_sde_step_backend.py
@@ -1,0 +1,35 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+from types import SimpleNamespace
+
+import torch
+
+from miles.backends.fsdp_utils.sde_step_backend import DiffusersSdeStepBackend
+from miles.utils.sde_log_prob import sde_step_with_logprob
+
+
+class _FakeScheduler:
+    def __init__(self, num_steps=8):
+        self.sigmas = torch.linspace(1.0, 0.0, num_steps + 1)
+
+    def index_for_timestep(self, t):
+        return int(torch.argmin((self.sigmas[:-1] - t).abs()))
+
+
+class TestDiffusersSdeStepBackend:
+    # The layered backend (mean/std kernel + Gaussian log_prob) must reproduce the
+    # monolithic sde_step_with_logprob bit-for-bit — that's the whole refactor contract.
+    def test_matches_monolithic_reference(self):
+        torch.manual_seed(0)
+        sched = _FakeScheduler()
+        t = sched.sigmas[[2, 5]]
+        v, x, nxt = (torch.randn(2, 4, 6) for _ in range(3))
+
+        backend = DiffusersSdeStepBackend(SimpleNamespace(), sched)
+        got = backend.sde_step_logprob(v, t, x, prev_sample=nxt, noise_level=0.7)
+        want = sde_step_with_logprob(sched, v, t, x, prev_sample=nxt, noise_level=0.7)
+        for g, w in zip(got, want, strict=True):
+            torch.testing.assert_close(g, w, rtol=0.0, atol=0.0)
+        assert got[1].shape == (2,)


### PR DESCRIPTION
## What

- **Pluggable SDE step**: the trainer scores each recorded rollout transition through an `SdeStepBackend` selected by `--sde-step-backend-path` (miles custom-function style; the family config declares the default). `DiffusersSdeStepBackend` — plain flow-matching SDE over the scheduler — is the default for existing models; a family with its own dynamics plugs in a different backend without touching the training loop.
- **Layered so the kernel can be shared with rollout**: `sde_step_logprob` (SCORE mode) composes two overridable pieces — `resolve_sigmas` (per-pair σ/σ_next) → `prev_sample_mean_and_std` (deterministic dynamics kernel) → `log_prob` (Gaussian scoring). The boundaries mirror sgl-d's `SchedulerRLMixin.flow_sde_sampling` so the same dynamics kernel can eventually be imported by the rollout engine (SAMPLE mode draws noise around the same mean).
- **Constructed from primitives, not the train pipeline config**: the backend takes `(scheduler, sde_timestep_divisor)` — no `train_pipeline_config`, so either side can `load_function` and construct it. 

## Why

Two goals drive the shape:

1. **Train↔rollout parity is the whole point.** Train pairs now carry `next_timestep` (the actual next rollout timestep, terminal 0), and `resolve_sigmas` maps the pair's own rollout values to (σ, σ_next). Previously the train side re-derived σ_next by indexing a train-side scheduler at `idx+1` / re-locating the timestep by value — fine when the reconstructed schedule happens to align, silently wrong when it drifts. sgl-d sends only per-step timesteps (not sigmas), so resolving from the carried values keeps parity without assuming positional scheduler alignment.
2. **The step math should be shareable with the rollout engine.** Binding to `train_pipeline_config` would block rollout reuse (the rollout process has no train pipeline); passing `dynamics_type` in would push dynamics branching into one backend. Instead the class encodes the dynamics and takes only primitives, so the kernel is a clean seam for the future SAMPLE/SCORE unification.

Deliberately NOT in this PR: no new dynamics backend (LTX's CPS backend lands with the LTX PR), no rollout-side changes.

## Validation

Behavior-preserving for the default path.

- CPU unit test (`tests/fast/backends/fsdp_utils/test_sde_step_backend.py`): the layered `DiffusersSdeStepBackend` (σ resolution + mean/std kernel + Gaussian log_prob), constructed from primitives, reproduces the monolithic `sde_step_with_logprob` **bit-for-bit** (`rtol=0, atol=0`), with the per-pair `(timestep, next_timestep)` inputs.
- `stage-a-cpu` suite (CI's real entrypoint) green in a B200 container: 56 passed, the sde test included.
- `python3 train_diffusion.py --help` parses the new `--sde-step-backend-path` flag.
- End-to-end: on the stacked LTX branch, a single GRPO train step reproduces the pre-refactor train↔rollout `log_prob_mean_abs_diff = 8.145968e-07` bit-identically.

## Files

| File                                                      | Role                                                         |
| --------------------------------------------------------- | ------------------------------------------------------------ |
| `miles/backends/fsdp_utils/sde_step_backend.py`           | new: `SdeStepBackend` (base) + `DiffusersSdeStepBackend` (default flow-SDE); layered resolve/kernel/log_prob |
| `miles/backends/fsdp_utils/actor.py`                      | construct the backend from primitives; route both SDE-step call sites (loss + KL ref) through it |
| `miles/utils/train_data_utils.py`                         | carry `next_timestep` per train pair (terminal 0)            |
| `miles/utils/arguments.py`                                | `--sde-step-backend-path`                                    |
| `tests/fast/backends/fsdp_utils/test_sde_step_backend.py` | new CPU test (bitwise equivalence)                           |

## Checklist

- [x] `pre-commit run --all-files` passes — run on all PR-touched files; all hooks green
- [x] Added/updated tests for new behaviour — `test_sde_step_backend.py` (bitwise equivalence, primitives construction, next_timestep)
- [x] `pytest tests/fast -x` is green — 56 passed (container, CI's stage-a-cpu entrypoint)
- [x] If launch flags changed, `python3 train_diffusion.py --help` still parses — `--sde-step-backend-path`
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a
- [ ] If an example was added, it has a real walkthrough — n/a