### PR TITLE
refactor(rollout): rollout patch group-management

### DIFF
--- a/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
@@ -1,29 +1,63 @@
-"""sgl-d → diffusers numerical-parity monkey patches.
+"""sgl-d numerical-parity monkey patches for miles training alignment.
 
-Patches sgl-d's generic op classes (RMSNorm, LayerNormScaleShift, MulAdd,
-USPAttention, etc.) to match diffusers' bf16 cast/op order. Apply once at
-sglang-d scheduler startup so DiT forwards on the rollout side agree with
-diffusers-style training-side forwards down to bf16 ULPs.
+Patch groups align sgl-d rollout ops/models with the training-side forward.
+The engine parent lists selected group names in ``MILES_ROLLOUT_PATCH_GROUPS``;
+the sglang scheduler grandchild (spawn: fresh imports) re-reads it and applies
+those groups before model construction.
 
-Patches are at the op layer, not the model layer — they apply to every sgl-d
-DiT that uses these generic classes. Adding alignment for a new op = drop a
-new ``patch_<op>.py`` file and add it to ``apply_sgld_monkey_patches``.
+- ``sgld``: diffusers / SD3 op parity (RMSNorm, LayerNormScaleShift, MulAdd,
+  USPAttention, ...). Op-layer patches: they apply to every sgl-d DiT built
+  from these generic classes.
+
+Patch modules are imported inside ``apply_*`` only, so CPU-only Ray actors
+can import this package without pulling sglang triton kernels. Adding a
+group = one ``@register_rollout_patch_group("<name>")``-decorated apply fn.
 """
 
-from miles.backends.sglang_diffusion_utils.monkey_patches import (
-    patch_layernorm_scale_shift,
-    patch_mul_add,
-    patch_qk_norm_rope,
-    patch_rmsnorm,
-    patch_scale_residual_layernorm,
-    patch_usp_attention,
-)
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+# Comma-separated group names selected by the engine parent, e.g. "sgld,ltx".
+ROLLOUT_PATCH_GROUPS_ENV = "MILES_ROLLOUT_PATCH_GROUPS"
+
+_ROLLOUT_PATCH_APPLIERS: dict[str, Callable[[], None]] = {}
 
 
+def register_rollout_patch_group(name: str):
+    """Decorator: register a patch group's apply fn under a group name."""
+
+    def wrapper(fn: Callable[[], None]) -> Callable[[], None]:
+        _ROLLOUT_PATCH_APPLIERS[name] = fn
+        return fn
+
+    return wrapper
+
+
+@register_rollout_patch_group("sgld")
 def apply_sgld_monkey_patches() -> None:
+    from miles.backends.sglang_diffusion_utils.monkey_patches import (
+        patch_layernorm_scale_shift,
+        patch_mul_add,
+        patch_qk_norm_rope,
+        patch_rmsnorm,
+        patch_scale_residual_layernorm,
+        patch_usp_attention,
+    )
+
     patch_rmsnorm.apply()
     patch_layernorm_scale_shift.apply()
     patch_scale_residual_layernorm.apply()
     patch_mul_add.apply()
     patch_usp_attention.apply()
     patch_qk_norm_rope.apply()
+
+
+def apply_env_selected_rollout_patches() -> None:
+    """Apply every group named in the env list (runs in the scheduler grandchild)."""
+    for name in filter(None, os.environ.get(ROLLOUT_PATCH_GROUPS_ENV, "").split(",")):
+        applier = _ROLLOUT_PATCH_APPLIERS.get(name)
+        if applier is None:
+            raise ValueError(f"Unknown rollout patch group {name!r}; known: {list(_ROLLOUT_PATCH_APPLIERS)}")
+        applier()

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -33,21 +33,22 @@ def _to_local_gpu_id(physical_gpu_id: int) -> int:
     )
 
 
-def _scheduler_process_with_sgld_monkey_patches(*args, **kwargs):
+def _scheduler_process_with_rollout_patches(*args, **kwargs):
     # Runs inside sglang-d's scheduler grandchild (spawned by launch_server via
     # mp.Process). Grandchild re-imports modules from scratch under spawn, so
     # any monkey patches done in the middle child are gone. Apply them HERE,
     # before calling the real run_scheduler_process, so the DiT that's
-    # constructed inside the grandchild sees the patched classes.
-    from miles.backends.sglang_diffusion_utils.monkey_patches import apply_sgld_monkey_patches
+    # constructed inside the grandchild sees the patched classes. Which groups
+    # apply is carried by env flags (set in the engine parent, inherited by spawn).
+    from miles.backends.sglang_diffusion_utils.monkey_patches import apply_env_selected_rollout_patches
 
-    apply_sgld_monkey_patches()
+    apply_env_selected_rollout_patches()
     from sglang.multimodal_gen.runtime.managers.gpu_worker import run_scheduler_process
 
     return run_scheduler_process(*args, **kwargs)
 
 
-def _launch_server_target(server_args, apply_sgld_monkey_patches: bool = False):
+def _launch_server_target(server_args, apply_rollout_patches: bool = False):
     # addict.Dict used by SGL-D loses its `__frozen` instance attribute across spawn pickle.
     # Reconstruct a fresh one from the unpickled (broken) instance
     import addict
@@ -55,7 +56,7 @@ def _launch_server_target(server_args, apply_sgld_monkey_patches: bool = False):
     if server_args.attention_backend_config is not None:
         server_args.attention_backend_config = addict.Dict(server_args.attention_backend_config)
 
-    if apply_sgld_monkey_patches:
+    if apply_rollout_patches:
         # launch_server spawns its scheduler via mp.Process(target=run_scheduler_process).
         # Under spawn, target is pickled by qualname and re-imported in the grandchild,
         # so patching in THIS process doesn't help. Instead, rebind the name inside
@@ -64,7 +65,7 @@ def _launch_server_target(server_args, apply_sgld_monkey_patches: bool = False):
         # calling the real scheduler entrypoint.
         import sglang.multimodal_gen.runtime.launch_server as _ls_mod
 
-        _ls_mod.run_scheduler_process = _scheduler_process_with_sgld_monkey_patches
+        _ls_mod.run_scheduler_process = _scheduler_process_with_rollout_patches
 
     from sglang.multimodal_gen.runtime.launch_server import launch_server
 
@@ -73,14 +74,14 @@ def _launch_server_target(server_args, apply_sgld_monkey_patches: bool = False):
 
 def launch_server_process(
     server_args: ServerArgs,
-    apply_sgld_monkey_patches: bool = False,
+    apply_rollout_patches: bool = False,
 ) -> multiprocessing.Process:
     # use spawn to avoid potential risks of fork in terms of subthreads or CUDA.
     multiprocessing.set_start_method("spawn", force=True)
     server_args.host = server_args.host.strip("[]")
     p = multiprocessing.Process(
         target=_launch_server_target,
-        args=(server_args, apply_sgld_monkey_patches),
+        args=(server_args, apply_rollout_patches),
     )
     p.start()
 
@@ -157,12 +158,17 @@ class SGLangDiffusionEngine(RayActor):
     def _init_normal(self, server_args_dict):
         logger.info(f"Launch HttpServerEngineAdapter at: {self.server_host}:{self.server_port}")
         self._pin_to_assigned_gpu()
-        apply_sgld_monkey_patches = self.args.apply_sgld_monkey_patches
-        if apply_sgld_monkey_patches:
-            logger.info("Launching sglang-d with sgl-d → diffusers monkey patches " "(--apply-sgld-monkey-patches)")
+        from miles.backends.sglang_diffusion_utils.monkey_patches import ROLLOUT_PATCH_GROUPS_ENV
+
+        patch_groups = []
+        if getattr(self.args, "apply_sgld_monkey_patches", False):
+            patch_groups.append("sgld")
+        if patch_groups:
+            os.environ[ROLLOUT_PATCH_GROUPS_ENV] = ",".join(patch_groups)
+            logger.info("Launching sglang-d with rollout patch groups: %s", patch_groups)
         self.process = launch_server_process(
             ServerArgs.from_kwargs(**server_args_dict),
-            apply_sgld_monkey_patches=apply_sgld_monkey_patches,
+            apply_rollout_patches=bool(patch_groups),
         )
 
         if self.node_rank == 0 and self.router_ip and self.router_port:

--- a/tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py
+++ b/tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py
@@ -1,0 +1,46 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import pytest
+
+import miles.backends.sglang_diffusion_utils.monkey_patches as mp
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    # Swap the registry for a copy (auto-restored) so the real public decorator
+    # can be exercised without leaking the dummy group into other tests.
+    monkeypatch.setattr(mp, "_ROLLOUT_PATCH_APPLIERS", dict(mp._ROLLOUT_PATCH_APPLIERS))
+
+
+class TestRolloutPatchGroups:
+    # End-to-end group mechanics: a dummy group registered through the public
+    # decorator is applied iff its name is listed in MILES_ROLLOUT_PATCH_GROUPS.
+    def test_dummy_group_applied_when_selected(self, isolated_registry, monkeypatch):
+        calls = []
+
+        @mp.register_rollout_patch_group("dummy")
+        def apply_dummy() -> None:
+            calls.append("dummy")
+
+        monkeypatch.setenv(mp.ROLLOUT_PATCH_GROUPS_ENV, "dummy")
+        mp.apply_env_selected_rollout_patches()
+        # Only the selected group ran (built-in appliers would import sglang and fail here).
+        assert calls == ["dummy"]
+
+    def test_no_selection_applies_nothing(self, isolated_registry, monkeypatch):
+        calls = []
+        mp.register_rollout_patch_group("dummy")(lambda: calls.append("dummy"))
+        monkeypatch.delenv(mp.ROLLOUT_PATCH_GROUPS_ENV, raising=False)
+        mp.apply_env_selected_rollout_patches()
+        assert calls == []
+
+    def test_unknown_group_fails_loud(self, monkeypatch):
+        monkeypatch.setenv(mp.ROLLOUT_PATCH_GROUPS_ENV, "bogus")
+        with pytest.raises(ValueError, match="Unknown rollout patch group"):
+            mp.apply_env_selected_rollout_patches()
+
+    def test_builtin_group_registered(self):
+        # The decorator ran at import time for the in-repo group.
+        assert "sgld" in mp._ROLLOUT_PATCH_APPLIERS


### PR DESCRIPTION
## What

- **Named rollout patch groups**: parity monkey-patches self-register with `@register_rollout_patch_group("<name>")`; the engine parent lists the selected group names in one env var (`MILES_ROLLOUT_PATCH_GROUPS`, e.g. `"sgld"`), and the sglang scheduler grandchild applies exactly those groups before model construction — unknown names fail loud with the known-group list.
- **Lazy patch imports**: patch modules import inside `apply_*` only, so CPU-only Ray actors can import the package without pulling sglang triton kernels (pinned by a CPU test).
- **sgld behavior unchanged**: `--apply-sgld-monkey-patches` now maps to group `"sgld"`; same patches, same grandchild application point (spawn re-imports, so patching must happen there).

## Why

Today the sgld patches are the only group and their wiring is hardcoded end-to-end (bool threaded through `launch_server_process`, dedicated grandchild wrapper). Each new model family that needs its own rollout parity patches (first consumer: LTX-2, follow-up PR) would have to clone that plumbing. This PR turns the wiring into a registry: adding a group = one decorated function; selection is data (an env list) instead of code.

Deliberately NOT in this PR: no new patch group, no family/config coupling — group selection beyond the sgld flag lands with the first family that needs it.

## Validation

- CPU unit tests (`tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py`): a dummy group registered through the public decorator (against a monkeypatch-copied registry) applies iff listed in the env; empty env applies nothing; unknown name raises; built-in `sgld` registers at import. Selectivity is implicitly guarded — wrongly applying built-ins would lazy-import sglang and fail in the CPU env.
- `stage-a-cpu` suite (CI's real entrypoint, `tests/ci/run_suite.py --hw cpu --suite stage-a-cpu`) green in a B200 container: 59 passed, the 4 above included.
- No launch-flag changes (`arguments.py` untouched).

## Files

| File                                                         | Role                                                         |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| `miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py` | group registry (`register_rollout_patch_group`), env-list applier, lazy `apply_sgld_monkey_patches` |
| `miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py` | parent builds the group list + sets the env; grandchild wrapper applies env-selected groups |
| `tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py` | new CPU tests (see Validation)                               |

## Checklist

- [x] `pre-commit run --all-files` passes — on all PR-touched files
- [x] Added/updated tests for new behaviour — dummy-group registration/selection tests
- [x] `pytest tests/fast -x` is green — 59 passed (container, CI's stage-a-cpu entrypoint)
- [x] If launch flags changed, `python3 train_diffusion.py --help` still parses — no flag changes
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a (no new flag)
- [ ] If an example was added, it has a real walkthrough — n/a