### PR TITLE
feat(rollout): add reward-bottleneck perf metrics to rollout

### DIFF
--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import inspect
 import logging
+import time
 from argparse import Namespace
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -129,6 +130,35 @@ class GenerateState(metaclass=SingletonMeta):
         self.remaining_batch_size = 0
         self.pendings = set()
         self.aborted = False
+        # Perf accounting for the reward-bottleneck metrics; see
+        # _compute_reward_perf_metrics. Cleared per rollout.
+        self.generate_done_ts: list[float] = []
+        self.reward_done_ts: list[float] = []
+        self.reward_inflight = 0
+        self.reward_max_inflight = 0
+
+    def mark_generate_done(self) -> None:
+        """Stamp when a microgroup's (semaphore-gated) generation finished."""
+        self.generate_done_ts.append(time.monotonic())
+
+    @contextmanager
+    def reward_inflight_scope(self, *, record: bool):
+        """Track concurrent reward tasks and stamp when each reward finishes.
+
+        Reward runs outside the generation semaphore, so this backlog is what
+        grows when reward cannot keep up with generation (see
+        _compute_reward_perf_metrics).
+        """
+        if not record:
+            yield
+            return
+        self.reward_inflight += 1
+        self.reward_max_inflight = max(self.reward_max_inflight, self.reward_inflight)
+        try:
+            yield
+        finally:
+            self.reward_inflight -= 1
+            self.reward_done_ts.append(time.monotonic())
 
     def submit_generate_tasks(self, samples: list[list[Sample]]) -> None:
         for group in samples:
@@ -215,13 +245,16 @@ async def generate_and_rm_microgroup(
                     microgroup = await custom_generate_func(args, microgroup, sampling_params)
             else:
                 microgroup = await generate_microgroup(args, microgroup, sampling_params, evaluation=evaluation)
+    if not evaluation:
+        state.mark_generate_done()
 
     # for the rm that need the whole group, we will not do the rm here
     if args.group_rm:
         return microgroup
 
     # calculate the reward for the microgroup
-    rewards = await batched_async_rm(args, microgroup)
+    with state.reward_inflight_scope(record=not evaluation):
+        rewards = await batched_async_rm(args, microgroup)
     for sample, reward in zip(microgroup, rewards, strict=True):
         sample.reward = reward
     return microgroup
@@ -230,7 +263,7 @@ async def generate_and_rm_microgroup(
 async def generate_and_rm_group(
     args: Namespace, group: list[Sample], sampling_params: dict[str, Any], evaluation: bool = False
 ) -> list[Sample]:
-    GenerateState(args)
+    state = GenerateState(args)
 
     # N-spaced base so sgl-d's seed→[seed+0..seed+N-1] expansion stays disjoint
     # per (rollout, prompt-group); group_index is monotonic across the run.
@@ -254,7 +287,8 @@ async def generate_and_rm_group(
 
     # for the rm that need the whole group, we will do the rm here
     if args.group_rm:
-        rewards = await batched_async_rm(args, group)
+        with state.reward_inflight_scope(record=not evaluation):
+            rewards = await batched_async_rm(args, group)
         for sample, reward in zip(group, rewards, strict=False):
             sample.reward = reward
 
@@ -264,6 +298,41 @@ async def generate_and_rm_group(
 async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
     # SGL-D TODO: support oversampling+filter & abort
     raise NotImplementedError("SGLang-Diffusion doesn't support abort")
+
+
+def _compute_reward_perf_metrics(state: GenerateState, gen_start: float) -> dict[str, float]:
+    """Metrics that reveal whether reward — not generation — is the streaming bottleneck.
+
+    Reward runs *outside* the generation semaphore, so a slow reward is free as
+    long as it stays hidden under generation: the engine keeps generating the
+    next groups while earlier groups are being scored. Reward only costs
+    wall-clock once generation has drained and the engine sits idle waiting for
+    the remaining reward tasks to finish.
+
+    - ``tail_time``: that idle-waiting-on-reward span (last reward done − last
+      generate done). This is the wall-clock reward adds on top of generation,
+      i.e. the ceiling on what removing/overlapping reward could save.
+    - ``tail_ratio``: ``tail_time`` as a fraction of generation wall-clock.
+      ~0 → reward is fully hidden (not the bottleneck, even if slow per item);
+      large → reward is the bottleneck.
+    - ``max_inflight``: peak concurrent reward tasks — a leading indicator; it
+      grows through the rollout when reward cannot keep up with generation.
+
+    Timestamps cover the microgroups that completed within the rollout; with
+    ``over_sampling_batch_size == rollout_batch_size`` (currently enforced) that
+    is effectively the whole batch.
+    """
+    if not state.generate_done_ts or not state.reward_done_ts:
+        return {}
+    generate_all_done = max(state.generate_done_ts)
+    reward_all_done = max(state.reward_done_ts)
+    wall = reward_all_done - gen_start
+    tail = max(0.0, reward_all_done - generate_all_done)
+    return {
+        "perf/reward/tail_time": tail,
+        "perf/reward/tail_ratio": tail / wall if wall > 0 else 0.0,
+        "perf/reward/max_inflight": float(state.reward_max_inflight),
+    }
 
 
 async def generate_rollout_async(
@@ -284,6 +353,13 @@ async def generate_rollout_async(
     assert args.rollout_global_dataset
 
     state = GenerateState(args)
+    # Fresh perf accounting for this rollout (defensive against a prior rollout
+    # that errored before its end-of-run state.reset()).
+    state.generate_done_ts = []
+    state.reward_done_ts = []
+    state.reward_inflight = 0
+    state.reward_max_inflight = 0
+    rollout_gen_start = time.monotonic()
 
     # instantiate data filters
     dynamic_filter = (
@@ -350,13 +426,16 @@ async def generate_rollout_async(
     data = sorted(data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
     sorted(all_data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
 
+    # Compute perf metrics before reset() clears the timing accumulators.
+    metrics = {**metric_gatherer.collect(), **_compute_reward_perf_metrics(state, rollout_gen_start)}
+
     # reset the global state to prevent effects on the next rollout or eval.
     state.reset()
     if args.rollout_sample_filter_path is not None:
         filter_func = load_function(args.rollout_sample_filter_path)
         filter_func(args, data)
 
-    return RolloutFnTrainOutput(samples=data, metrics=metric_gatherer.collect())
+    return RolloutFnTrainOutput(samples=data, metrics=metrics)
 
 
 EVAL_PROMPT_DATASET = {}

--- a/tests/fast/rollout/test_reward_perf_metrics.py
+++ b/tests/fast/rollout/test_reward_perf_metrics.py
@@ -1,0 +1,61 @@
+"""CPU unit tests for _compute_reward_perf_metrics (reward-bottleneck perf).
+
+Pure timestamp arithmetic over the generate/reward completion stamps collected
+during streaming rollout. No ray / engine / model needed — the state is faked
+with a SimpleNamespace exposing only the three fields the function reads.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+from miles.rollout.sglang_diffusion_rollout import _compute_reward_perf_metrics
+
+
+def _state(generate_done_ts, reward_done_ts, reward_max_inflight):
+    return SimpleNamespace(
+        generate_done_ts=generate_done_ts,
+        reward_done_ts=reward_done_ts,
+        reward_max_inflight=reward_max_inflight,
+    )
+
+
+def test_no_stamps_returns_empty():
+    # e.g. group_rm with no reward recorded, or an aborted rollout.
+    assert _compute_reward_perf_metrics(_state([], [], 0), gen_start=0.0) == {}
+    assert _compute_reward_perf_metrics(_state([1.0], [], 0), gen_start=0.0) == {}
+
+
+def test_reward_hidden_under_generation_is_not_bottleneck():
+    # last generate at t=10, last reward at t=10.1 -> tiny tail, ratio ~0.
+    m = _compute_reward_perf_metrics(_state([2.0, 5.0, 10.0], [3.0, 6.0, 10.1], 3), gen_start=0.0)
+    assert m["perf/reward/tail_time"] == pytest.approx(0.1)
+    assert m["perf/reward/tail_ratio"] == pytest.approx(0.1 / 10.1)
+    assert m["perf/reward/max_inflight"] == 3.0
+
+
+def test_reward_tail_is_the_bottleneck():
+    # generation drained at t=10, reward keeps going to t=18 -> tail=8, ratio=8/18.
+    m = _compute_reward_perf_metrics(_state([4.0, 8.0, 10.0], [9.0, 14.0, 18.0], 12), gen_start=0.0)
+    assert m["perf/reward/tail_time"] == pytest.approx(8.0)
+    assert m["perf/reward/tail_ratio"] == pytest.approx(8.0 / 18.0)
+    assert m["perf/reward/max_inflight"] == 12.0
+
+
+def test_tail_clamped_non_negative():
+    # A late generation stamp (e.g. an oversampled task) must not yield a
+    # negative tail — reward finished before the last generate.
+    m = _compute_reward_perf_metrics(_state([5.0, 20.0], [6.0, 10.0], 2), gen_start=0.0)
+    assert m["perf/reward/tail_time"] == 0.0
+    assert m["perf/reward/tail_ratio"] == 0.0
+
+
+def test_ratio_uses_gen_start_as_wall_clock_origin():
+    # wall = last_reward - gen_start = 18 - 2 = 16; tail = 18 - 12 = 6.
+    m = _compute_reward_perf_metrics(_state([8.0, 12.0], [15.0, 18.0], 4), gen_start=2.0)
+    assert m["perf/reward/tail_time"] == pytest.approx(6.0)
+    assert m["perf/reward/tail_ratio"] == pytest.approx(6.0 / 16.0)


### PR DESCRIPTION
## What

Instrument the streaming rollout to answer one question: **is reward the bottleneck, or is it slow but fully hidden under generation?** Per rollout we now emit three metrics:

- `perf/reward/tail_time` — the idle-waiting-on-reward span (`last reward done − last generate done`), i.e. the wall-clock reward adds on top of generation.
- `perf/reward/tail_ratio` — `tail_time` as a fraction of generation wall-clock. `~0` → reward is fully hidden (not the bottleneck, even if slow per item); large → reward **is** the bottleneck. This is also the ceiling on what removing/overlapping reward could save.
- `perf/reward/max_inflight` — peak concurrent reward tasks; a leading indicator that grows through the rollout when reward can't keep up with generation.

## Why

In the streaming rollout, reward runs **outside** the generation semaphore (`generate_and_rm_microgroup` releases the semaphore before calling `batched_async_rm`). So while group A is being scored, the engine is already generating group B. A slow reward costs **zero** wall-clock as long as it stays hidden under generation — it only starts costing once generation has drained and the engine sits idle waiting for the remaining reward tasks to finish.

That means the intuitive metrics — reward throughput or per-item reward latency — are misleading: a 5s/item reward fully overlapped under a 20s generate is not a bottleneck at all. The honest signal is the **non-overlapped reward tail**, which is exactly what `tail_time` / `tail_ratio` measure.

## How it works

- `GenerateState` accumulates `generate_done_ts` / `reward_done_ts` timestamps (`time.monotonic()`) and tracks reward in-flight count with a running peak.
- Generate stamp is taken right after the semaphore-gated generation; reward stamp + in-flight tracking wrap the `batched_async_rm` call — covering both the per-microgroup path and the `group_rm` per-group path.
- Recording is gated to **training** rollouts (`record=not evaluation`), so eval doesn't pollute the accumulators.
- Metrics are computed **before** the end-of-rollout `state.reset()` and merged into the existing `RolloutFnTrainOutput.metrics`, so they flow through `_log_rollout_data` to wandb with no new plumbing. Empty/again-safe: returns `{}` when no stamps were recorded.

## Files

- `miles/rollout/sglang_diffusion_rollout.py` — timing accumulators + `reward_inflight_scope` on `GenerateState`; stamps in `generate_and_rm_microgroup` / `generate_and_rm_group`; `_compute_reward_perf_metrics`; wired into `generate_rollout_async`.
- `tests/fast/rollout/test_reward_perf_metrics.py` — CPU unit tests for the metric (hidden vs bottleneck vs clamp vs gen-start origin vs empty).
- `tests/fast/rollout/__init__.py` — new test package.

## Notes / scope

- Timestamps cover microgroups that **completed** within the rollout. With `over_sampling_batch_size == rollout_batch_size` (currently enforced) that is effectively the whole batch; if/when oversampling+abort lands, the tail becomes an approximation over completed work.
- No launch flags added; metrics are always emitted (three scalars per rollout, negligible cost).

## Checklist

- [ ] `pre-commit run --all-files` — **not run locally** (pre-commit not installed in this env). Changes were hand-checked against the repo config: black/isort line-length 119, imports ordered, `import time` used, all lines ≤119.
- [x] Added tests for new behaviour (`tests/fast/rollout/test_reward_perf_metrics.py`, registered `stage-a-cpu`).
- [ ] `pytest -x` — **not run locally**: this env has no `ray`/`torch`, so importing the module fails. The metric's arithmetic was verified standalone (all 6 cases pass); the fast CPU suite will exercise it in CI.
- [x] No launch flags changed — `--help` unaffected.
- [x] No public flag added — no CLI reference doc change needed.
- [x] No example added.
