### PR TITLE
fix(fsdp): apply set_attention_backend per raw model (wan2.2)

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -127,13 +127,14 @@ class FSDPTrainRayActor(TrainRayActor):
             self.scheduler = pipeline.scheduler
             del pipeline
 
-        if args.fsdp_attention_backend is not None:
-            model.set_attention_backend(args.fsdp_attention_backend)
-
         self.train_pipeline_config = get_train_pipeline_config(args.diffusion_model)
 
         self.models: dict[str, torch.nn.Module] = {}
         for component, model in raw_models.items():
+            # per raw component (wan2.2 has two transformers), before LoRA/FSDP wrap
+            if args.fsdp_attention_backend is not None:
+                model.set_attention_backend(args.fsdp_attention_backend)
+
             if args.use_lora:
                 model = apply_lora(model, args, self.train_pipeline_config)
 


### PR DESCRIPTION
The wan2.2 refactor moved DiT loading to a raw_models dict + per-component loop, but conflicts the set_attention_backend call outside the loop referencing an undefined `model` — so `--fsdp-attention-backend` raised NameError (the default None path hid it). Move it into the loop, on each raw component before LoRA/FSDP wrapping, so wan2.2's two transformers both get it.