### PR TITLE
refactor(fsdp): route attention-backend selection through ModelBackend

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -115,7 +115,7 @@ class FSDPTrainRayActor(TrainRayActor):
         for component, model in raw_models.items():
             # per raw component (wan2.2 has two transformers), before LoRA/FSDP wrap
             if args.fsdp_attention_backend is not None:
-                model.set_attention_backend(args.fsdp_attention_backend)
+                self.model_backend.set_attention_backend(model, args.fsdp_attention_backend)
 
             if args.use_lora:
                 model = apply_lora(model, args, self.train_pipeline_config)

--- a/miles/backends/fsdp_utils/model_backend.py
+++ b/miles/backends/fsdp_utils/model_backend.py
@@ -42,6 +42,10 @@ class ModelBackend(abc.ABC):
         """Block class names FSDP wraps; default = the model's own declaration."""
         return model._no_split_modules
 
+    def set_attention_backend(self, model: torch.nn.Module, backend: str) -> None:
+        """Select the DiT attention backend; default = the diffusers protocol method."""
+        model.set_attention_backend(backend)
+
 
 class DiffusersModelBackend(ModelBackend):
     """Load trainable components from a diffusers pipeline checkpoint."""

--- a/tests/fast/backends/fsdp_utils/test_model_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_model_backend.py
@@ -1,0 +1,42 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=15, suite="stage-a-cpu", labels=[])
+
+import torch
+
+from miles.backends.fsdp_utils.model_backend import DiffusersModelBackend, ModelBackend
+
+
+class _RecordingModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.selected = None
+
+    def set_attention_backend(self, backend):  # diffusers protocol method
+        self.selected = backend
+
+
+class TestSetAttentionBackend:
+    # Default hook delegates to the model's own diffusers protocol method.
+    def test_diffusers_default_delegates_to_model(self):
+        model = _RecordingModel()
+        DiffusersModelBackend(None).set_attention_backend(model, "flash")
+        assert model.selected == "flash"
+
+    # A custom backend overrides the hook (non-diffusers models select attention a
+    # different way, or opt out) — the actor no longer calls model.set_attention_backend
+    # directly, so a model without that method never crashes.
+    def test_subclass_can_override(self):
+        seen = {}
+
+        class _CustomBackend(ModelBackend):
+            def load_models_and_scheduler(self, args, *, master_dtype):
+                raise NotImplementedError
+
+            def set_attention_backend(self, model, backend):
+                seen["backend"] = backend
+
+        model = _RecordingModel()
+        _CustomBackend(None).set_attention_backend(model, "fa3")
+        assert seen["backend"] == "fa3"
+        assert model.selected is None  # diffusers default path not taken

--- a/tests/fast/backends/fsdp_utils/test_model_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_model_backend.py
@@ -40,3 +40,19 @@ class TestSetAttentionBackend:
         _CustomBackend(None).set_attention_backend(model, "fa3")
         assert seen["backend"] == "fa3"
         assert model.selected is None  # diffusers default path not taken
+
+    # The concrete crash the refactor removes: a model without set_attention_backend
+    # (e.g. ltx_core transformers) must not raise when a backend that opts out of the
+    # diffusers protocol handles it — the actor never calls the model method directly.
+    def test_model_without_method_does_not_crash(self):
+        class _NoAttnModel(torch.nn.Module):
+            pass  # no set_attention_backend, like a native ltx_core transformer
+
+        class _OptOutBackend(ModelBackend):
+            def load_models_and_scheduler(self, args, *, master_dtype):
+                raise NotImplementedError
+
+            def set_attention_backend(self, model, backend):
+                pass  # this family selects attention its own way
+
+        _OptOutBackend(None).set_attention_backend(_NoAttnModel(), "fa3")  # no AttributeError


### PR DESCRIPTION
## What

Move DiT attention-backend selection off the actor and onto `ModelBackend`, so each
model family picks its attention backend its own way and the actor stays model-agnostic.

- New hook `ModelBackend.set_attention_backend(model, backend)`, defaulting to the
  diffusers protocol method (`model.set_attention_backend(backend)`) — the same
  default-on-base / override-in-subclass shape as `enable_gradient_checkpointing` and
  `fsdp_no_split_modules`.
- The actor now calls `self.model_backend.set_attention_backend(model, args.fsdp_attention_backend)`
  instead of `model.set_attention_backend(...)` directly.

## Why

Since #16, model-behaviour methods live on `ModelBackend` so custom (non-diffusers)
models can override them. #20 added `--fsdp-attention-backend` by calling
`model.set_attention_backend(...)` **directly in the actor loop**, which silently
reintroduced the diffusers-only assumption: a raw component without that method crashes
with `AttributeError` the moment `--fsdp-attention-backend` is passed.

This is not hypothetical for custom models. LTX's `ltx_core` transformers select
attention through a completely different API (an `AttentionFunction` enum applied via
`set_attention_module_op`, not a `set_attention_backend(str)` method), and today LTX
only avoids the crash because its example omits the flag. Routing through the backend
restores the abstraction and lets each family implement attention selection correctly
(the LTX override — mapping the flag to `ltx_core`'s FA3/FA4/SDPA backends — lands with
the LTX PR).

## Files

- `miles/backends/fsdp_utils/model_backend.py` — add the `set_attention_backend` hook (diffusers default).
- `miles/backends/fsdp_utils/actor.py` — call the hook instead of `model.set_attention_backend` directly.
- `tests/fast/backends/fsdp_utils/test_model_backend.py` — cover the default delegation,
  a subclass override, and a custom model with no `set_attention_backend` method (the
  crash this fix removes).

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour (3 cases: diffusers default, subclass override, method-less model)
- [x] `pytest -x` is green (`stage-a-cpu`: 71 passed, incl. the new cases)
- [x] Launch flags unchanged; `python3 train_diffusion.py --help` still parses (exit 0)
- [ ] No public flag added → CLI reference docs unchanged (N/A)
- [ ] No example added (N/A)