### PR TITLE
fsdp: fix --config YAML values being silently ignored for registered args

### DIFF
--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -64,7 +64,7 @@ class FSDPArgs:
     config: str | None = None
 
 
-def parse_fsdp_cli(extra_args_provider=None):
+def _build_fsdp_parser(extra_args_provider=None):
     parser = argparse.ArgumentParser("FSDP SFT Training (miles)")
     parser.add_argument("--config", type=str, default=None, help="YAML config path")
     for f in dataclasses.fields(FSDPArgs):
@@ -86,8 +86,26 @@ def parse_fsdp_cli(extra_args_provider=None):
 
     if extra_args_provider is not None:
         parser = extra_args_provider(parser)
-    args = parser.parse_args()
-    return args
+    return parser
+
+
+def parse_fsdp_cli(extra_args_provider=None):
+    return _build_fsdp_parser(extra_args_provider).parse_args()
+
+
+def _explicit_cli_dests(extra_args_provider=None):
+    """Dests the user actually passed on the command line.
+
+    argparse fills every dest with its default, so a plain parse can't
+    distinguish "--lr 2e-5 given" from "lr defaulted". Re-parse with all
+    defaults suppressed: only explicitly-passed options survive.
+    """
+    parser = _build_fsdp_parser(extra_args_provider)
+    for action in parser._actions:
+        action.default = argparse.SUPPRESS
+    parser._defaults.clear()  # set_defaults() from extra_args_provider
+    known, _ = parser.parse_known_args()
+    return set(vars(known))
 
 
 # Deterministic-mode attention support matrix — KEEP IN SYNC. torch's flag only
@@ -153,12 +171,20 @@ def validate_attention_args(args):
 
 
 def load_fsdp_args(extra_args_provider=None):
+    """Parse args with precedence: explicit CLI > YAML --config > defaults.
+
+    The previous `if not hasattr(args, k)` guard made YAML unable to set ANY
+    registered option (argparse pre-fills them all with defaults), silently
+    ignoring most of the config file. Unknown YAML keys are still attached to
+    args as-is for custom function arguments.
+    """
     args = parse_fsdp_cli(extra_args_provider)
     if args.config:
         with open(args.config) as f:
             data = yaml.safe_load(f) or {}
+        explicit = _explicit_cli_dests(extra_args_provider)
         for k, v in data.items():
-            if not hasattr(args, k):
+            if k not in explicit:
                 setattr(args, k, v)
     validate_attention_args(args)
     return args

--- a/tests/fast/backends/fsdp_utils/test_yaml_config_precedence.py
+++ b/tests/fast/backends/fsdp_utils/test_yaml_config_precedence.py
@@ -1,0 +1,117 @@
+"""YAML --config precedence: explicit CLI > YAML > dataclass defaults.
+
+Regression test for load_fsdp_args silently ignoring YAML values: the old
+`if not hasattr(args, k)` guard rejected every registered option because
+argparse pre-fills all dests with defaults. CPU-only, no GPU needed.
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+import sys
+from contextlib import contextmanager
+
+import yaml
+
+from miles.backends.fsdp_utils.arguments import load_fsdp_args
+
+
+@contextmanager
+def _argv(*argv):
+    old = sys.argv
+    sys.argv = ["train.py", *argv]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+def _write_config(tmp_path, data):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return str(path)
+
+
+def test_yaml_overrides_default(tmp_path):
+    config = _write_config(tmp_path, {"attn_implementation": "sdpa", "lr": 1e-4})
+    with _argv("--config", config):
+        args = load_fsdp_args()
+    assert args.attn_implementation == "sdpa"
+    assert args.lr == 1e-4
+
+
+def test_explicit_cli_beats_yaml(tmp_path):
+    config = _write_config(tmp_path, {"attn_implementation": "sdpa"})
+    with _argv("--config", config, "--attn-implementation", "eager"):
+        args = load_fsdp_args()
+    assert args.attn_implementation == "eager"
+
+
+def test_explicit_cli_beats_yaml_even_at_default_value(tmp_path):
+    config = _write_config(tmp_path, {"attn_implementation": "sdpa"})
+    with _argv("--config", config, "--attn-implementation", "flash_attention_2"):
+        args = load_fsdp_args()
+    assert args.attn_implementation == "flash_attention_2"
+
+
+def test_yaml_sets_bool_flag(tmp_path):
+    config = _write_config(tmp_path, {"gradient_checkpointing": True})
+    with _argv("--config", config):
+        args = load_fsdp_args()
+    assert args.gradient_checkpointing is True
+
+
+def test_cli_bool_flag_beats_yaml_false(tmp_path):
+    config = _write_config(tmp_path, {"fp16": False})
+    with _argv("--config", config, "--fp16"):
+        args = load_fsdp_args()
+    assert args.fp16 is True
+
+
+def test_unknown_yaml_key_still_attached(tmp_path):
+    config = _write_config(tmp_path, {"custom_reward_arg": 42})
+    with _argv("--config", config):
+        args = load_fsdp_args()
+    assert args.custom_reward_arg == 42
+
+
+def test_extra_args_provider_yaml_and_set_defaults(tmp_path):
+    def provider(parser):
+        parser.add_argument("--extra-knob", type=str, default="a")
+        parser.set_defaults(extra_knob_two="x")
+        return parser
+
+    config = _write_config(tmp_path, {"extra_knob": "b", "extra_knob_two": "y"})
+    with _argv("--config", config):
+        args = load_fsdp_args(extra_args_provider=provider)
+    assert args.extra_knob == "b"
+    assert args.extra_knob_two == "y"
+
+    with _argv("--config", config, "--extra-knob", "c"):
+        args = load_fsdp_args(extra_args_provider=provider)
+    assert args.extra_knob == "c"
+
+
+def test_no_config_unchanged():
+    with _argv("--attn-implementation", "eager"):
+        args = load_fsdp_args()
+    assert args.attn_implementation == "eager"
+    assert args.config is None
+
+
+if __name__ == "__main__":
+    import pathlib
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        tmp = pathlib.Path(d)
+        test_yaml_overrides_default(tmp)
+        test_explicit_cli_beats_yaml(tmp)
+        test_explicit_cli_beats_yaml_even_at_default_value(tmp)
+        test_yaml_sets_bool_flag(tmp)
+        test_cli_bool_flag_beats_yaml_false(tmp)
+        test_unknown_yaml_key_still_attached(tmp)
+        test_extra_args_provider_yaml_and_set_defaults(tmp)
+        test_no_config_unchanged()
+    print("PASS: YAML --config precedence (CLI > YAML > defaults)")


### PR DESCRIPTION
## Problem

`load_fsdp_args` applies YAML `--config` keys only when `not hasattr(args, k)`. But argparse pre-fills **every registered dest** with its default before this check runs, so `hasattr` is always true for any known option — `attn_implementation`, `lr`, `fp16`, and (since the parser is built with `extra_args_provider=add_miles_arguments`) every miles argument too.

Net effect: a YAML config file can only inject keys the parser has never heard of (custom function args). Everything else in it is **silently dropped** and training runs with CLI/defaults, with no warning. E.g. `attn_implementation: sdpa` in YAML does nothing.

## Fix

Detect which dests the user actually passed on the command line by re-parsing with all defaults suppressed (`argparse.SUPPRESS` on every action, plus clearing `set_defaults`), then apply YAML values to every key **not** explicitly given:

```
explicit CLI > YAML --config > dataclass defaults
```

- Explicit CLI always wins, even when the passed value equals the default.
- Unknown YAML keys still attach to `args` as before (custom function arguments keep working).
- `parse_fsdp_cli` behavior is unchanged; parser construction is extracted into `_build_fsdp_parser` so both parses share one definition.

## Tests

`tests/fast/backends/fsdp_utils/test_yaml_config_precedence.py` (registered `stage-a-cpu`, no GPU):

- YAML overrides defaults (str + float)
- explicit CLI beats YAML, including when CLI value == default
- bool flags: YAML `true` applies; CLI `--fp16` beats YAML `false`
- unknown YAML keys still attach
- `extra_args_provider` args + `set_defaults` interplay
- no-`--config` path unchanged

Local machine only has Python 3.9 (repo needs 3.10+), so the mechanism was verified with a standalone replica of the argparse logic (all 8 scenarios pass); the real test relies on CI.

## Note

`miles/backends/experimental/fsdp_utils/arguments.py` in radixark/miles has the same bug — if this approach lands, I can port it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)