### PR TITLE
fsdp: meta-init non-rank0 models, broadcast weights from rank 0 (align with miles LLM backend)

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -107,9 +107,21 @@ class FSDPTrainRayActor(TrainRayActor):
 
         self.train_pipeline_config = load_function(args.train_pipeline_config_path)()
         self.model_backend = load_function(args.model_backend_path)(self.train_pipeline_config)
-        raw_models, self.scheduler = self.model_backend.load_models_and_scheduler(
-            args, master_dtype=self._master_dtype
-        )
+
+        # Rank 0 loads real weights on CPU; every other rank builds an
+        # architecture-only meta skeleton (no checkpoint IO). Weights reach the
+        # other ranks via broadcast in _fsdp2_load_full_state_dict below.
+        # Ref: miles/backends/experimental/fsdp_utils/actor.py (LLM backend).
+        if dist.get_rank() == 0:
+            logger.info("[Rank 0] loading full weights on CPU (will broadcast to other ranks)")
+            raw_models, self.scheduler = self.model_backend.load_models_and_scheduler(
+                args, master_dtype=self._master_dtype
+            )
+        else:
+            logger.info(f"[Rank {dist.get_rank()}] building meta skeleton, no checkpoint weight IO")
+            raw_models, self.scheduler = self.model_backend.build_meta_models_and_scheduler(
+                args, master_dtype=self._master_dtype
+            )
 
         self.models: dict[str, torch.nn.Module] = {}
         for component, model in raw_models.items():
@@ -125,9 +137,9 @@ class FSDPTrainRayActor(TrainRayActor):
             if args.gradient_checkpointing:
                 self.model_backend.enable_gradient_checkpointing(model)
 
-            model.to(torch.cuda.current_device())
-
-            self.train_pipeline_config.preprocess_model_before_fsdp(model)
+            # Capture the full state dict (real tensors on rank 0, meta elsewhere)
+            # BEFORE fully_shard turns the params into DTensor shards.
+            full_state = model.state_dict()
 
             model = apply_fsdp2(
                 model,
@@ -136,6 +148,20 @@ class FSDPTrainRayActor(TrainRayActor):
                 args=self.args,
                 no_split_modules=self.model_backend.fsdp_no_split_modules(model),
             )
+
+            model = self._fsdp2_load_full_state_dict(
+                model,
+                full_state,
+                self.parallel_state.dp_mesh,
+                cpu_offload=True if self.args.fsdp_cpu_offload else None,
+            )
+            del full_state
+
+            # Runs after materialization: the qwen_image hook rebuilds RoPE caches
+            # on the params' device, which must be CUDA — before the broadcast
+            # above, non-rank-0 params are meta and the hook would silently no-op.
+            self.train_pipeline_config.preprocess_model_before_fsdp(model)
+
             self.models[component] = model
         # Force a sync to ensure sharding is complete and old memory is freed.
         torch.cuda.synchronize()
@@ -201,6 +227,44 @@ class FSDPTrainRayActor(TrainRayActor):
 
     def _get_parallel_config(self) -> dict:
         return {"dp_size": getattr(self.parallel_state, "dp_size", 1)}
+
+    def _fsdp2_load_full_state_dict(self, model, full_state, device_mesh, cpu_offload):
+        """Load the full state dict into the FSDP2 model, broadcasting from rank 0.
+
+        Rank 0 holds the only real copy of the weights (other ranks built meta
+        skeletons); after fully_shard, rank 0 broadcasts and each rank keeps just
+        its own DTensor shard — no rank ever materializes the whole model on GPU.
+
+        Args:
+            model: FSDP2-wrapped model (params: DTensor on cpu for rank 0, meta elsewhere)
+            full_state: state dict captured before fully_shard (real on rank 0)
+            device_mesh: FSDP device mesh
+            cpu_offload: if not None, offload params back to CPU (CPUOffloadPolicy)
+
+        Ref: miles/backends/experimental/fsdp_utils/actor.py::_fsdp2_load_full_state_dict
+             (itself from verl/utils/fsdp_utils.py::fsdp2_load_full_state_dict)
+        """
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
+
+        if dist.get_rank() == 0:
+            model = model.to(device=torch.cuda.current_device(), non_blocking=True)
+        else:
+            model = model.to_empty(device=torch.cuda.current_device())
+
+        is_cpu_offload = cpu_offload is not None
+        options = StateDictOptions(full_state_dict=True, cpu_offload=is_cpu_offload, broadcast_from_rank0=True)
+        set_model_state_dict(model, full_state, options=options)
+
+        # set_model_state_dict does not broadcast buffers; do it manually.
+        for _, buf in model.named_buffers():
+            dist.broadcast(buf, src=0)
+
+        if is_cpu_offload:
+            model.to("cpu", non_blocking=True)
+            for buf in model.buffers():
+                buf.data = buf.data.to(torch.cuda.current_device())
+
+        return model
 
     @timer
     def sleep(self) -> None:

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -108,12 +108,11 @@ class FSDPTrainRayActor(TrainRayActor):
         self.train_pipeline_config = load_function(args.train_pipeline_config_path)()
         self.model_backend = load_function(args.model_backend_path)(self.train_pipeline_config)
 
-        # Rank 0 loads real weights on CPU; every other rank builds an
-        # architecture-only meta skeleton (no checkpoint IO). Weights reach the
-        # other ranks via broadcast in _fsdp2_load_full_state_dict below.
-        # Ref: miles/backends/experimental/fsdp_utils/actor.py (LLM backend).
-        if dist.get_rank() == 0:
-            logger.info("[Rank 0] loading full weights on CPU (will broadcast to other ranks)")
+        # dp-rank-0 loads real weights on CPU; other ranks build meta skeletons and
+        # receive weights via broadcast in _fsdp2_load_full_state_dict.
+        dp_rank = self.parallel_state.dp_mesh.get_local_rank()
+        if dp_rank == 0:
+            logger.info(f"[Rank {dist.get_rank()}] loading full weights on CPU (broadcast source)")
             raw_models, self.scheduler = self.model_backend.load_models_and_scheduler(
                 args, master_dtype=self._master_dtype
             )
@@ -137,8 +136,7 @@ class FSDPTrainRayActor(TrainRayActor):
             if args.gradient_checkpointing:
                 self.model_backend.enable_gradient_checkpointing(model)
 
-            # Capture the full state dict (real tensors on rank 0, meta elsewhere)
-            # BEFORE fully_shard turns the params into DTensor shards.
+            # Capture before fully_shard turns params into DTensor shards.
             full_state = model.state_dict()
 
             model = apply_fsdp2(
@@ -157,9 +155,7 @@ class FSDPTrainRayActor(TrainRayActor):
             )
             del full_state
 
-            # Runs after materialization: the qwen_image hook rebuilds RoPE caches
-            # on the params' device, which must be CUDA — before the broadcast
-            # above, non-rank-0 params are meta and the hook would silently no-op.
+            # After materialization: the qwen_image hook needs CUDA-resident params.
             self.train_pipeline_config.preprocess_model_before_fsdp(model)
 
             self.models[component] = model
@@ -229,24 +225,11 @@ class FSDPTrainRayActor(TrainRayActor):
         return {"dp_size": getattr(self.parallel_state, "dp_size", 1)}
 
     def _fsdp2_load_full_state_dict(self, model, full_state, device_mesh, cpu_offload):
-        """Load the full state dict into the FSDP2 model, broadcasting from rank 0.
-
-        Rank 0 holds the only real copy of the weights (other ranks built meta
-        skeletons); after fully_shard, rank 0 broadcasts and each rank keeps just
-        its own DTensor shard — no rank ever materializes the whole model on GPU.
-
-        Args:
-            model: FSDP2-wrapped model (params: DTensor on cpu for rank 0, meta elsewhere)
-            full_state: state dict captured before fully_shard (real on rank 0)
-            device_mesh: FSDP device mesh
-            cpu_offload: if not None, offload params back to CPU (CPUOffloadPolicy)
-
-        Ref: miles/backends/experimental/fsdp_utils/actor.py::_fsdp2_load_full_state_dict
-             (itself from verl/utils/fsdp_utils.py::fsdp2_load_full_state_dict)
-        """
+        """Broadcast dp-rank-0's full state dict into every rank's DTensor shards.
+        Ref: miles LLM experimental/fsdp_utils actor (from verl fsdp2_load_full_state_dict)."""
         from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 
-        if dist.get_rank() == 0:
+        if device_mesh.get_local_rank() == 0:
             model = model.to(device=torch.cuda.current_device(), non_blocking=True)
         else:
             model = model.to_empty(device=torch.cuda.current_device())
@@ -255,9 +238,9 @@ class FSDPTrainRayActor(TrainRayActor):
         options = StateDictOptions(full_state_dict=True, cpu_offload=is_cpu_offload, broadcast_from_rank0=True)
         set_model_state_dict(model, full_state, options=options)
 
-        # set_model_state_dict does not broadcast buffers; do it manually.
+        # set_model_state_dict does not broadcast buffers; do it over the dp group.
         for _, buf in model.named_buffers():
-            dist.broadcast(buf, src=0)
+            dist.broadcast(buf, group=device_mesh.get_group(), group_src=0)
 
         if is_cpu_offload:
             model.to("cpu", non_blocking=True)

--- a/miles/backends/fsdp_utils/model_backend.py
+++ b/miles/backends/fsdp_utils/model_backend.py
@@ -43,18 +43,10 @@ class ModelBackend(abc.ABC):
         *,
         master_dtype: torch.dtype,
     ) -> tuple[dict[str, torch.nn.Module], Any]:
-        """Architecture-only twin of ``load_models_and_scheduler`` for non-rank-0
-        FSDP ranks: same components with every parameter on the meta device and no
-        checkpoint weight IO. Rank 0 loads real weights and broadcasts into the
-        sharded model (``actor._fsdp2_load_full_state_dict``), so state-dict keys
-        and param dtypes must match rank 0 exactly.
-
-        Default falls back to a full load (the pre-meta-init behavior) so custom
-        backends keep working; override for the memory/IO win.
-        """
+        """Meta-device twin of ``load_models_and_scheduler`` (same state-dict keys and
+        dtypes, no weight IO) for ranks that receive weights via broadcast."""
         logger.warning(
-            "%s does not implement build_meta_models_and_scheduler; "
-            "falling back to loading full weights on every rank",
+            "%s lacks build_meta_models_and_scheduler; every rank loads full weights",
             type(self).__name__,
         )
         return self.load_models_and_scheduler(args, master_dtype=master_dtype)
@@ -107,9 +99,7 @@ class DiffusersModelBackend(ModelBackend):
         *,
         master_dtype: torch.dtype,
     ) -> tuple[dict[str, torch.nn.Module], Any]:
-        # diffusers' from_pretrained materializes real weights even inside an outer
-        # accelerate.init_empty_weights (loading happens after __init__ via direct
-        # tensor assignment), so build skeletons from component configs instead.
+        # from_pretrained ignores an outer init_empty_weights, so build from configs.
         import diffusers
         from accelerate import init_empty_weights
 
@@ -126,7 +116,7 @@ class DiffusersModelBackend(ModelBackend):
             cls = getattr(diffusers, class_name, None)
             if cls is None:
                 raise ValueError(
-                    f"component '{component}' class '{class_name}' is not a diffusers-native class; "
+                    f"component '{component}' class '{class_name}' is not diffusers-native; "
                     "override build_meta_models_and_scheduler in a custom ModelBackend"
                 )
             sub_config = cls.load_config(args.hf_checkpoint, subfolder=component)

--- a/miles/backends/fsdp_utils/model_backend.py
+++ b/miles/backends/fsdp_utils/model_backend.py
@@ -15,10 +15,13 @@ native model overrides methods here instead of retrofitting its instances.
 from __future__ import annotations
 
 import abc
+import logging
 from typing import Any
 
 import torch
 from diffusers import DiffusionPipeline
+
+logger = logging.getLogger(__name__)
 
 
 class ModelBackend(abc.ABC):
@@ -33,6 +36,28 @@ class ModelBackend(abc.ABC):
         master_dtype: torch.dtype,
     ) -> tuple[dict[str, torch.nn.Module], Any]:
         """Return ``({component: model}, scheduler)`` on CPU."""
+
+    def build_meta_models_and_scheduler(
+        self,
+        args,
+        *,
+        master_dtype: torch.dtype,
+    ) -> tuple[dict[str, torch.nn.Module], Any]:
+        """Architecture-only twin of ``load_models_and_scheduler`` for non-rank-0
+        FSDP ranks: same components with every parameter on the meta device and no
+        checkpoint weight IO. Rank 0 loads real weights and broadcasts into the
+        sharded model (``actor._fsdp2_load_full_state_dict``), so state-dict keys
+        and param dtypes must match rank 0 exactly.
+
+        Default falls back to a full load (the pre-meta-init behavior) so custom
+        backends keep working; override for the memory/IO win.
+        """
+        logger.warning(
+            "%s does not implement build_meta_models_and_scheduler; "
+            "falling back to loading full weights on every rank",
+            type(self).__name__,
+        )
+        return self.load_models_and_scheduler(args, master_dtype=master_dtype)
 
     def enable_gradient_checkpointing(self, model: torch.nn.Module) -> None:
         """Turn on grad checkpointing; default = the diffusers protocol method."""
@@ -74,4 +99,42 @@ class DiffusersModelBackend(ModelBackend):
             raw_models[component] = sub_model
         scheduler = pipeline.scheduler
         del pipeline
+        return raw_models, scheduler
+
+    def build_meta_models_and_scheduler(
+        self,
+        args,
+        *,
+        master_dtype: torch.dtype,
+    ) -> tuple[dict[str, torch.nn.Module], Any]:
+        # diffusers' from_pretrained materializes real weights even inside an outer
+        # accelerate.init_empty_weights (loading happens after __init__ via direct
+        # tensor assignment), so build skeletons from component configs instead.
+        import diffusers
+        from accelerate import init_empty_weights
+
+        pipeline_config = DiffusionPipeline.load_config(args.hf_checkpoint)
+
+        raw_models: dict[str, torch.nn.Module] = {}
+        for component in args.update_weight_target_modules:
+            entry = pipeline_config.get(component)
+            if entry is None:
+                raise ValueError(
+                    f"--update-weight-target-module: pipeline {args.hf_checkpoint} " f"has no component '{component}'"
+                )
+            _, class_name = entry
+            cls = getattr(diffusers, class_name, None)
+            if cls is None:
+                raise ValueError(
+                    f"component '{component}' class '{class_name}' is not a diffusers-native class; "
+                    "override build_meta_models_and_scheduler in a custom ModelBackend"
+                )
+            sub_config = cls.load_config(args.hf_checkpoint, subfolder=component)
+            with init_empty_weights():
+                model = cls.from_config(sub_config)
+            model.to(master_dtype)
+            raw_models[component] = model
+
+        _, scheduler_class = pipeline_config["scheduler"]
+        scheduler = getattr(diffusers, scheduler_class).from_pretrained(args.hf_checkpoint, subfolder="scheduler")
         return raw_models, scheduler

--- a/miles/backends/fsdp_utils/model_backend.py
+++ b/miles/backends/fsdp_utils/model_backend.py
@@ -65,7 +65,33 @@ class ModelBackend(abc.ABC):
 
 
 class DiffusersModelBackend(ModelBackend):
-    """Load trainable components from a diffusers pipeline checkpoint."""
+    """Load exactly the ``--update-weight-target-module`` components (plus the
+    scheduler) straight from the checkpoint; no pipeline-level loading."""
+
+    @staticmethod
+    def _component_class(pipeline_config, component: str, hf_checkpoint: str):
+        import diffusers
+
+        entry = pipeline_config.get(component)
+        if entry is None:
+            raise ValueError(
+                f"--update-weight-target-module: pipeline {hf_checkpoint} " f"has no component '{component}'"
+            )
+        _, class_name = entry
+        cls = getattr(diffusers, class_name, None)
+        if cls is None:
+            raise ValueError(
+                f"component '{component}' class '{class_name}' is not diffusers-native; "
+                "override the loader in a custom ModelBackend"
+            )
+        return cls
+
+    @staticmethod
+    def _load_scheduler(args, pipeline_config):
+        import diffusers
+
+        _, scheduler_class = pipeline_config["scheduler"]
+        return getattr(diffusers, scheduler_class).from_pretrained(args.hf_checkpoint, subfolder="scheduler")
 
     def load_models_and_scheduler(
         self,
@@ -73,25 +99,14 @@ class DiffusersModelBackend(ModelBackend):
         *,
         master_dtype: torch.dtype,
     ) -> tuple[dict[str, torch.nn.Module], Any]:
-        pipeline = DiffusionPipeline.from_pretrained(
-            args.hf_checkpoint,
-            torch_dtype=master_dtype,
-            trust_remote_code=True,
-            text_encoder=None,
-            vae=None,
-            tokenizer=None,
-        )
+        pipeline_config = DiffusionPipeline.load_config(args.hf_checkpoint)
         raw_models: dict[str, torch.nn.Module] = {}
         for component in args.update_weight_target_modules:
-            sub_model = getattr(pipeline, component, None)
-            if sub_model is None:
-                raise ValueError(
-                    f"--update-weight-target-module: pipeline {args.hf_checkpoint} " f"has no component '{component}'"
-                )
-            raw_models[component] = sub_model
-        scheduler = pipeline.scheduler
-        del pipeline
-        return raw_models, scheduler
+            cls = self._component_class(pipeline_config, component, args.hf_checkpoint)
+            raw_models[component] = cls.from_pretrained(
+                args.hf_checkpoint, subfolder=component, torch_dtype=master_dtype
+            )
+        return raw_models, self._load_scheduler(args, pipeline_config)
 
     def build_meta_models_and_scheduler(
         self,
@@ -100,31 +115,14 @@ class DiffusersModelBackend(ModelBackend):
         master_dtype: torch.dtype,
     ) -> tuple[dict[str, torch.nn.Module], Any]:
         # from_pretrained ignores an outer init_empty_weights, so build from configs.
-        import diffusers
         from accelerate import init_empty_weights
 
         pipeline_config = DiffusionPipeline.load_config(args.hf_checkpoint)
-
         raw_models: dict[str, torch.nn.Module] = {}
         for component in args.update_weight_target_modules:
-            entry = pipeline_config.get(component)
-            if entry is None:
-                raise ValueError(
-                    f"--update-weight-target-module: pipeline {args.hf_checkpoint} " f"has no component '{component}'"
-                )
-            _, class_name = entry
-            cls = getattr(diffusers, class_name, None)
-            if cls is None:
-                raise ValueError(
-                    f"component '{component}' class '{class_name}' is not diffusers-native; "
-                    "override build_meta_models_and_scheduler in a custom ModelBackend"
-                )
-            sub_config = cls.load_config(args.hf_checkpoint, subfolder=component)
+            cls = self._component_class(pipeline_config, component, args.hf_checkpoint)
             with init_empty_weights():
-                model = cls.from_config(sub_config)
+                model = cls.from_config(cls.load_config(args.hf_checkpoint, subfolder=component))
             model.to(master_dtype)
             raw_models[component] = model
-
-        _, scheduler_class = pipeline_config["scheduler"]
-        scheduler = getattr(diffusers, scheduler_class).from_pretrained(args.hf_checkpoint, subfolder="scheduler")
-        return raw_models, scheduler
+        return raw_models, self._load_scheduler(args, pipeline_config)

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -131,6 +131,13 @@ def allocate_train_group(args, num_nodes, num_gpus_per_node, pg):
 
 def create_training_models(args, pgs, rollout_manager):
     logger.info("Initializing actor model...")
+    if args.colocate and not args.debug_train_only:
+        # Colocated engines grab their full GPU memory pool during init and only
+        # release it at the end; actor GPU materialization must not overlap that
+        # window. RolloutManager.__init__ blocks on engine init, so one ordered
+        # call is a sufficient barrier.
+        logger.info("Waiting for rollout engines to finish init (colocate)...")
+        ray.get(rollout_manager.wait_ready.remote())
     actor_model = allocate_train_group(
         args=args,
         num_nodes=args.actor_num_nodes,

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -132,10 +132,8 @@ def allocate_train_group(args, num_nodes, num_gpus_per_node, pg):
 def create_training_models(args, pgs, rollout_manager):
     logger.info("Initializing actor model...")
     if args.colocate and not args.debug_train_only:
-        # Colocated engines grab their full GPU memory pool during init and only
-        # release it at the end; actor GPU materialization must not overlap that
-        # window. RolloutManager.__init__ blocks on engine init, so one ordered
-        # call is a sufficient barrier.
+        # Colocated engines hold their full GPU pool until init ends; wait so
+        # actor GPU materialization never overlaps that window.
         logger.info("Waiting for rollout engines to finish init (colocate)...")
         ray.get(rollout_manager.wait_ready.remote())
     actor_model = allocate_train_group(

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -208,9 +208,7 @@ class RolloutManager:
         self.data_source.load(rollout_id)
 
     def wait_ready(self):
-        """Barrier for callers: a ray actor serves calls in order, so this returns
-        only after __init__ — including engine init and the colocate initial
-        memory release — has completed."""
+        """Barrier: actor calls are served in order, so this returns after __init__."""
         return True
 
     def offload(self):

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -207,6 +207,12 @@ class RolloutManager:
     def load(self, rollout_id=None):
         self.data_source.load(rollout_id)
 
+    def wait_ready(self):
+        """Barrier for callers: a ray actor serves calls in order, so this returns
+        only after __init__ — including engine init and the colocate initial
+        memory release — has completed."""
+        return True
+
     def offload(self):
         self.health_monitoring_pause()
         return ray.get(


### PR DESCRIPTION
## What

Port the miles LLM backend's FSDP2 init pattern (rank-0 load + broadcast, from `miles/backends/experimental/fsdp_utils/actor.py`, itself from verl) to the diffusion FSDP actor:

- **Rank 0** loads real weights on CPU via the existing `ModelBackend.load_models_and_scheduler`.
- **Every other rank** builds an architecture-only skeleton on the meta device via the new `ModelBackend.build_meta_models_and_scheduler` — zero checkpoint IO, zero weight RAM.
- After `apply_fsdp2`, the new `_fsdp2_load_full_state_dict` (same name/shape as miles LLM) broadcasts rank 0's full state dict directly into each rank's DTensor shards (`set_model_state_dict(..., broadcast_from_rank0=True)` + manual buffer broadcast). No rank ever materializes the whole model on GPU.

Also fixes a colocate startup race this exposed: rollout engines grab their full GPU pool during init and release it at the end, but nothing ordered train-actor GPU materialization after that window (`RolloutManager.__init__` runs async in its own actor). The old flow dodged it by accident — 4 ranks × full checkpoint read kept actors off the GPU for minutes. Now `create_training_models` blocks on `rollout_manager.wait_ready()` in colocate mode.

## Why (measured, qwen-image 4GPU OCR script on 4×H100-80GB)

| | main (before) | this PR (after) |
|---|---|---|
| Ranks reading the checkpoint | 4 | 1 |
| Peak host RSS during init | ~80 GB × 4 ranks = 320 GB | 81 GB (rank 0) + ~1.4 GB × 3 |
| Peak GPU during train init | 81,001 MiB (all GPUs pegged) | 28,415 MiB |
| Outcome | **OOM at `model.to(cuda)` (actor.py:128), job dead** | init clean, rollout + training proceed |

With `--fsdp-master-dtype fp32`, Qwen-Image (20B) is ~76 GiB unsharded — the old flow's per-rank `model.to(cuda)` cannot fit on an 80 GB H100 alongside the sleeping engine's ~5 GB residue, so `scripts/run-diffusion-grpo-ocr-4gpu-flowgrpo-aligned.sh` OOMs at init on this hardware. (BEFORE traceback: `torch.OutOfMemoryError` at `actor.py:128`, GPU 0 with 73.76 GiB in the train actor + 5.32 GiB sglang.)

## Deviation from miles LLM (and why)

diffusers' `from_pretrained` materializes real weights even inside an outer `accelerate.init_empty_weights` — loading happens after `__init__` via direct tensor assignment, unlike transformers. Verified empirically (`all_meta: False`). So non-rank-0 skeletons are built from component configs (`cls.from_config` under `init_empty_weights`) instead of wrapping the loader in an init context. Custom `ModelBackend`s that don't implement the new hook fall back to full-load with a warning.

`preprocess_model_before_fsdp` now runs after weight materialization: its only non-trivial implementation (qwen_image RoPE cache rebuild) requires CUDA-resident params and would silently no-op on meta ranks (breaking train/rollout bit-parity).

Side effect worth noting: LoRA adapter init is now rank-0-authoritative via the broadcast, instead of relying on identical per-rank RNG draws.

## Verification

1. **4-rank parity preflight** (tiny SD pipeline, real repo code paths): old-flow shards vs new-flow shards **bitwise equal** for all params and buffers, with and without LoRA; forward output bitwise equal. PASS.
2. **E2E**: `run-diffusion-grpo-ocr-4gpu-flowgrpo-aligned.sh` (Qwen-Image 20B, fp32 master, LoRA r64, colocate):
   - main: 4× full load → GPU OOM at init (100% reproducible on 4×H100-80GB)
   - this branch: rank-0-only load (log: `[Rank 0] loading full weights on CPU` + 3× `building meta skeleton, no checkpoint weight IO`), init GPU peak 28 GiB, rollout generates (68× 200 OK), and training runs:
     ```
     [train step 1] train/loss=3.69e-07 train/grad_norm=6.69e-04 train/approx_kl=1.24e-09 train/log_prob_mean_abs_diff=3.95e-05
     [train step 2] train/loss finite   train/grad_norm=4.79e-04 train/approx_kl=2.98e-09 train/log_prob_mean_abs_diff=5.36e-05
     ```
     `log_prob_mean_abs_diff` ≈ 4–5e-05 (bf16 level) means the broadcast weights agree with what the engines received via `update_weights` — end-to-end weight-correctness signal.
3. `tests/fast/backends/fsdp_utils/` — 18 passed.

## Environment note (orthogonal to this PR)

On the cu130 experimental image (`rockdu/miles_diffusion:dev-cu130-sglang-v0.5.14-20260630`), the sglang-d engine allocates a fixed ~70.8 GiB during generation and VAE-decode transients (~1.5 GiB at `--diffusion-microgroup-size 16`) then don't fit next to the sleeping train actor's ~1.9 GiB residue. The E2E run above used `--diffusion-microgroup-size 8` (halves the decode transient; resolution and optimizer math unchanged). main can't even reach rollout on this hardware, so this tightness is pre-existing engine sizing, not introduced here — but it's why the barrier fix alone didn't make the stock script pass end-to-end on this image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
