### PR TITLE
ci: enable GPU stages on self-hosted 8×H200 runner fleet

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -2,16 +2,17 @@ name: CI Job
 
 # Reusable workflow ported from radixark/miles (.github/workflows/_run-ci.yml).
 #
-# CPU-only path: GitHub-hosted ubuntu-latest. Trimmed from miles main:
-#   * GPU `run:` job removed entirely — miles-D has no self-hosted GPU
-#     runners. To re-add: copy the `run:` job block back from miles main,
-#     reintroduce `runs_on / container_image / skip_dependency_install /
-#     cpu_runner` inputs, and add a matching `if: !inputs.cpu_runner` gate.
+# Differences vs miles main:
 #   * Megatron-LM checkout/install removed: miles-D source has zero
 #     `from megatron` imports (verified via grep).
 #   * PR-body magic for `ci-megatron-pr:` removed for the same reason.
 #   * sglang checkout/install preserved (miles-D imports
-#     sglang.multimodal_gen.runtime.* and sglang.srt.*).
+#     sglang.multimodal_gen.runtime.* and sglang.srt.*), fetched from the
+#     Rockdu/sglang fork (`ci-sglang-repo:` PR-body override) until the
+#     diffusion RPCs land on sgl main.
+#   * GPU `run:` job uses the radixark/miles-diffusion image (not
+#     radixark/miles) and the h200 runner fleet on the dedicated CI node
+#     (labels: h200 + 2gpu/4gpu).
 
 on:
   workflow_call:
@@ -19,10 +20,157 @@ on:
       execute_command:
         type: string
         required: true
+      runs_on:
+        type: string
+        required: false
+        description: 'JSON-encoded list of runner labels (all required). e.g. ''["h200", "2gpu"]'' picks runners that carry BOTH labels. No default: GPU jobs (cpu_runner: false) must pass this explicitly.'
+      container_image:
+        type: string
+        required: false
+        default: 'rockdu/miles_diffusion:latest'
+      skip_dependency_install:
+        type: boolean
+        required: false
+        default: false
+      cpu_runner:
+        type: boolean
+        required: false
+        default: false
+        description: 'Run on GitHub-hosted ubuntu-latest with bare pip install (for CPU-only fast tests)'
 
-# TODO: run gpu
 jobs:
+  run:
+    if: ${{ !inputs.cpu_runner }}
+    # fromJSON parses the input list so `runs-on` receives an actual array.
+    # Without this, GitHub treats the string verbatim as one label literal
+    # (e.g. the label name '["h200", "2gpu"]' with brackets), which no
+    # runner carries, and the job queues forever.
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    container:
+      image: ${{ inputs.container_image }}
+      options: >
+        --gpus all
+        --env CUDA_VISIBLE_DEVICES
+        --ipc=host
+        --shm-size=32g
+        --ulimit memlock=-1
+        --ulimit stack=67108864
+        --memory=0
+        --memory-swap=0
+        -v /data/miles_ci:/data/miles_ci
+        -v /data/miles_ci/models:/root/models
+        -v /data/miles_ci/datasets:/root/datasets
+        -v /data/miles_ci/hf_cache:/root/.cache/huggingface
+        -v /data/miles_ci/paddleocr:/github/home/.paddleocr
+        --privileged
+        --ulimit nofile=65535:65535
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      GITHUB_COMMIT_NAME: ${{ github.sha }}_${{ github.event.pull_request.number || 'non-pr' }}
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cleanup Ray processes
+        shell: bash
+        run: |
+          pkill -9 -f 'ray::' 2>/dev/null || true
+          pkill -9 -f raylet 2>/dev/null || true
+          pkill -9 -f gcs_server 2>/dev/null || true
+          pkill -9 -f 'ray-dashboard' 2>/dev/null || true
+          pkill -9 sglang 2>/dev/null || true
+          ray stop --force 2>/dev/null || true
+          sleep 3
+
+      - name: Wait for GPU ready
+        shell: bash
+        run: |
+          # When a self-hosted runner accepts a new job seconds after the
+          # previous job's container exits, the NVIDIA driver subsystem may
+          # still be tearing down its prior CUDA context. The next process
+          # to call cudaGetDeviceCount() then hits Error 802 ("system not
+          # yet initialized"). Block here until nvidia-smi succeeds, with
+          # a bounded retry budget so a genuinely-broken GPU fails fast.
+          for i in $(seq 1 60); do
+            if nvidia-smi -L >/dev/null 2>&1; then
+              echo "GPU ready after $((i-1)) retry(s)"
+              nvidia-smi --query-gpu=index,name,memory.used --format=csv,noheader
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: nvidia-smi did not become ready after 120s" >&2
+          nvidia-smi 2>&1 | tail -20 || true
+          exit 1
+
+      - name: Resolve dependency refs
+        if: ${{ !inputs.skip_dependency_install }}
+        id: resolve-refs
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          INPUT_SGLANG_PR: ${{ github.event.inputs.ci_sglang_pr || '' }}
+          INPUT_SGLANG_REPO: ${{ github.event.inputs.ci_sglang_repo || '' }}
+        run: |
+          SGLANG_PR="${INPUT_SGLANG_PR}"
+          SGLANG_REPO="${INPUT_SGLANG_REPO}"
+          if [ -n "$PR_BODY" ]; then
+            PR_SGLANG_PR=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-pr:\s+\K\S+' || true)
+            [ -z "$SGLANG_PR" ] && [ -n "$PR_SGLANG_PR" ] && SGLANG_PR="$PR_SGLANG_PR"
+            PR_SGLANG_REPO=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-repo:\s+\K\S+' || true)
+            [ -z "$SGLANG_REPO" ] && [ -n "$PR_SGLANG_REPO" ] && SGLANG_REPO="$PR_SGLANG_REPO"
+          fi
+          [ -z "$SGLANG_PR" ] && SGLANG_PR="sglang-diffusion-rollout-test"
+          # TODO: default repo Rockdu/sglang to be switched back to sgl-project/sglang
+          [ -z "$SGLANG_REPO" ] && SGLANG_REPO="Rockdu/sglang"
+          resolve_fetch_ref() {
+            local ref="$1"
+            if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
+              echo "refs/pull/${BASH_REMATCH[1]}/head"
+            else
+              echo "$ref"
+            fi
+          }
+          SGLANG_FETCH=$(resolve_fetch_ref "$SGLANG_PR")
+          echo "ci_sglang_pr=$SGLANG_FETCH" >> $GITHUB_OUTPUT
+          echo "sglang_repo=$SGLANG_REPO" >> $GITHUB_OUTPUT
+          echo "Resolved: sglang repo=$SGLANG_REPO ref=$SGLANG_PR -> fetch=$SGLANG_FETCH"
+
+      - name: Install dependencies
+        if: ${{ !inputs.skip_dependency_install }}
+        shell: bash
+        env:
+          SGLANG_PR: ${{ steps.resolve-refs.outputs.ci_sglang_pr }}
+          SGLANG_REPO: ${{ steps.resolve-refs.outputs.sglang_repo }}
+        run: |
+          # The image ships sglang editable at /sgl-workspace/sglang, already
+          # on the Rockdu fork's pinned commit. Fetch by explicit URL so
+          # `ci-sglang-repo:` overrides work regardless of the checkout's
+          # configured remote.
+          cd /sgl-workspace/sglang && git reset --hard HEAD && git clean -fd && git fetch "https://github.com/${SGLANG_REPO}.git" "$SGLANG_PR" && git checkout -f FETCH_HEAD && git log --oneline -1 && pip install -e python --no-deps --break-system-packages
+          cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
+
+      - name: Install (miles-diffusion only)
+        if: ${{ inputs.skip_dependency_install }}
+        shell: bash
+        run: |
+          cd $GITHUB_WORKSPACE && pip install -e . --no-deps --break-system-packages
+
+      - name: Resolve suite plan
+        shell: bash
+        run: ${{ inputs.execute_command }} --list-only
+
+      - name: Run tests
+        shell: bash
+        run: ${{ inputs.execute_command }}
+
+  # CPU-only path: GitHub-hosted ubuntu-latest, bare pip install.
   run-cpu:
+    if: ${{ inputs.cpu_runner }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,14 +3,15 @@ name: PR Test
 # Ported from radixark/miles (.github/workflows/pr-test.yml).
 #
 # Differences vs miles main:
-#   * All GPU stages (stage-b-2-gpu-h200, stage-c-8-gpu-h100,
-#     stage-c-4-gpu-h200, stage-c-2-gpu-h200) removed — miles-D has no
-#     self-hosted GPU runner fleet yet. To re-enable, copy the job blocks
-#     back from miles main and provision matching runners.
-#   * `resolve-ci-image` job removed — only relevant for GPU stages that
-#     pull a `radixark/miles:<tag>` container.
+#   * GPU stages run on the dedicated miles-D CI node (8×H200,
+#     node-radixark-32-0000) split into (h200,3gpu) + (h200,5gpu) runners —
+#     currently only stage-b-2-gpu-h200 exists (no stage-c-8-gpu-h100).
+#   * `resolve-ci-image` resolves a `rockdu/miles_diffusion:<tag>`
+#     container (default `latest`), overridable via the `ci-image-tag:`
+#     PR-body line or the `ci_image_tag` dispatch input.
 #   * `ci_megatron_pr` workflow_dispatch input removed — miles-D source has
 #     zero `from megatron` imports.
+#   * No `schedule` trigger yet (miles main runs a nightly full CI).
 
 on:
   pull_request:
@@ -27,6 +28,11 @@ on:
         required: false
         type: string
         default: 'Rockdu/sglang'
+      ci_image_tag:
+        description: 'miles-diffusion Docker image tag (default: latest)'
+        required: false
+        type: string
+        default: 'latest'
 
 permissions:
   contents: read
@@ -44,11 +50,38 @@ concurrency:
 # every enabled test in the suite.
 
 jobs:
+  resolve-ci-image:
+    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    runs-on: ubuntu-latest
+    outputs:
+      container_image: ${{ steps.resolve.outputs.container_image }}
+    steps:
+      - name: Resolve CI image
+        id: resolve
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          INPUT_CI_IMAGE_TAG: ${{ github.event.inputs.ci_image_tag || '' }}
+        run: |
+          CI_IMAGE_TAG="${INPUT_CI_IMAGE_TAG}"
+          if [ -n "$PR_BODY" ]; then
+            PR_CI_IMAGE_TAG=$(echo "$PR_BODY" | grep -m1 -oP '^ci-image-tag:\s+\K\S+' || true)
+            [ -z "$CI_IMAGE_TAG" ] && [ -n "$PR_CI_IMAGE_TAG" ] && CI_IMAGE_TAG="$PR_CI_IMAGE_TAG"
+          fi
+          [ -z "$CI_IMAGE_TAG" ] && CI_IMAGE_TAG="latest"
+          if [[ ! "$CI_IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::ci-image-tag must be a Docker tag, not a full image name: $CI_IMAGE_TAG"
+            exit 1
+          fi
+          echo "container_image=rockdu/miles_diffusion:${CI_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved CI image: rockdu/miles_diffusion:${CI_IMAGE_TAG}"
+
   # Stage A: CPU-only fast tests (always runs on PR)
   stage-a-cpu:
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
+      cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
@@ -62,8 +95,30 @@ jobs:
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
+      cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-b-cpu
+        --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+    secrets: inherit
+
+  # Stage B GPU: fast 2-GPU bucket, gates nothing yet but runs on every PR
+  # once stage-a-cpu is green (fast-fail: broken imports shouldn't burn GPU
+  # runner slots).
+  stage-b-2-gpu-h200:
+    needs: [resolve-ci-image, stage-a-cpu]
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-image.result == 'success' &&
+      needs.stage-a-cpu.result == 'success' &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+    uses: ./.github/workflows/_run-ci.yml
+    with:
+      # 2-gpu suite runs on the 3gpu runner: the node is split 3(GPU0-2)+5(GPU3-7).
+      runs_on: '["h200", "3gpu"]'
+      container_image: ${{ needs.resolve-ci-image.outputs.container_image }}
+      execute_command: >-
+        python tests/ci/run_suite.py --hw cuda --suite stage-b-2-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
     secrets: inherit

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -22,15 +22,17 @@ _RUN_CI_PREFIX = "run-ci-"
 # Per-commit test suites (run on every PR; per-domain selection is done at
 # runtime by `filter_tests` via the `--labels` arg, not via per-suite jobs).
 #
-# CUDA suites: empty for now — miles-D does not yet have self-hosted GPU
-# runners. Add stage-c-* entries here when the GPU fleet is provisioned and
-# matching jobs are added to .github/workflows/pr-test.yml.
+# CUDA suites: each is served by a matching workflow job in
+# .github/workflows/pr-test.yml. The H200 fleet is one 8-GPU node split into
+# 3+5 workers via per-runner CUDA_VISIBLE_DEVICES (see pr-test.yml job comments).
 PER_COMMIT_SUITES = {
     HWBackend.CPU: [
         "stage-a-cpu",
         "stage-b-cpu",
     ],
-    HWBackend.CUDA: [],
+    HWBackend.CUDA: [
+        "stage-b-2-gpu-h200",
+    ],
 }
 
 # Nightly test suites (placeholder for future use)
@@ -189,8 +191,13 @@ def run_a_suite(args):
     auto_partition_id = args.auto_partition_id
     auto_partition_size = args.auto_partition_size
 
-    # Discover test files: e2e/ for CUDA, fast/ for CPU
-    e2e_files = [f for f in glob.glob("tests/e2e/**/*.py", recursive=True) if _is_e2e_discovery_file(f)]
+    # Discover test files: e2e/ + fast-gpu/ for CUDA, fast/ for CPU
+    e2e_files = [
+        f
+        for pat in ("tests/e2e/**/*.py", "tests/fast-gpu/**/*.py")
+        for f in glob.glob(pat, recursive=True)
+        if _is_e2e_discovery_file(f)
+    ]
     fast_files = [
         f
         for f in glob.glob("tests/fast/**/*.py", recursive=True)

--- a/tests/fast-gpu/test_lora_weight_sync.py
+++ b/tests/fast-gpu/test_lora_weight_sync.py
@@ -1,0 +1,76 @@
+from tests.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=120,
+    suite="stage-b-2-gpu-h200",
+    labels=[],
+)
+
+from argparse import Namespace
+
+import pytest
+import torch
+from peft import LoraConfig, get_peft_model
+
+from miles.backends.fsdp_utils.diffusion_update_weight_utils import DiffusionUpdateWeightFromTensorLoRA
+
+
+class _TinyBlock(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(16, 16, bias=False)
+        self.norm = torch.nn.LayerNorm(16)
+
+
+class _CaptureUpdater(DiffusionUpdateWeightFromTensorLoRA):
+    """Capture flushed buckets instead of pushing to rollout engines."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.buckets: list[list[tuple[str, torch.Tensor]]] = []
+
+    def wait_and_update_bucket_weights(self, bucket, target_module):
+        self.buckets.append([(name, tensor.clone()) for name, tensor in bucket])
+
+
+def _make_peft_model():
+    torch.manual_seed(0)
+    peft_model = get_peft_model(_TinyBlock().cuda(), LoraConfig(r=4, lora_alpha=8, target_modules=["proj"]))
+    # peft zero-inits lora_B; randomize it so the merge delta is nonzero.
+    for module in peft_model.modules():
+        if hasattr(module, "lora_B"):
+            for adapter in module.lora_B:
+                torch.nn.init.normal_(module.lora_B[adapter].weight)
+    return peft_model
+
+
+def _run_update(peft_model, buffer_size):
+    updater = _CaptureUpdater(Namespace(update_weight_buffer_size=buffer_size), {"transformer": peft_model})
+    updater.update_weights()
+    return updater.buckets
+
+
+def test_lora_merge_and_name_mapping():
+    peft_model = _make_peft_model()
+    synced = {name: tensor for bucket in _run_update(peft_model, 1 << 30) for name, tensor in bucket}
+
+    # PEFT wrappers stripped, lora_* params excluded — names match sglang-d's DiT.
+    assert set(synced) == {"proj.weight", "norm.weight", "norm.bias"}
+
+    lora_layer = peft_model.base_model.model.proj
+    A, B = lora_layer.lora_A["default"].weight, lora_layer.lora_B["default"].weight
+    expected = lora_layer.base_layer.weight + lora_layer.scaling["default"] * (B @ A)
+    torch.testing.assert_close(synced["proj.weight"], expected)
+    torch.testing.assert_close(synced["norm.weight"], peft_model.base_model.model.norm.weight)
+
+
+def test_bucket_flush_respects_buffer_size():
+    buckets = _run_update(_make_peft_model(), buffer_size=1)
+    assert all(len(bucket) == 1 for bucket in buckets)
+    assert sum(len(bucket) for bucket in buckets) == 3
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/fast-gpu/test_qwen_image_pos_embed_freqs.py
+++ b/tests/fast-gpu/test_qwen_image_pos_embed_freqs.py
@@ -1,0 +1,54 @@
+from tests.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=60,
+    suite="stage-b-2-gpu-h200",
+    labels=[],
+)
+
+import torch
+from diffusers.models.transformers.transformer_qwenimage import QwenEmbedRope as DiffusersQwenEmbedRope
+from sglang.multimodal_gen.runtime.models.dits.qwen_image import QwenEmbedRope as SglQwenEmbedRope
+
+from miles.backends.fsdp_utils.configs.qwen_image import _rebuild_pos_embed_freqs_on_cuda
+
+# Qwen-Image production config (sgl-d qwen_image.py instantiation).
+THETA, AXES_DIM = 10000, [16, 56, 56]
+
+
+class _Holder(torch.nn.Module):
+    """Minimal stand-in for the train-side transformer: one CUDA param + the rope."""
+
+    def __init__(self, rope):
+        super().__init__()
+        self.rope = rope
+        self.anchor = torch.nn.Parameter(torch.zeros(1, device="cuda"))
+
+
+def test_rebuilt_freqs_match_sglang_d_bitwise():
+    # Rollout side: sgl-d meta-inits, then its forward rebuilds the freqs on CUDA.
+    with torch.device("meta"):
+        sgl_rope = SglQwenEmbedRope(theta=THETA, axes_dim=AXES_DIM, scale_rope=True)
+    sgl_rope.forward((1, 8, 8), [32], torch.device("cuda"))
+    assert sgl_rope.pos_freqs.device.type == "cuda"
+
+    # Train side: diffusers builds the freqs on CPU at init (ULP-off vs CUDA);
+    # _rebuild_pos_embed_freqs_on_cuda must restore bitwise equality.
+    holder = _Holder(DiffusersQwenEmbedRope(theta=THETA, axes_dim=AXES_DIM, scale_rope=True))
+    cpu_built = holder.rope.pos_freqs.clone()
+    _rebuild_pos_embed_freqs_on_cuda(holder)
+
+    assert holder.rope.pos_freqs.device.type == "cuda"
+    assert torch.equal(holder.rope.pos_freqs, sgl_rope.pos_freqs)
+    assert torch.equal(holder.rope.neg_freqs, sgl_rope.neg_freqs)
+    # Premise of the fix: CPU-built freqs differ from CUDA-built by fp32 ULPs.
+    # If this ever fails, the rebuild (and this test) can be retired.
+    assert not torch.equal(cpu_built.cuda(), sgl_rope.pos_freqs)
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Step 1 of the CI plan (GPU fast tests; **e2e ships later as an independent system** with its own suites + metrics registry). One squashed commit porting the GPU CI path from [miles main tests/ci @ 01a6d7bb](https://github.com/radixark/miles/tree/01a6d7bb74befa6e97579c80a2b1add0667606f3/tests/ci), minus Megatron / ROCm / nightly:

- **`_run-ci.yml`** — the GPU `run:` job (same structure as miles main): self-hosted runner → container (`--gpus all`, `/data/miles_ci` cache mounts) → checkout → cleanup stale ray → wait GPU → install sglang fork (`ci-sglang-pr:` / `ci-sglang-repo:` PR-body overrides) + miles-D → run suite. `run-cpu` gated behind `cpu_runner: true`.
- **`pr-test.yml`** — `resolve-ci-image` (`rockdu/miles_diffusion:<tag>`, `ci-image-tag:` override) + `stage-b-2-gpu-h200`, gated on `stage-a-cpu`.
- **`run_suite.py`** — register the `stage-b-2-gpu-h200` CUDA suite; CUDA discovery covers `tests/fast-gpu/` (upstream layout).
- **`tests/fast-gpu/`** — two fast GPU tests (3 cases, each <1 s, verified in the CI image on the CI node):
  | test | covers |
  |---|---|
  | `test_lora_weight_sync.py` | LoRA merge math (`W + s·B@A`), PEFT→sglang-d name mapping, weight-buffer bucketing |
  | `test_qwen_image_pos_embed_freqs.py` | train-side (diffusers + `_rebuild_pos_embed_freqs_on_cuda`) RoPE freq caches must match sglang-d's meta→CUDA rebuild **bitwise** — kills the CPU-vs-CUDA ULP drift that cost ~2e-2 on noise_pred |

## Runner fleet (provisioned, online)
node-radixark-32-0000 (8×H200), two disjoint runners:
| runner | labels | CUDA_VISIBLE_DEVICES |
|---|---|---|
| ci-h200-3gpu-0 | h200, 3gpu | 0,1,2 |
| ci-h200-5gpu-0 | h200, 5gpu | 3,4,5,6,7 |

Pre-staged under `/data/miles_ci` (host-mounted into job containers): Qwen-Image (54G), flowgrpo_ocr dataset, PaddleOCR models.

## Follow-ups
- e2e as an independent system: own stage-c-* suites + per-step metrics registry (separate PR).
- Move the image to the radixark Docker Hub org once org push creds exist (one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
