### PR TITLE
scripts: name pickscore runs by total GPU count (train + reward)

### DIFF
--- a/scripts/run-diffusion-grpo-pickscore-3gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-3gpu-flowgrpo-aligned.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-4,5,1}"
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-RUN_NAME="diffusion_grpo_pickscore_2gpu_flowgrpo_aligned_$(date +%Y%m%d_%H%M%S)"
+RUN_NAME="diffusion_grpo_pickscore_3gpu_flowgrpo_aligned_$(date +%Y%m%d_%H%M%S)"
 SAVE_DIR="${ROOT_DIR}/logs/${RUN_NAME}/ckpt"
 
 WANDB_ARGS=()

--- a/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-4,5,6,7,1}"
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-RUN_NAME="diffusion_grpo_pickscore_4gpu_flowgrpo_aligned_$(date +%Y%m%d_%H%M%S)"
+RUN_NAME="diffusion_grpo_pickscore_5gpu_flowgrpo_aligned_$(date +%Y%m%d_%H%M%S)"
 SAVE_DIR="${ROOT_DIR}/logs/${RUN_NAME}/ckpt"
 
 WANDB_ARGS=()


### PR DESCRIPTION
The pickscore reward worker holds a dedicated GPU, so the "4gpu"/"2gpu" runs actually occupy 5/3 GPUs. Renames the two scripts and their RUN_NAMEs to the total count (matching `wan22-pickscore-5gpu`). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)