### PR TITLE
ci: gate e2e tests behind the run-ci-e2e label

### DIFF
--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -24,4 +24,5 @@ KNOWN_LABELS: dict[str, str] = {
     "router": "Router routing decision tests",
     "arguments": "Top-level argparse / validate_args tests",
     "model-scripts": "train_diffusion.py + scripts/*.sh smoke tests",
+    "e2e": "End-to-end example-script metric regression tests",
 }

--- a/tests/e2e/short/test_qwen_image_ocr_grpo_4xGPU.py
+++ b/tests/e2e/short/test_qwen_image_ocr_grpo_4xGPU.py
@@ -9,6 +9,7 @@ from tests.ci.e2e_metrics_registry import register_e2e_ci
 register_e2e_ci(
     est_time=1500,
     suite="stage-c-5-gpu-h200",
+    labels=["e2e"],
     script="scripts/run-diffusion-grpo-ocr-4gpu-flowgrpo-aligned.sh",
     env={"NUM_ROLLOUT": "2", "DETERMINISTIC_MODE": "1"},
     metrics=[


### PR DESCRIPTION
## What
- Register the `e2e` domain label and attach it to the qwen-image OCR e2e test. Default (unlabeled) PRs now run only the CPU suites and stage-b fast-gpu; stage-c enumerates zero tests and exits green. Attach `run-ci-e2e` (or `run-ci-all`) to a PR to run the e2e suite.

## Why
- Mirrors miles main, where every e2e test carries a domain label and only `tests/fast-gpu/` is always-on — a plain PR should not spend ~25 min of 5gpu-runner time per push.
- `run-ci-e2e` / `run-ci-all` / `run-ci-image` GitHub labels are created (they were referenced by the workflow but never existed).

## Checklist
- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour — n/a, two-line label change; filtering itself is covered by `tests/ci/run_suite.py` machinery already in main
- [x] `pytest -x` is green (label enumeration verified via `run_suite.py --list-only` with and without `run-ci-e2e`)
- [x] Launch flags / CLI docs / example walkthrough — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
