### PR TITLE
Fix: sd3.5 2-GPU colocate for SD3 OCR sglang training

### DIFF
--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -99,8 +99,9 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --rollout-batch-size 8 \
   --n-samples-per-prompt 16 \
   --num-rollout "${NUM_ROLLOUT}" \
-  --micro-batch-size-sample 8 \
+  --micro-batch-size-sample 16 \
   --micro-batch-size-tstep 5 \
+  --diffusion-microgroup-size 8 \
   --gradient-checkpointing \
   --actor-num-gpus-per-node 2 \
   --rollout-num-gpus 2 \
@@ -108,7 +109,7 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --num-gpus-per-node 2 \
   --colocate \
   --use-miles-router \
-  --sglang-server-concurrency 4 \
+  --sglang-server-concurrency 8 \
   --use-lora \
   --lora-rank 32 \
   --lora-alpha 64 \

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -3,12 +3,11 @@
 #
 # Usage:
 #   CUDA_VISIBLE_DEVICES=2,3 WANDB_API_KEY=<key> \
-#     nohup bash scripts/run-diffusion-grpo-sd3-pickscore-sglang.sh \
+#     nohup bash scripts/run-diffusion-grpo-sd3-ocr-sglang.sh \
 #       > logs/sd3_ocr_sglang_$(date +%Y%m%d_%H%M%S).log 2>&1 &
 #
 # GPU layout (default, override with CUDA_VISIBLE_DEVICES):
-#   slot 0 (e.g. physical GPU 2) → FSDP actor
-#   slot 1 (e.g. physical GPU 3) → sglang-diffusion rollout engine
+#   2-GPU colocate: FSDP DP=2 + 2 sglang rollout engines (time-multiplexed per GPU).
 #
 # The script kills only processes whose cwd is inside this Miles workspace,
 # so co-located experiments on other GPUs are not disturbed.
@@ -103,11 +102,10 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --micro-batch-size-sample 8 \
   --micro-batch-size-tstep 5 \
   --gradient-checkpointing \
-  --actor-num-gpus-per-node 1 \
-  --rollout-num-gpus 1 \
+  --actor-num-gpus-per-node 2 \
+  --rollout-num-gpus 2 \
   --rollout-num-gpus-per-engine 1 \
   --num-gpus-per-node 2 \
-  --no-offload-rollout \
   --colocate \
   --use-miles-router \
   --sglang-server-concurrency 4 \
@@ -129,6 +127,9 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --sglang-dit-precision fp16 \
   --sglang-vae-slicing \
   --diffusion-num-steps 10 \
+  --diffusion-step-strategy-path miles.rollout.step_strategy_hub.sde_window \
+  --diffusion-sde-window-size 10 \
+  --diffusion-sde-window-range 0,10 \
   --diffusion-eval-num-steps 40 \
   --update-weight-buffer-size 2147483648 \
   --diffusion-guidance-scale 4.5 \


### PR DESCRIPTION

## Summary
 Fix 2-GPU colocate layout: FSDP DP=2 + 2 sglang rollout engines; remove `--no-offload-rollout`.
- Add SDE step strategy with full 10-step trajectory training (aligned with `feat/support_sd3`).
- Tune rollout throughput: `micro-batch-size-sample=16`, `diffusion-microgroup-size=8`, `sglang-server-concurrency=8`.
- Keep `global-batch-size=64` (128 rollout samples → 2 optimizer steps per rollout).
- 
## Benchmark (NUM_ROLLOUT=1, rollout 8×16=128, 2×H200)
All configs use the same model/data unless noted. Timings from `perf/step_time` on step 0.
| Config | Step | Rollout (`train_wait`) | Train (`actor_train`) | Notes |
|--------|------|------------------------|----------------------|-------|
| Baseline: 1 engine, actor/rollout split (`miles_diffusion`) | **288s** | 162s | 126s | 1 GPU bundle |
| 2-GPU colocate only | **187s** | 110s | 73s | micro 8/5, conc 4, full traj, gbs 64 |
| **This PR (final script)** | **135s** | 66s | 65s | micro 16/5, microgroup 8, conc 8, full traj, gbs 64 |
| Full traj + batch opt, gbs 128 | **121s** | 53s | 65s | 1 optim step/rollout |
| SDE window=2 (steps 3–4) + batch opt, gbs 128 | **59s** | 44s | 14s | faster train, not `feat/support_sd3` parity |
| SDE window=2, gbs 64 (earlier probe) | **102s** | 87s | 15s | micro 8/8, conc 4 |

**Takeaways**
- 2-GPU colocate alone: **288s → 187s** (~1.5×).
- Adding rollout batch tuning (this PR): **187s → 135s** (~1.4×); **288s → 135s overall (~2.1×)**.
- Main rollout lever: `diffusion-microgroup-size=8` + `sglang-server-concurrency=8` (rollout ~110s → ~66s at gbs 64).
- `gbs=64` vs `128` mainly changes optimizer steps per rollout (2 vs 1); train time similar (~65–73s) for full trajectory.
- SDE window=2 cuts train time sharply (~15s) but trains only 2/10 steps; kept full trajectory for parity with original SD3 OCR work.
