### PR TITLE
feat: LoRA IPC weight sync for colocated diffusion GRPO

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -28,7 +28,11 @@ from miles.utils.train_data_utils import (
 )
 from . import checkpoint
 from .arguments import deterministic_capable_flash_fns
-from .diffusion_update_weight_utils import DiffusionUpdateWeightFromTensor, DiffusionUpdateWeightFromTensorLoRA
+from .diffusion_update_weight_utils import (
+    DiffusionUpdateWeightFromTensor,
+    DiffusionUpdateWeightFromTensorLoRA,
+    DiffusionUpdateWeightFromTensorLoRAIPC,
+)
 from .lr_scheduler import get_lr_scheduler
 from .parallel import create_fsdp_parallel_state
 
@@ -185,6 +189,8 @@ class FSDPTrainRayActor(TrainRayActor):
         # sglang-d now supports /update_weights_from_tensor (PR #20464).
         if self.args.debug_train_only:
             self.weight_updater = None
+        elif self.args.use_lora and self.args.lora_ipc_weight_sync:
+            self.weight_updater = DiffusionUpdateWeightFromTensorLoRAIPC(self.args, self.models)
         elif self.args.use_lora:
             self.weight_updater = DiffusionUpdateWeightFromTensorLoRA(self.args, self.models)
         else:

--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -1,8 +1,9 @@
 import abc
 import logging
 import os
+import re
 from argparse import Namespace
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import ray
 import torch
@@ -32,6 +33,70 @@ except ImportError as _e:
 
 
 logger = logging.getLogger(__name__)
+
+LORA_IPC_WEIGHT_UPDATE_MODE = "lora_merge"
+
+
+class PeftLoRAKeyMapper:
+    """Map PEFT LoRA state-dict keys to sglang-d tensor names for IPC sync."""
+
+    _LORA_KEY_RE = re.compile(r"\.lora_([AB])(?:\.[^.]+)?(?:\.weight)?$")
+    _PEFT_PREFIX = "base_model.model."
+
+    @classmethod
+    def is_lora_key(cls, name: str) -> bool:
+        return ".lora_A" in name or ".lora_B" in name
+
+    @classmethod
+    def to_sgld_name(cls, name: str) -> str | None:
+        """Map a PEFT state-dict key to sglang-d LoRA tensor name."""
+        if not cls.is_lora_key(name):
+            return None
+
+        stripped = name
+        if stripped.startswith(cls._PEFT_PREFIX):
+            stripped = stripped[len(cls._PEFT_PREFIX) :]
+
+        match = cls._LORA_KEY_RE.search(stripped)
+        if match is None:
+            return None
+
+        layer_prefix = stripped[: match.start()]
+        ab = match.group(1)
+        return f"{layer_prefix}.lora_{ab}"
+
+    @classmethod
+    def collect_sgld_names(cls, state_dict: Mapping[str, torch.Tensor]) -> set[str]:
+        names: set[str] = set()
+        for key in state_dict:
+            sgld_name = cls.to_sgld_name(key)
+            if sgld_name is not None:
+                names.add(sgld_name)
+        return names
+
+    @classmethod
+    def collect_layer_prefixes(cls, state_dict: Mapping[str, torch.Tensor]) -> set[str]:
+        return {name.rsplit(".lora_", 1)[0] for name in cls.collect_sgld_names(state_dict)}
+
+    @classmethod
+    def summarize_mapping(
+        cls,
+        state_dict: Mapping[str, torch.Tensor],
+    ) -> tuple[int, int, list[str], list[str]]:
+        """Return (num_tensors, num_layers, sample_layer_prefixes, unmapped_peft_keys)."""
+        sgld_names: list[str] = []
+        unmapped: list[str] = []
+        for key in state_dict:
+            if not cls.is_lora_key(key):
+                continue
+            sgld_name = cls.to_sgld_name(key)
+            if sgld_name is None:
+                unmapped.append(key)
+            else:
+                sgld_names.append(sgld_name)
+        layer_prefixes = {name.rsplit(".lora_", 1)[0] for name in sgld_names}
+        sample = sorted(layer_prefixes)[:5]
+        return len(sgld_names), len(layer_prefixes), sample, unmapped
 
 
 class DiffusionUpdateWeight(abc.ABC):
@@ -88,12 +153,23 @@ class DiffusionUpdateWeight(abc.ABC):
             self.wait_and_update_bucket_weights(bucket, target_module)
             del bucket
 
-    def wait_and_update_bucket_weights(self, bucket, target_module: str):
+    def wait_and_update_bucket_weights(self, bucket, target_module: str, weight_update_mode=None):
         bucket = [(name, param.wait()) if hasattr(param, "wait") else (name, param) for name, param in bucket]
-        self.update_bucket_weights(bucket, target_module, weight_version=self.weight_version)
+        self.update_bucket_weights(
+            bucket,
+            target_module,
+            weight_version=self.weight_version,
+            weight_update_mode=weight_update_mode,
+        )
 
     @abc.abstractmethod
-    def update_bucket_weights(self, named_tensors, target_module: str, weight_version=None) -> None:
+    def update_bucket_weights(
+        self,
+        named_tensors,
+        target_module: str,
+        weight_version=None,
+        weight_update_mode: str | None = None,
+    ) -> None:
         pass
 
 
@@ -123,7 +199,13 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
                 # Calculate TP rank within this SGLang engine group.
                 self.tp_rank = dist.get_rank() - start_rank
 
-    def update_bucket_weights(self, named_tensors, target_module: str, weight_version=None) -> None:
+    def update_bucket_weights(
+        self,
+        named_tensors,
+        target_module: str,
+        weight_version=None,
+        weight_update_mode: str | None = None,
+    ) -> None:
         monkey_patch_torch_reductions()
         logger.info("Using flattened tensor bucket (diffusion updater, module=%s)", target_module)
         named_tensors_by_dtypes = {}
@@ -173,6 +255,10 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
                     "target_modules": [target_module],
                     "weight_version": str(weight_version),
                 }
+                if weight_update_mode is not None:
+                    kwargs["weight_update_mode"] = weight_update_mode
+                    kwargs["lora_alpha"] = self.args.lora_alpha
+                    kwargs["lora_rank"] = self.args.lora_rank
                 ref = self._ipc_engine.update_weights_from_tensor.remote(**kwargs)
                 ray.get(ref)
 
@@ -322,3 +408,78 @@ class DiffusionUpdateWeightFromTensorLoRA(DiffusionUpdateWeightFromTensor):
         all_equal = all(s == first_sum for _, s in engine_sums)
         pretty = "  ".join(f"eng{idx}={s[:16] if isinstance(s, str) else s}" for idx, s in engine_sums)
         logger.warning(f"[weight_sync verify v{self.weight_version} cross-engine] " f"all_equal={all_equal}  {pretty}")
+
+
+class DiffusionUpdateWeightFromTensorLoRAIPC(DiffusionUpdateWeightFromTensor):
+    """Push only lora_A/lora_B tensors; rollout merges locally via weight_update_mode=lora_merge."""
+
+    def update_weights(self) -> None:
+        self.weight_version += 1
+        for target_module, model in self.models.items():
+            bucket: list[tuple[str, torch.Tensor]] = []
+            bucket_size = 0
+            num_lora_keys = 0
+            unmapped_keys: list[str] = []
+
+            for name, param in model.state_dict().items():
+                if not PeftLoRAKeyMapper.is_lora_key(name):
+                    continue
+                sgld_name = PeftLoRAKeyMapper.to_sgld_name(name)
+                if sgld_name is None:
+                    unmapped_keys.append(name)
+                    continue
+
+                param = param.cuda()
+                if isinstance(param, DTensor):
+                    param = param.redistribute(
+                        placements=[Replicate()] * param.device_mesh.ndim,
+                        async_op=True,
+                    ).to_local()
+
+                sz = param.numel() * param.element_size()
+                if bucket and bucket_size + sz >= self.args.update_weight_buffer_size:
+                    self.wait_and_update_bucket_weights(
+                        bucket,
+                        target_module,
+                        weight_update_mode=LORA_IPC_WEIGHT_UPDATE_MODE,
+                    )
+                    bucket, bucket_size = [], 0
+
+                bucket.append((sgld_name, param))
+                bucket_size += sz
+                num_lora_keys += 1
+
+            if bucket:
+                self.wait_and_update_bucket_weights(
+                    bucket,
+                    target_module,
+                    weight_update_mode=LORA_IPC_WEIGHT_UPDATE_MODE,
+                )
+
+            if self.weight_version <= 2 and dist.get_rank() == 0:
+                _, num_layers, sample_layers, _ = PeftLoRAKeyMapper.summarize_mapping(model.state_dict())
+                logger.info(
+                    "LoRA IPC weight sync v%s [%s]: pushed %d lora tensors, " "%d layer prefixes (unmapped=%d)",
+                    self.weight_version,
+                    target_module,
+                    num_lora_keys,
+                    num_layers,
+                    len(unmapped_keys),
+                )
+                if sample_layers:
+                    logger.info(
+                        "LoRA IPC [%s] sample layer prefixes: %s",
+                        target_module,
+                        sample_layers,
+                    )
+                if unmapped_keys:
+                    logger.warning(
+                        "LoRA IPC unmapped PEFT keys [%s] (first 5): %s",
+                        target_module,
+                        unmapped_keys[:5],
+                    )
+                if num_lora_keys == 0:
+                    logger.error(
+                        "LoRA IPC [%s]: no lora tensors found in training state_dict",
+                        target_module,
+                    )

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -246,6 +246,9 @@ class SGLangDiffusionEngine(RayActor):
         load_format: str | None = None,
         target_modules: list[str] | None = None,
         weight_version: str | None = None,
+        weight_update_mode: str | None = None,
+        lora_alpha: int | None = None,
+        lora_rank: int | None = None,
     ):
         """
         Update model weights from tensor data. The HTTP server will only post meta data, and the real weights will be copied directly from GPUs.
@@ -261,6 +264,12 @@ class SGLangDiffusionEngine(RayActor):
             payload["target_modules"] = target_modules
         if weight_version is not None:
             payload["weight_version"] = weight_version
+        if weight_update_mode is not None:
+            payload["weight_update_mode"] = weight_update_mode
+        if lora_alpha is not None:
+            payload["lora_alpha"] = lora_alpha
+        if lora_rank is not None:
+            payload["lora_rank"] = lora_rank
         return self._make_request(
             "update_weights_from_tensor",
             payload,
@@ -308,6 +317,11 @@ class SGLangDiffusionEngine(RayActor):
 
 
 def _compute_server_args(args, host, port, nccl_port):
+    from miles.backends.fsdp_utils.configs.train_pipeline_config import (
+        get_train_pipeline_config_cls,
+        resolve_diffusion_model_family,
+    )
+
     # Only set fields SGL-D's ServerArgs actually accepts. GPU pinning is done
     # in `_init_normal` via CUDA_VISIBLE_DEVICES — SGL-D has no base_gpu_id arg.
     kwargs = {
@@ -338,5 +352,10 @@ def _compute_server_args(args, host, port, nccl_port):
     for attr in dataclasses.fields(ServerArgs):
         if hasattr(args, f"sglang_{attr.name}") and attr.name not in kwargs:
             kwargs[attr.name] = getattr(args, f"sglang_{attr.name}")
+
+    if getattr(args, "use_lora", False) and getattr(args, "lora_ipc_weight_sync", False):
+        family = resolve_diffusion_model_family(args.diffusion_model)
+        train_pipeline_config = get_train_pipeline_config_cls(family)()
+        kwargs["lora_target_modules"] = args.lora_target_modules or train_pipeline_config.lora_target_modules
 
     return kwargs

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -300,11 +300,6 @@ class SGLangDiffusionEngine(RayActor):
 
 
 def _compute_server_args(args, host, port, nccl_port):
-    from miles.backends.fsdp_utils.configs.train_pipeline_config import (
-        get_train_pipeline_config_cls,
-        resolve_diffusion_model_family,
-    )
-
     # Only set fields SGL-D's ServerArgs actually accepts. GPU pinning is done
     # in `_init_normal` via CUDA_VISIBLE_DEVICES — SGL-D has no base_gpu_id arg.
     kwargs = {
@@ -332,9 +327,7 @@ def _compute_server_args(args, host, port, nccl_port):
             kwargs[attr.name] = getattr(args, f"sglang_{attr.name}")
 
     if getattr(args, "use_lora", False) and getattr(args, "lora_ipc_weight_sync", False):
-        family = resolve_diffusion_model_family(args.diffusion_model)
-        train_pipeline_config = get_train_pipeline_config_cls(family)()
-        kwargs["lora_target_modules"] = args.lora_target_modules or train_pipeline_config.lora_target_modules
+        kwargs["lora_target_modules"] = args.lora_target_modules
     # dit_precision / vae_precision are PipelineConfig fields, not ServerArgs, so forward them explicitly (only when changed from the class default, to avoid clobbering a subclass override).
     from sglang.multimodal_gen.configs.pipeline_configs.base import PipelineConfig
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1369,6 +1369,17 @@ def miles_validate_args(args):
         if args.model_backend_path is None:
             args.model_backend_path = cfg_cls.model_backend_path
         cfg_cls.validate_args(args)
+        if args.use_lora and args.lora_target_modules is None:
+            args.lora_target_modules = list(cfg_cls.lora_target_modules)
+
+    if getattr(args, "lora_ipc_weight_sync", False):
+        if not args.use_lora:
+            raise ValueError("--lora-ipc-weight-sync requires --use-lora")
+        if not args.lora_target_modules:
+            raise ValueError(
+                "--lora-ipc-weight-sync requires LoRA target modules; "
+                "set --diffusion-model (for per-model defaults) or --lora-target-modules."
+            )
 
     if args.dump_details is not None:
         args.save_debug_rollout_data = f"{args.dump_details}/rollout_data/{{rollout_id}}.pt"

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1040,6 +1040,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Override LoRA target modules. Default: per-model from TrainPipelineConfig.",
             )
             parser.add_argument(
+                "--lora-ipc-weight-sync",
+                action="store_true",
+                default=False,
+                help=(
+                    "Sync only lora_A/lora_B to rollout via IPC with weight_update_mode=lora_merge "
+                    "(requires matching sglang-d LoRAPipeline support)."
+                ),
+            )
+            parser.add_argument(
                 "--diffusion-init-lora-weight",
                 type=str,
                 default="gaussian",

--- a/scripts/run-diffusion-grpo-ocr-2gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-ocr-2gpu-flowgrpo-aligned.sh
@@ -63,6 +63,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --num-gpus-per-node 2 \
   --colocate \
   --use-lora \
+  --lora-ipc-weight-sync \
   --lora-rank 64 \
   --lora-alpha 128 \
   --diffusion-init-lora-weight gaussian \

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -111,6 +111,7 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --use-miles-router \
   --sglang-server-concurrency 8 \
   --use-lora \
+  --lora-ipc-weight-sync \
   --lora-rank 32 \
   --lora-alpha 64 \
   --diffusion-init-lora-weight gaussian \

--- a/tests/fast/backends/fsdp_utils/test_peft_lora_key_mapper.py
+++ b/tests/fast/backends/fsdp_utils/test_peft_lora_key_mapper.py
@@ -1,0 +1,68 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=15, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.backends.fsdp_utils.diffusion_update_weight_utils import PeftLoRAKeyMapper
+
+_QWEN_A = "base_model.model.transformer_blocks.0.attn.to_q.lora_A.default.weight"
+_QWEN_B = "base_model.model.transformer_blocks.0.attn.to_q.lora_B.default.weight"
+_SD3_A = "base_model.model.transformer_blocks.1.attn.add_k_proj.lora_A.weight"
+_MLP_B = "base_model.model.transformer_blocks.2.img_mlp.net.0.proj.lora_B.default.weight"
+
+
+class TestPeftLoRAKeyMapper:
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            (_QWEN_A, "transformer_blocks.0.attn.to_q.lora_A"),
+            (_QWEN_B, "transformer_blocks.0.attn.to_q.lora_B"),
+            (_SD3_A, "transformer_blocks.1.attn.add_k_proj.lora_A"),
+            (_MLP_B, "transformer_blocks.2.img_mlp.net.0.proj.lora_B"),
+            ("transformer_blocks.0.attn.to_v.lora_A.default.weight", "transformer_blocks.0.attn.to_v.lora_A"),
+        ],
+    )
+    def test_to_sgld_name_maps_peft_keys(self, key, expected):
+        assert PeftLoRAKeyMapper.to_sgld_name(key) == expected
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "transformer_blocks.0.attn.to_q.weight",
+            "base_model.model.norm.weight",
+            "lora_A.default.weight",
+        ],
+    )
+    def test_to_sgld_name_returns_none_for_non_lora_keys(self, key):
+        assert PeftLoRAKeyMapper.to_sgld_name(key) is None
+
+    def test_is_lora_key(self):
+        assert PeftLoRAKeyMapper.is_lora_key(_QWEN_A)
+        assert PeftLoRAKeyMapper.is_lora_key(_QWEN_B)
+        assert not PeftLoRAKeyMapper.is_lora_key("transformer_blocks.0.attn.to_q.weight")
+
+    def test_collect_sgld_names_and_layer_prefixes(self):
+        state_dict = {
+            _QWEN_A: torch.zeros(4, 8),
+            _QWEN_B: torch.zeros(8, 4),
+            "base_model.model.norm.weight": torch.zeros(8),
+        }
+        sgld_names = PeftLoRAKeyMapper.collect_sgld_names(state_dict)
+        assert sgld_names == {
+            "transformer_blocks.0.attn.to_q.lora_A",
+            "transformer_blocks.0.attn.to_q.lora_B",
+        }
+        assert PeftLoRAKeyMapper.collect_layer_prefixes(state_dict) == {"transformer_blocks.0.attn.to_q"}
+
+    def test_summarize_mapping_reports_unmapped_lora_keys(self):
+        state_dict = {
+            _QWEN_A: torch.zeros(4, 8),
+            "base_model.model.weird.lora_A.default.weight.extra": torch.zeros(4, 8),
+        }
+        num_tensors, num_layers, sample_layers, unmapped = PeftLoRAKeyMapper.summarize_mapping(state_dict)
+        assert num_tensors == 1
+        assert num_layers == 1
+        assert sample_layers == ["transformer_blocks.0.attn.to_q"]
+        assert unmapped == ["base_model.model.weird.lora_A.default.weight.extra"]

--- a/tests/fast/utils/test_lora_args.py
+++ b/tests/fast/utils/test_lora_args.py
@@ -1,6 +1,6 @@
-from tests.ci.ci_register import register_cpu_ci
+from tests.ci.ci_register import register_cuda_ci
 
-register_cpu_ci(est_time=15, suite="stage-a-cpu", labels=[])
+register_cuda_ci(est_time=15, suite="stage-b-3-gpu-h200", labels=[])
 
 from argparse import Namespace
 

--- a/tests/fast/utils/test_lora_args.py
+++ b/tests/fast/utils/test_lora_args.py
@@ -1,0 +1,34 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=15, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+from miles.backends.sglang_diffusion_utils.sglang_diffusion_engine import _compute_server_args
+
+
+def _server_args(**overrides):
+    base = dict(
+        diffusion_model="Qwen/Qwen-Image",
+        diffusion_flow_shift=None,
+        rollout_num_gpus_per_engine=1,
+        sglang_sp_degree=None,
+        sglang_enable_cfg_parallel=False,
+        use_lora=True,
+        lora_ipc_weight_sync=True,
+        lora_target_modules=["to_q", "to_k"],
+    )
+    base.update(overrides)
+    return Namespace(**base)
+
+
+class TestLoRATargetModulesServerArgs:
+    def test_lora_ipc_uses_resolved_args(self):
+        args = _server_args()
+        kwargs = _compute_server_args(args, "127.0.0.1", 15000, 15001)
+        assert kwargs["lora_target_modules"] == ["to_q", "to_k"]
+
+    def test_lora_ipc_omitted_when_disabled(self):
+        args = _server_args(lora_ipc_weight_sync=False)
+        kwargs = _compute_server_args(args, "127.0.0.1", 15000, 15001)
+        assert "lora_target_modules" not in kwargs


### PR DESCRIPTION
## Motivation
Add an opt-in LoRA IPC weight sync path for colocated diffusion GRPO training. When `--lora-ipc-weight-sync` is enabled, miles pushes only `lora_A` / `lora_B` tensors to rollout via IPC with `weight_update_mode=lora_merge`, instead of all-gathering full base weights.
This reduces weight-sync cost from near-100% model parameters to ~1–5% LoRA parameters, while keeping rollout behavior equivalent for correctly mapped models.


## Modifications
- **`miles/utils/arguments.py`**
  - Add `--lora-ipc-weight-sync`
- **`miles/backends/fsdp_utils/diffusion_update_weight_utils.py`**
  - Add `PeftLoRAKeyMapper` for PEFT → sglang-d LoRA key mapping
  - Add `DiffusionUpdateWeightFromTensorLoRAIPC`
  - Extend updater API to pass `weight_update_mode`, `lora_alpha`, and `lora_rank`
- **`miles/backends/fsdp_utils/actor.py`**
  - Select `DiffusionUpdateWeightFromTensorLoRAIPC` when `use_lora and lora_ipc_weight_sync`
- **`miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py`**
  - Forward `weight_update_mode`, `lora_alpha`, `lora_rank` in `/update_weights_from_tensor`
  - Pass `lora_target_modules` to rollout server args when LoRA IPC is enabled
- **Scripts**
  - Enable `--lora-ipc-weight-sync` in:
    - `scripts/run-diffusion-grpo-sd3-ocr-sglang.sh`
    - `scripts/run-diffusion-grpo-ocr-2gpu-flowgrpo-aligned.sh`

Rollout-side LoRA IPC merge is implemented in [sglang-d](https://github.com/sgl-project/sglang/pull/31029).


## Performance
Benchmarks were run on 2-GPU colocate OCR GRPO with 5 rollout cycles, comparing merge baseline vs LoRA IPC.
### Weight sync time (`perf/update_weights_time`)
| Model | Merge baseline | LoRA IPC | Speedup |
|------|----------------|----------|---------|
| **SD3.5 medium** | ~4.2–5.4s | ~1.3–1.6s | **~3×** |
| **Qwen-Image** | ~24–28s | 6–7s | **~3–4×** |

Rollout-side verification:
- Qwen IPC sync: **720 / 720 LoRA layers updated, 0 skipped**
- SD3.5 IPC sync: **191 / 191 LoRA layers updated, 0 skipped**

### Train/inference consistency on Qwen-Image
We compared LoRA IPC vs the existing merged-weight sync path on the same Qwen-Image OCR colocate setup (10 rollout steps). The plot below shows `train/log_prob_mean_abs_diff` over training steps:
<img width="2084" height="772" alt="merge_vs_lora_ipc_compare" src="https://github.com/user-attachments/assets/8d456184-9c06-43b4-b264-5c64a0c2c22c" />

Both paths remain on the same order of magnitude (~1e-5 to ~5e-5). Step 1 is bit-identical, and later steps stay numerically close. This suggests LoRA IPC does not materially affect train/rollout log-prob consistency on Qwen-Image.


