### PR TITLE
fsdp: materialize clip_grad_norm's DTensor before logging

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -7,6 +7,7 @@ from contextlib import nullcontext
 import ray
 import torch
 import torch.distributed as dist
+from torch.distributed.tensor import DTensor
 
 import miles.backends.fsdp_utils.configs.qwen_image  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.sd3  # noqa: F401 — register pipeline config
@@ -407,6 +408,10 @@ class FSDPTrainRayActor(TrainRayActor):
                 if not self.args.debug_skip_optimizer_step:
                     self.scaler.unscale_(self.optimizer)
                     grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.clip_grad)
+                    if isinstance(grad_norm, DTensor):
+                        # clip returns a lazily-reduced partial norm; materialize it,
+                        # otherwise the logged metric leaks the local shard's value.
+                        grad_norm = grad_norm.full_tensor()
                     log_stats["grad_norm"].append(grad_norm.detach())
                     self.scaler.step(self.optimizer)
                     self.scaler.update()


### PR DESCRIPTION
`clip_grad_norm_` on DTensor parameters returns a lazily-reduced **partial** norm; the logging path (`.detach()` → `.mean().item()`) leaked the local shard's value, under-reporting the `train/grad_norm` metric by ×√(n_shards) on **every** FSDP config (historical dp4 wandb curves are ×2 too low). Clipping itself was always correct — the clip coefficient is computed inside DTensor arithmetic — only the logged metric was wrong.

Fix: `.full_tensor()` before logging.

Found while cross-validating the two SP parameter placements in #21 (different shard counts → reported norms differed by √2 while instrumented per-param grads were bitwise identical). #21's validation claims depend on this landing first.

**Expect wandb `grad_norm` curves to step up** (×2 on the dp4 recipe) after this merges — historical values were under-reported, not the new ones inflated.