### PR TITLE
fsdp: assert weight-sync grouping covers the train world

### DIFF
--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -107,10 +107,18 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
     ) -> None:
         self.rollout_engines = rollout_engines
 
+        # Match rollout.init_rollout_engines' per-engine span; a mismatch would
+        # leave orphaned ranks that fail much later in update_bucket_weights.
+        num_gpu_per_engine = min(self.args.rollout_num_gpus_per_engine, self.args.num_gpus_per_node)
+        assert dist.get_world_size() == len(rollout_engines) * num_gpu_per_engine, (
+            f"train world {dist.get_world_size()} != {len(rollout_engines)} engines x "
+            f"{num_gpu_per_engine} gpus per engine"
+        )
+
         # Here we assume the gpu id of rollout engines and train actors are the same.
         for i, engine in enumerate(self.rollout_engines):
-            start_rank = i * self.args.rollout_num_gpus_per_engine
-            end_rank = (i + 1) * self.args.rollout_num_gpus_per_engine
+            start_rank = i * num_gpu_per_engine
+            end_rank = (i + 1) * num_gpu_per_engine
             group_ranks = list(range(start_rank, end_rank))
             new_group = dist.new_group(
                 ranks=group_ranks,


### PR DESCRIPTION
`connect_rollout_engines` computed its per-engine rank span as raw `rollout_num_gpus_per_engine`, while `rollout.init_rollout_engines` sizes engines with `min(rollout_num_gpus_per_engine, num_gpus_per_node)`. For every current single-node config the two coincide — **behavior is byte-identical for all existing recipes** (Wan / SD3 / Qwen-Image; the qwen OCR e2e in CI exercises this path).

Honest scope statement for the multi-node colocate case (engine TP spanning nodes): **neither** convention yields a working weight push there — the FromTensor path is CUDA-IPC based and cannot cross nodes, so the old code failed much later inside `update_bucket_weights` with no indication of cause. The new assert (`world == engines × span`) turns that into a connect-time failure with the three numbers spelled out. Proper multi-node weight sync needs per-node-shard grouping (using `all_rollout_engines`, not the deduped list) and its own design — out of scope here; this PR only makes the unsupported case fail loudly instead of mysteriously.
