### PR TITLE
fix(LTX): checkpoint resume

### DIFF
--- a/miles/backends/fsdp_utils/configs/ltx.py
+++ b/miles/backends/fsdp_utils/configs/ltx.py
@@ -22,6 +22,8 @@ class LTXTrainPipelineConfig(TrainPipelineConfig):
     rollout_patch_group = "ltx"
     hf_ckpt_name_patterns = ("ltx",)
     model_backend_path = "miles.backends.fsdp_utils.model_backend.LTXModelBackend"
+    # Audio branch has no optimizer state: we only train the video stream.
+    optimizer_state_allowed_missing = ["audio"]
 
     def configure(self, args: Namespace) -> None:
         self._height = args.diffusion_height

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -673,8 +673,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--start-rollout-id",
                 type=int,
-                default=0,
-                help="The starting rollout step.",
+                default=None,
+                help=(
+                    "The starting rollout step; if unset, resume it from --load when continuing "
+                    "training, otherwise default to 0 (train from scratch)."
+                ),
             )
 
             # batch sizes


### PR DESCRIPTION
1. Tiny fix for LTX resume from checkpoint: since the audio stream didn't receive any gradients, audio-related weights are added to the optimizer state loading allowlist.
2. Set start-rollout-id default to None. So that rollout_id will be set by checkpoint metadata for resume