### PR TITLE
perf(rollout): streaming optimization for tensor transfer

### DIFF
--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -108,11 +108,20 @@ class GenerateState(metaclass=SingletonMeta):
         self.dp_counts = [0] * args.sglang_dp_size
         self.dp_rank = 0
         self.node_id = ray.get_runtime_context().get_node_id()
-        self.response_parser_actor = RolloutImageResponseParserActor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=self.node_id, soft=False)
-        ).remote()
+        self.response_parsers = [
+            RolloutImageResponseParserActor.options(
+                scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=self.node_id, soft=False)
+            ).remote()
+            for _ in range(args.rollout_parser_num_workers)
+        ]
+        self._parser_rr = 0
 
         self.reset()
+
+    def next_parser(self):
+        parser = self.response_parsers[self._parser_rr % len(self.response_parsers)]
+        self._parser_rr += 1
+        return parser
 
     @contextmanager
     def dp_rank_context(self):
@@ -178,8 +187,7 @@ async def generate_microgroup(
 
     output = await post(url, payload)
     refs = [
-        state.response_parser_actor.apply.remote(sample, response)
-        for sample, response in zip(microgroup, output, strict=True)
+        state.next_parser().apply.remote(sample, response) for sample, response in zip(microgroup, output, strict=True)
     ]
     microgroup = await asyncio.to_thread(ray.get, refs)
 

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -185,11 +185,9 @@ async def generate_microgroup(
         sampling_params, microgroup[0].prompt, num_outputs_per_prompt=len(microgroup)
     )
 
-    output = await post(url, payload)
-    refs = [
-        state.next_parser().apply.remote(sample, response) for sample, response in zip(microgroup, output, strict=True)
-    ]
-    microgroup = await asyncio.to_thread(ray.get, refs)
+    raw = await post(url, payload, raw=True)
+    ref = state.next_parser().apply_raw.remote(microgroup, raw)
+    microgroup = await asyncio.to_thread(ray.get, ref)
 
     # Stash the SDE/training step indices on each sample so _train_core can
     # slice the full-length trajectory & rollout_log_probs down to the window.

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1135,6 +1135,13 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Number of Ray PickScore actors used when --rm-type pickscore.",
             )
             parser.add_argument(
+                "--rollout-parser-num-workers",
+                type=int,
+                default=1,
+                help="Number of Ray actors that deserialize rollout responses; raise to keep "
+                "engines fed when trajectory tensors are large.",
+            )
+            parser.add_argument(
                 "--pickscore-num-gpus-per-worker",
                 type=float,
                 default=1.0,

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+
+import msgpack
 import ray
 import torch
 
 from miles.utils.processing_utils import fhwc_to_cfhw
-from miles.utils.types import (
-    CondKwargs,
-    DenoisingEnv,
-    DiTTrajectory,
-    RolloutDebugTensors,
-    Sample,
-    decode_tensor_base64,
-)
+from miles.utils.types import CondKwargs, DenoisingEnv, DiTTrajectory, RolloutDebugTensors, Sample, decode_tensor
 
 __all__ = [
     "apply_rollout_image_response",
@@ -31,7 +26,7 @@ def _default_deserialize_func(value: Any) -> torch.Tensor | None:
     if value is None:
         return None
     if isinstance(value, dict) and value.get("__tensor__"):
-        return decode_tensor_base64(value["data"]).detach().cpu()
+        return decode_tensor(value["data"]).detach().cpu()
     raise TypeError(f"Cannot deserialize {type(value)}")
 
 
@@ -201,5 +196,6 @@ def apply_rollout_image_response(
 
 @ray.remote(num_cpus=1)
 class RolloutImageResponseParserActor:
-    def apply(self, sample: Sample, body: dict[str, Any]) -> Sample:
-        return apply_rollout_image_response(sample, body)
+    def apply_raw(self, samples: list[Sample], raw: bytes) -> list[Sample]:
+        bodies = msgpack.unpackb(raw, raw=False)
+        return [apply_rollout_image_response(s, b) for s, b in zip(samples, bodies, strict=True)]

--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -8,6 +8,7 @@ import random
 import socket
 
 import httpx
+import msgpack
 
 logger = logging.getLogger(__name__)
 
@@ -162,16 +163,24 @@ def _next_actor():
     return actor
 
 
-async def _post(client, url, payload, max_retries=60):
+def _parse_response(response, raw=False):
+    if raw:
+        return response.content
+    if "application/msgpack" in response.headers.get("content-type", ""):
+        return msgpack.unpackb(response.content, raw=False)
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return response.text
+
+
+async def _post(client, url, payload, max_retries=60, raw=False):
     retry_count = 0
     while retry_count < max_retries:
         try:
             response = await client.post(url, json=payload or {})
             response.raise_for_status()
-            try:
-                output = response.json()
-            except json.JSONDecodeError:
-                output = response.text
+            output = _parse_response(response, raw=raw)
         except Exception as e:
             retry_count += 1
 
@@ -240,8 +249,8 @@ def _init_ray_distributed_post(args):
                 timeout=httpx.Timeout(None),
             )
 
-        async def do_post(self, url, payload, max_retries=60):
-            return await _post(self._client, url, payload, max_retries)
+        async def do_post(self, url, payload, max_retries=60, raw=False):
+            return await _post(self._client, url, payload, max_retries, raw)
 
     # Create actors per node
     created = []
@@ -265,7 +274,7 @@ def _init_ray_distributed_post(args):
     _post_actors = created
 
 
-async def post(url, payload, max_retries=60):
+async def post(url, payload, max_retries=60, raw=False):
     # If distributed mode is enabled and actors exist, dispatch via Ray.
     if _distributed_post_enabled and _post_actors:
         try:
@@ -274,17 +283,17 @@ async def post(url, payload, max_retries=60):
             actor = _next_actor()
             if actor is not None:
                 # Use a thread to avoid blocking the event loop on ray.get
-                obj_ref = actor.do_post.remote(url, payload, max_retries)
+                obj_ref = actor.do_post.remote(url, payload, max_retries, raw)
                 return await asyncio.to_thread(ray.get, obj_ref)
         except Exception as e:
             logger.info(f"[http_utils] Distributed POST failed, falling back to local: {e} (url={url})")
             # fall through to local
 
-    return await _post(_http_client, url, payload, max_retries)
+    return await _post(_http_client, url, payload, max_retries, raw)
 
 
 async def get(url):
     response = await _http_client.get(url)
     response.raise_for_status()
-    output = response.json()
+    output = _parse_response(response)
     return output

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -1,25 +1,16 @@
 from __future__ import annotations
 
-import base64
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
 import torch
-from safetensors.torch import load, save
+from safetensors.torch import load
 
 
-def decode_tensor_base64(b64: str) -> torch.Tensor:
-    """Deserialize base64 to CPU tensor (same wire format as inference: safetensors ``[\"t\"]``, else ``torch.load``)."""
-    raw = base64.b64decode(b64.encode("ascii") if isinstance(b64, str) else b64)
-    return load(raw)["t"]
-
-
-def tensor_to_base64(tensor: torch.Tensor) -> str:
-    """Encode a CPU tensor as base64 safetensors (single key ``tensor_key``, default ``t``)."""
-    tensor = tensor.detach().cpu()
-    raw = save({"t": tensor})
-    return base64.b64encode(raw).decode("ascii")
+def decode_tensor(data: bytes) -> torch.Tensor:
+    """Deserialize safetensors raw bytes to a CPU tensor (single key ``t``)."""
+    return load(data)["t"]
 
 
 @dataclass

--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -142,6 +142,7 @@ fi
   --pickscore-num-frames "${PICKSCORE_NUM_FRAMES:-3}" \
   --pickscore-num-gpus-per-worker "${PICKSCORE_NUM_GPUS_PER_WORKER:-0}" \
   --pickscore-num-workers "${PICKSCORE_NUM_WORKERS:-1}" \
+  --rollout-parser-num-workers "${ROLLOUT_PARSER_NUM_WORKERS:-8}" \
   --pickscore-batch-size "${PICKSCORE_BATCH_SIZE:-8}" \
   --update-weight-buffer-size "${UPDATE_WEIGHT_BUFFER_SIZE:-2147483648}" \
   --save "${SAVE_DIR}" \


### PR DESCRIPTION
## Motivation

Rollout tensor transfer (sglang engine → trainer) was the rollout-step bottleneck. Trajectory tensors were base64-encoded inside a JSON body; each sample's response was then JSON-parsed on the main asyncio event loop and handed to a single Ray parser actor one sample at a time. For large LTX video trajectory tensors this serialize/deserialize path dominated `perf/rollout_time`.

## Modifications

- **msgpack raw-bytes transport.** Consume the sglang-side `application/msgpack` response (sgl-project/sglang#31565). `decode_tensor` now loads safetensors raw bytes directly; base64 helpers (`tensor_to_base64` / `decode_tensor_base64`) are removed from `types.py`. `http_utils._parse_response` decodes `application/msgpack`, with a `raw=True` passthrough that returns the response bytes untouched.
- **Deserialization moved off the event loop into the parser actor.** `post(..., raw=True)` returns raw bytes; the parser actor's new `apply_raw(samples, raw)` runs `msgpack.unpackb` + tensor decode inside the Ray actor, so the main asyncio loop no longer blocks on unpacking (previously `response.json()` ran in-process).
- **Batched parsing.** One `apply_raw.remote(microgroup, raw)` call parses a whole microgroup, replacing the previous per-sample `apply.remote(sample, body)` fan-out — fewer Ray RPCs, one unpack per microgroup.
- **Parser actor pool.** New `--rollout-parser-num-workers` spins up N `RolloutImageResponseParserActor`s dispatched round-robin, so multiple microgroups deserialize in parallel instead of funneling through a single actor. The LTX-2.3 recipe sets it to 8.

## Perf

`Lightricks/LTX-2.3` (LTX2AV) rollout e2e on H200, same config (only the transport/parser path differs), averaged over two consecutive RL steps:

| Metric | base64/JSON | msgpack (this PR) | Speedup |
| --- | --- | --- | --- |
| Per rollout step (`perf/rollout_time`) | 157.4 s | 87.6 s | **~1.8x (-44%)** |
| Full training step (`perf/step_time`) | 321.9 s | 252.1 s | **~1.28x (-22%)** |

Per-denoising-step time is unchanged (~0.174 s), so the win is entirely in rollout transfer; the full-step reduction (~70 s) equals the rollout reduction. Baseline run 29674754955 (base64/JSON); new run 29699261828 (this PR + sgl-project/sglang#31565). Both on the CI stage-c short e2e (`test_ltx23_pickscore_grpo_4xGPU.py`, NUM_ROLLOUT=2); absolute numbers scale with config/hardware, the ratio does not.

<!-- CI dependency overrides -->
<!-- pin miles-D container to the freshly built image -->
ci-image-tag: dev-cu129-sglang-main-20260719
<!-- pin sglang to the matching PR head (msgpack transport, not yet on sglang main) -->
ci-sglang-repo: sgl-project/sglang
ci-sglang-pr: #31565

