### PR TITLE
fix(metrics): skip the jsonl metrics tee for media logs

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -441,7 +441,7 @@ class RolloutManager:
             if not log_dict:
                 return
             log_dict[step_key] = step_value
-            tracking_utils.log(self.args, log_dict, step_key=step_key)
+            tracking_utils.log(self.args, log_dict, step_key=step_key, is_media=True)
 
     def set_train_parallel_config(self, config: dict):
         self.train_parallel_config = config

--- a/miles/utils/tracking_utils.py
+++ b/miles/utils/tracking_utils.py
@@ -13,24 +13,15 @@ def init_tracking(args, primary: bool = True, **kwargs):
         wandb_utils.init_wandb_secondary(args, **kwargs)
 
 
-def log(args, metrics, step_key):
+def log(args, metrics, step_key, is_media=False):
     # E2E metrics tee (tests/ci/e2e_metrics_registry.py): mirror every metric
     # dict to MILES_METRICS_JSONL; O_APPEND keeps concurrent writers line-atomic.
     jsonl_path = os.environ.get("MILES_METRICS_JSONL")
-    if jsonl_path:
+    if jsonl_path and not is_media:
         with open(jsonl_path, "a") as f:
             f.write(json.dumps({"step_key": step_key, **metrics}, sort_keys=True) + "\n")
     del step_key
     if args.use_wandb:
-        # Do NOT pass step=... to wandb.log: wandb requires the explicit step
-        # argument to be monotonically increasing across all log calls, but
-        # miles interleaves per-rollout logs (step=rollout_id, +1 per rollout)
-        # with per-optimizer-step training logs (step=global_step, +2 per
-        # rollout), so rollout calls end up < current internal step and get
-        # dropped / bumped — users see rollout/* x-axis jumping like 1, 6, 10.
-        # The right pattern with wandb.define_metric(step_metric=...) is to
-        # leave wandb's internal commit counter auto-incrementing and let
-        # define_metric pull the x-axis value out of each metric dict
-        # (``rollout/step`` / ``train/step`` / ``eval/step``) — that's the
-        # step_metric wiring set up in wandb_utils._init_wandb_common().
+        # No step=: interleaved rollout/train logs aren't globally monotonic; the
+        # x-axis comes from per-metric step_metric (wandb_utils._init_wandb_common).
         wandb.log(metrics)


### PR DESCRIPTION
## What

Add an `is_media` flag to `tracking_utils.log()`. Media call sites (`_log_images`)
pass `is_media=True` so their wandb `Video` / `Image` logs skip the
`MILES_METRICS_JSONL` tee entirely instead of crashing it. `MILES_METRICS_JSONL` is used for dumping metrics when recording CI standards.

## How

`log(..., is_media=False)`; the media path passes `is_media=True` and bypasses the
jsonl tee, logging only to wandb. Scalar metric rows in the tee are unchanged, and
no per-value serializability probing is needed.

## Repro

LTX-2.3 pickscore GRPO recipe with `MILES_METRICS_JSONL` set + `--diffusion-log-images 4`
crashes at the first rollout's `_log_images`:

```
File "miles/ray/rollout.py", line 444, in _log_images
File "miles/utils/tracking_utils.py", line 22, in log
TypeError: Object of type Video is not JSON serializable
```

With this patch the run proceeds; the jsonl keeps the scalar metrics and the
videos show up in wandb.
