### PR TITLE
fix(rollout): disable sglang fp32 lora merge under ipc weight sync

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -487,6 +487,9 @@ def init_rollout_engines(args, pg, all_rollout_engines):
             "SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION": "false",
             "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE": "false",
         }
+        if args.lora_ipc_weight_sync:
+            # Merge in the train forward dtype, not fp32, to cut train/rollout consistency error.
+            env_vars["SGLANG_DIFFUSION_LORA_MERGE_FP32"] = "1" if args.diffusion_forward_dtype == "fp32" else "0"
 
         rollout_engine = RolloutRayActor.options(
             num_cpus=num_cpus,


### PR DESCRIPTION
## What

When `--lora-ipc-weight-sync` is on, set `SGLANG_DIFFUSION_LORA_MERGE_FP32` on the
rollout engines to match `--diffusion-forward-dtype`: `0` (no fp32 upcast) for the
bf16/fp16 forward, `1` only when the forward itself is fp32.

## Why

The train forward multiplies the LoRA branch in `--diffusion-forward-dtype` (bf16 by
default). The ipc path sends raw `lora_A`/`lora_B` and the sglang engine merges them
locally, upcasting to fp32 by default (`_should_merge_in_fp32`). Merging at a higher
precision than the forward makes the rollout policy drift from the training policy,
which is exactly the train/rollout consistency the deterministic path is meant to hold.

Measured on LTX-2.3 (deterministic, bf16 forward, 2 rollouts) — first post-sync rollout:

| config | rollout-1 reward | Δ vs ipc-off |
| --- | --- | --- |
| ipc on, fp32 merge (default) | 0.6828193664550781 | 9.1e-4 |
| ipc on, bf16 merge (this fix) | 0.6818487644195557 | 5.7e-5 |
| ipc off                       | 0.6819055080413818 | — |

Matching the merge to the bf16 forward closes ~16x of the gap (rollout-0 and the
training on it are already bit-identical). A residual 5.7e-5 remains from the merge's
scale/add ordering, out of scope here.
