### PR TITLE
fix(rollout): parse encoder_attention_mask as per-encoder list

### DIFF
--- a/miles/backends/fsdp_utils/configs/ltx.py
+++ b/miles/backends/fsdp_utils/configs/ltx.py
@@ -54,13 +54,13 @@ class LTXTrainPipelineConfig(TrainPipelineConfig):
             if audio_ctx.ndim == 2:
                 audio_ctx = audio_ctx.unsqueeze(0)
             kwargs["audio_context"] = audio_ctx
-        if cond.encoder_attention_mask is not None:
-            mask = cond.encoder_attention_mask.to(device)
+        if cond.encoder_attention_mask:
+            mask = torch.cat(cond.encoder_attention_mask).to(device)
             if mask.ndim == 1:
                 mask = mask.unsqueeze(0)
             kwargs["context_mask"] = mask
-        if cond.audio_encoder_attention_mask is not None:
-            audio_mask = cond.audio_encoder_attention_mask.to(device)
+        if cond.audio_encoder_attention_mask:
+            audio_mask = torch.cat(cond.audio_encoder_attention_mask).to(device)
             if audio_mask.ndim == 1:
                 audio_mask = audio_mask.unsqueeze(0)
             kwargs["audio_context_mask"] = audio_mask

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -113,8 +113,12 @@ def _parse_cond_kwargs(
             data.get("audio_encoder_hidden_states"),
             deserialize_func=deserialize_func,
         ),
-        encoder_attention_mask=deserialize_func(data.get("encoder_attention_mask")),
-        audio_encoder_attention_mask=deserialize_func(data.get("audio_encoder_attention_mask")),
+        encoder_attention_mask=_parse_tensor_or_list(
+            data.get("encoder_attention_mask"), deserialize_func=deserialize_func
+        ),
+        audio_encoder_attention_mask=_parse_tensor_or_list(
+            data.get("audio_encoder_attention_mask"), deserialize_func=deserialize_func
+        ),
         pooled_projections=_parse_tensor_or_list(data.get("pooled_projections"), deserialize_func=deserialize_func),
     )
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -30,8 +30,8 @@ class CondKwargs:
     img_shapes: list[list[tuple[int, int, int]]] | None = None
     encoder_hidden_states: list[torch.Tensor] | None = None
     audio_encoder_hidden_states: list[torch.Tensor] | None = None
-    encoder_attention_mask: torch.Tensor | None = None
-    audio_encoder_attention_mask: torch.Tensor | None = None
+    encoder_attention_mask: list[torch.Tensor] | None = None
+    audio_encoder_attention_mask: list[torch.Tensor] | None = None
     pooled_projections: list[torch.Tensor] | None = None
 
 


### PR DESCRIPTION
## What

- Parse `encoder_attention_mask` / `audio_encoder_attention_mask` from the rollout response as a **list over text encoders** (`_parse_tensor_or_list`), the same way `encoder_hidden_states`, `audio_encoder_hidden_states` and `pooled_projections` are already parsed.
- Type both fields as `list[torch.Tensor] | None` in `CondKwargs`.
- Update the LTX consumer to `torch.cat(cond.encoder_attention_mask)`, mirroring how it already consumes `encoder_hidden_states`.

## Why

sglang-diffusion's text-encoding stage emits every text-encoder output as a **list indexed by encoder**. Every other encoder-output field in `CondKwargs` already reflects this (`list[Tensor]`), but `encoder_attention_mask` / `audio_encoder_attention_mask` were typed and parsed as a single tensor via `deserialize_func(...)`.

That single-tensor assumption breaks any model whose response carries the mask as a list. Wan2.2 (standard text-encoding path, single UMT5 encoder) sends `encoder_attention_mask` as a length-1 list `[Tensor[1, 512]]`, which trips the parser:

```
TypeError: Cannot deserialize <class 'list'>
```

(the batch dimension is already sliced engine-side in `_extract_single_sample_tensor`, so the list is over encoders, not over batch).

Routing both mask fields through `_parse_tensor_or_list` normalizes the two response shapes — a bare serialized tensor (LTX, injected by its rollout monkey-patch) and a list of them (Wan) — into a single `list[Tensor]`, consistent with the sibling encoder fields. LTX's single tensor normalizes to a length-1 list, so `torch.cat(...)` reproduces its previous value and its behavior is unchanged.

## Files

- `miles/utils/types.py` — `encoder_attention_mask` / `audio_encoder_attention_mask` → `list[torch.Tensor] | None`.
- `miles/utils/diffusion_rollout_response.py` — parse both mask fields with `_parse_tensor_or_list`.
- `miles/backends/fsdp_utils/configs/ltx.py` — consume the mask list via `torch.cat`, mirroring `encoder_hidden_states`.

## Validation

- Reproduced end-to-end on a Wan2.2-T2V-A14B pickscore GRPO run: before the fix the rollout parser died with `Cannot deserialize <class 'list'>`; after it, the first rollout parses and training reaches optimization steps with valid GRPO metrics (`grad_norm`, `policy_loss`, `adv_abs_mean`), no parse/type errors.
- Wan does not read the mask downstream, so its numerics are unaffected; the LTX path change is a mechanical mirror of the existing `encoder_hidden_states` handling.

## Checklist

- [x] `pre-commit run` on the changed files passes — ruff / autoflake / isort / black all green (black wrapped the two `_parse_tensor_or_list` calls; folded into the commit)
- [ ] Added/updated tests for new behaviour — **not added** (existing `tests/fast/utils/test_diffusion_rollout_response.py` does not cover the mask; a list-shaped-mask case would be a good follow-up)
- [ ] `pytest -x` is green — **not run**
- [x] No launch flags changed
- [x] No public flag added
- [x] No example added

> Draft: opened for review of the approach (mask as per-encoder list) before adding a regression test and running the hooks.
