### PR TITLE
scripts: load ltx23 hf-checkpoint from the diffusion model

### DIFF
--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -35,7 +35,7 @@ fi
   --deterministic-mode \
   --rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout \
   --diffusion-model Lightricks/LTX-2.3 \
-  --hf-checkpoint gpt2 \
+  --hf-checkpoint Lightricks/LTX-2.3 \
   --prompt-data "${DATASETS_DIR}/flowgrpo_pickscore/train.jsonl" \
   --input-key input \
   --rollout-batch-size 8 \


### PR DESCRIPTION
## What

Point the LTX-2.3 recipe's `--hf-checkpoint` at the diffusion model
(`Lightricks/LTX-2.3`) instead of the `gpt2` placeholder.
