### PR TITLE
fix(wandb): upgrade wandb to fix missing system metrics

### DIFF
--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -111,11 +111,11 @@ def init_wandb_secondary(args, router_addr=None):
     if offline:
         settings_kwargs = dict(mode="offline")
     else:
+        # Keep stats on so GPU workers report per-GPU system metrics.
         settings_kwargs = dict(
             mode="shared",
             x_primary=False,
             x_update_finish_state=False,
-            x_disable_stats=True,
         )
 
     if getattr(args, "sglang_enable_metrics", False) and router_addr is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ tensorboard==2.20.0
 transformers==5.5.4
 typer==0.23.2
 uvicorn==0.39.0
-wandb==0.23.1
+wandb==0.28.1


### PR DESCRIPTION
## What

Upgrade `wandb` to fix missing W&B system metrics.

- `requirements.txt`: `wandb==0.23.1` → `wandb==0.28.1`.
- `miles/utils/wandb_utils.py`: drop `x_disable_stats=True` on secondaries.

## Why

Our W&B **System** panel logged far fewer metrics than `miles` core — most
visibly no `GPU SM Active (%)`. Two things were needed:

1. **Version.** The NVML GPM profiling metrics for Hopper+ GPUs
   (`SM Active`, tensor/FP-pipe activity, DRAM bandwidth, PCIe/NVLink
   throughput) are collected by wandb-core without a DCGM daemon, but the
   feature only shipped in **wandb 0.26.0** (wandb/wandb#11622). We were pinned
   to `0.23.1`, which predates it, so the metrics were never collected.

2. **Stats were disabled on the GPU workers.** GPM metrics are sampled on the
   process that owns the GPU. Our wandb primary is the CPU-only Ray driver, and
   every GPU worker inited as a secondary with `x_disable_stats=True`, so no
   process ever sampled GPU stats. `miles` core does not set this flag. Only the
   rank-0 actor and the rollout manager init as secondary, so re-enabling stats
   adds no duplicate per-node sampling.

`SM Active` requires Hopper+ (H100/H200) hardware.

## Status

Draft — the code change is verified (pre-commit green on the changed files),
but confirming the metrics actually appear needs an online run on H100/H200,
which hasn't been done yet.
