### PR TITLE
fix(rollout): pin sglang engine to base_gpu_id when CUDA_VISIBLE_DEVICES is unset

### DIFF
--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -167,6 +167,8 @@ class SGLangDiffusionEngine(RayActor):
             return
         cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
         if not cvd:
+            # No ambient device list (full-node multi-node ray start): pin to the physical GPU.
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(self.base_gpu_id)
             return
         visible = [x.strip() for x in cvd.split(",") if x.strip()]
         local_idx = _to_local_gpu_id(self.base_gpu_id)


### PR DESCRIPTION
## What

When `CUDA_VISIBLE_DEVICES` is unset, `_pin_to_assigned_gpu` now pins the sglang engine directly to its `base_gpu_id` instead of returning early (which left the engine unpinned).

## Why

Under `--colocate`, each rollout engine must pin to its assigned physical GPU. `_pin_to_assigned_gpu` read `CUDA_VISIBLE_DEVICES` and returned early when it was empty, so if Ray is started full-node without `CUDA_VISIBLE_DEVICES` (e.g. `ray start --num-gpus 8`, the way core miles multi-node recipes bring Ray up), every engine on a node fell back to GPU 0 and OOM'd. `_to_local_gpu_id` already handles the empty-`CUDA_VISIBLE_DEVICES` case (returns the physical id); this aligns `_pin_to_assigned_gpu` with it. `base_gpu_id` is the per-node physical GPU index the engine is placed on (from the placement group's reordered bundle ids), so pinning to it is correct on every node.

## Files

- `miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py` — pin to `base_gpu_id` when `CUDA_VISIBLE_DEVICES` is unset.

## Checklist

- [x] `pre-commit run` on the changed file passes
- [ ] Added/updated tests for new behaviour — **not added**
- [ ] `pytest -x` is green — **not run**
- [x] No launch flags changed
- [x] No public flag added
