### PR TITLE
feat(rollout): colocate reward actors onto rollout GPUs via --colocate-reward

### DIFF
--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -124,8 +124,7 @@ def allocate_train_group(args, num_nodes, num_gpus_per_node, pg):
         num_nodes=num_nodes,
         num_gpus_per_node=num_gpus_per_node,
         pg=pg,
-        # Diffusion training is GPU-heavy; avoid fractional-GPU scheduling stalls.
-        num_gpus_per_actor=0.8,
+        num_gpus_per_actor=0.7,
     )
 
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -14,6 +14,7 @@ from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 
 from miles.backends.sglang_diffusion_utils.sglang_diffusion_engine import SGLangDiffusionEngine
 from miles.rollout.base_types import call_rollout_fn
+from miles.rollout.rm_hub.core import set_reward_placement_group
 from miles.utils import tracking_utils
 from miles.utils.health_monitor import RolloutHealthMonitor
 from miles.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -45,6 +46,7 @@ class RolloutManager:
         logger.info("RolloutManager init start")
         self.args = args
         self.pg = pg
+        set_reward_placement_group(pg)
         logger.info("RolloutManager: starting router...")
         _start_router(args)
         logger.info("RolloutManager: router started, init tracking...")
@@ -465,7 +467,8 @@ def init_rollout_engines(args, pg, all_rollout_engines):
         if all_rollout_engines[i] is not None:
             continue
 
-        num_gpus = 0.2
+        # Leave 0.05 for a colocated reward actor when --colocate-reward is set.
+        num_gpus = 0.25 if args.colocate_reward else 0.3
         num_cpus = num_gpus
 
         # Get the base GPU ID from placement group

--- a/miles/rollout/rm_hub/core.py
+++ b/miles/rollout/rm_hub/core.py
@@ -1,0 +1,84 @@
+"""Shared building blocks for asynchronous reward actor pools."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+_reward_placement_group = None
+logger = logging.getLogger(__name__)
+
+
+def set_reward_placement_group(pg) -> None:
+    global _reward_placement_group
+    _reward_placement_group = pg
+
+
+def get_reward_placement_group():
+    return _reward_placement_group
+
+
+class AsyncRewardActorPool:
+    """Round-robin pool for Ray reward actors exposing ``score_batch``."""
+
+    def __init__(
+        self,
+        *,
+        actor_cls,
+        actor_kwargs: dict,
+        num_workers: int,
+        batch_size: int,
+        num_gpus_per_worker: float,
+        colocate: bool,
+        name: str,
+    ) -> None:
+        if colocate:
+            pg, bundle_indices, _ = get_reward_placement_group()
+            strategies = [
+                PlacementGroupSchedulingStrategy(
+                    placement_group=pg,
+                    placement_group_bundle_index=bundle_indices[w],
+                )
+                for w in range(num_workers)
+            ]
+            num_gpus_per_worker = 0.05
+            num_cpus_per_worker = 0.05
+        else:
+            strategies = ["DEFAULT"] * num_workers
+            num_cpus_per_worker = 1
+
+        self._actors = [
+            actor_cls.options(
+                num_cpus=num_cpus_per_worker,
+                num_gpus=num_gpus_per_worker,
+                scheduling_strategy=strategies[i],
+            ).remote(**actor_kwargs)
+            for i in range(num_workers)
+        ]
+        self._batch_size = batch_size
+        self._round_robin_index = 0
+        logger.info(
+            "Initialized %s actor pool with %d workers, %.3f GPUs/worker, batch_size=%d.",
+            name,
+            num_workers,
+            num_gpus_per_worker,
+            batch_size,
+        )
+
+    def _next_actor(self):
+        actor = self._actors[self._round_robin_index % len(self._actors)]
+        self._round_robin_index += 1
+        return actor
+
+    async def score(self, images: list, prompts: list[str]) -> list[float]:
+        refs = []
+        for start in range(0, len(images), self._batch_size):
+            end = start + self._batch_size
+            refs.append(self._next_actor().score_batch.remote(images[start:end], prompts[start:end]))
+
+        loop = asyncio.get_running_loop()
+        chunked_scores = await loop.run_in_executor(None, ray.get, refs)
+        return [float(score) for chunk in chunked_scores for score in chunk]

--- a/miles/rollout/rm_hub/pickscore.py
+++ b/miles/rollout/rm_hub/pickscore.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import logging
 from collections.abc import Sequence
 
 import numpy as np
@@ -13,7 +11,7 @@ from miles.utils.misc import SingletonMeta
 from miles.utils.processing_utils import cfhw_to_fhwc, image_or_video_to_uint8
 from miles.utils.types import Sample
 
-logger = logging.getLogger(__name__)
+from .core import AsyncRewardActorPool
 
 
 def sample_frame_indices(num_total_frames: int, num_frames: int | None) -> list[int]:
@@ -115,46 +113,22 @@ class PickScoreRewardActor:
         return self.scorer(prompts, pil_images)
 
 
-class AsyncPickScorePool(metaclass=SingletonMeta):
+class AsyncPickScorePool(AsyncRewardActorPool, metaclass=SingletonMeta):
     """Ray actor pool for GPU PickScore reward inference."""
 
     def __init__(self, args) -> None:
-        num_workers = args.pickscore_num_workers
-        num_gpus_per_worker = args.pickscore_num_gpus_per_worker
-        self._batch_size = args.pickscore_batch_size
-        self._actors = [
-            PickScoreRewardActor.options(
-                num_cpus=1,
-                num_gpus=num_gpus_per_worker,
-                scheduling_strategy="DEFAULT",
-            ).remote(
-                processor_path=args.pickscore_processor_path,
-                model_path=args.pickscore_model_path,
-            )
-            for _ in range(num_workers)
-        ]
-        self._round_robin_index = 0
-        logger.info(
-            "Initialized PickScore actor pool with %d workers, %.3f GPUs/worker, batch_size=%d.",
-            num_workers,
-            num_gpus_per_worker,
-            self._batch_size,
+        super().__init__(
+            actor_cls=PickScoreRewardActor,
+            actor_kwargs={
+                "processor_path": args.pickscore_processor_path,
+                "model_path": args.pickscore_model_path,
+            },
+            num_workers=args.pickscore_num_workers,
+            batch_size=args.pickscore_batch_size,
+            num_gpus_per_worker=args.pickscore_num_gpus_per_worker,
+            colocate=args.colocate_reward,
+            name="PickScore",
         )
-
-    def _next_actor(self):
-        i = self._round_robin_index % len(self._actors)
-        self._round_robin_index += 1
-        return self._actors[i]
-
-    async def score(self, images: list, prompts: list[str]) -> list[float]:
-        refs = []
-        for start in range(0, len(images), self._batch_size):
-            end = start + self._batch_size
-            refs.append(self._next_actor().score_batch.remote(images[start:end], prompts[start:end]))
-
-        loop = asyncio.get_running_loop()
-        chunked_scores = await loop.run_in_executor(None, ray.get, refs)
-        return [float(score) for chunk in chunked_scores for score in chunk]
 
 
 async def pickscore_rm(args, samples: Sequence[Sample]) -> list[float]:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1145,7 +1145,15 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--pickscore-num-gpus-per-worker",
                 type=float,
                 default=1.0,
-                help="GPU resources per PickScore actor. Use 1.0 for a dedicated GPU smoke test.",
+                help="GPU resources per PickScore actor when reward is not colocated. "
+                "Use a fractional value below 1.0 for lightweight single-GPU reward models.",
+            )
+            parser.add_argument(
+                "--colocate-reward",
+                action="store_true",
+                default=False,
+                help="Colocate reward actors onto rollout GPUs (train 0.7 + rollout 0.25 + reward 0.05). "
+                "Requires --colocate.",
             )
             parser.add_argument(
                 "--pickscore-batch-size",
@@ -1464,6 +1472,15 @@ def miles_validate_args(args):
         args.offload_train = False
     if args.offload_rollout is None:
         args.offload_rollout = False
+
+    if args.colocate_reward:
+        assert args.colocate, "--colocate-reward requires --colocate."
+        num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
+        num_engines = args.rollout_num_gpus // num_gpu_per_engine
+        assert args.pickscore_num_workers <= num_engines, (
+            f"--colocate-reward requires pickscore_num_workers ({args.pickscore_num_workers}) "
+            f"<= rollout engines ({num_engines})."
+        )
 
     if args.eval_function_path is None:
         args.eval_function_path = args.rollout_function_path


### PR DESCRIPTION
Add `--colocate-reward` to run the PickScore reward actor on the rollout GPUs instead of a dedicated card.

Per colocated GPU: train 0.7 + rollout 0.25 + reward 0.05 = 1.0. The rollout placement group is handed to the reward pool (`rm_hub/core.py`) and each reward actor is pinned into a rollout-engine bundle via `PlacementGroupSchedulingStrategy`. Off by default; requires `--colocate`.

Verified on the Qwen-Image pickscore recipe (H200, `--deterministic-mode`): first-2-step reward is bitwise-equal between colocate and same-code non-colocate runs, and reproducible across two identical colocate runs.