### PR TITLE
ci(ltx): LTX recipe to 4-GPU with colocated reward

### DIFF
--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# LTX-2.3 video PickScore GRPO: 4-GPU FSDP train + sglang rollout colocate, 1-GPU pickscore.
+# LTX-2.3 video PickScore GRPO: 4-GPU FSDP train + sglang rollout + colocated pickscore reward.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3,4}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1,2,3}"
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 RUN_NAME="diffusion_grpo_ltx23_pickscore_$(date +%Y%m%d_%H%M%S)"
 SAVE_DIR="${ROOT_DIR}/logs/${RUN_NAME}/ckpt"
@@ -48,6 +48,7 @@ fi
   --diffusion-microgroup-size 1 \
   --gradient-checkpointing \
   --colocate \
+  --colocate-reward \
   --actor-num-gpus-per-node 4 \
   --actor-num-nodes 1 \
   --num-gpus-per-node 4 \


### PR DESCRIPTION
## What
- Switch the LTX-2.3 PickScore GRPO recipe from 5 GPUs (4 train+rollout + 1 dedicated pickscore) to 4 GPUs with `--colocate-reward`: the reward actor rides the rollout GPUs (per GPU: train 0.7 + rollout 0.25 + reward 0.05).
- This recipe is exactly what the LTX e2e CI runs (`tests/e2e/short/test_ltx23_pickscore_grpo_4xGPU.py`, suite `stage-c-5-gpu-h200`).

## Why
- Frees the dedicated pickscore GPU (5 → 4) at no numerical cost: the PickScore reward model is light and the dedicated card sat mostly idle.
- Stacked on #61 (the `--colocate-reward` feature). Base retargets to `main` once #61 merges.

## Validation
Benchmark: `--colocate-reward` ON vs OFF, LTX-2.3 pickscore recipe, `--deterministic-mode`, dedicated H200 node, 5 rollouts each.

| config | GPUs | rollout_time median (skip step0) | reward raw_mean |
|---|---|---|---|
| OFF (`--colocate-reward` off) | 5 (4 train+rollout + 1 dedicated pickscore) | 99.1s | reference |
| ON (`--colocate-reward` on) | 4 (train 0.7 + rollout 0.25 + reward 0.05) | 97.8s | bitwise-identical to OFF, all 5 steps |

- **GPUs: 5 → 4** (−20%), the point of the change.
- **Reward is bitwise-identical** ON vs OFF across all 5 rollout steps → `--colocate-reward` is numerically transparent. Since the LTX e2e standard asserts reward/loss/grad, the recorded standard is expected to still hold under colocate (CI on this PR is the check).
- **No measurable timing regression**: the ~1s median delta is within run-to-run noise, not a speedup.
- Wall-clock per-step timing is inherently noisy on CI because the CI H200 node is shared between concurrent 3-gpu/5-gpu runner splits (`tests/ci/run_suite.py`); the e2e standard never asserts timing, only the deterministic metrics.

## Files
- `scripts/run-diffusion-grpo-ltx23-sglang.sh` — default `CUDA_VISIBLE_DEVICES` 5→4 GPUs, add `--colocate-reward`, update header comment.

## Checklist
- [ ] `pre-commit run --all-files` passes — **not run locally** (the PR's `Run pre-commit` CI check covers it)
- [x] Added/updated tests for new behaviour — no new test; the existing LTX e2e (`test_ltx23_pickscore_grpo_4xGPU`) already exercises this recipe and its recorded standard is the check
- [ ] `pytest -x` is green — **not run locally**; the LTX e2e (GPU) runs in CI on this PR, **not yet confirmed green**
- [x] If launch flags changed, `--help` still parses — no new flag in this PR (script-only); `--colocate-reward` itself lands in #61
- [x] If a public flag was added, it appears in the CLI reference docs — N/A, no new flag here
- [x] If an example was added, it has a real walkthrough — this is the example recipe; ON-vs-OFF validation above
