### PR TITLE
fix(rollout): make engine port range start configurable via MILES_ROLLOUT_START_PORT

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import multiprocessing
+import os
 import random
 import time
 from pathlib import Path
@@ -547,7 +548,10 @@ def _allocate_rollout_engine_addr_and_ports_normal(*, args, num_engines, rollout
         def get_addr_and_ports(engine):
             # use small ports to prevent ephemeral port between 32768 and 65536.
             # also, ray uses port 10002-19999, thus we avoid near-10002 to avoid racing condition
-            start_port = 15000
+            # MILES_ROLLOUT_START_PORT: shift the range so concurrent miles runs
+            # on one host don't collide (the free-port probe can miss servers
+            # bound to a specific interface).
+            start_port = int(os.environ.get("MILES_ROLLOUT_START_PORT", "15000"))
 
             def port(consecutive=1):
                 nonlocal start_port


### PR DESCRIPTION
## Problem

Engine port allocation scans upward from a hardcoded `15000`, and the free-port probe misses servers bound to a specific interface (rather than `0.0.0.0`). When two miles runs share a host, both claim the same port range: the second run's trainer connects to the first run's sglang engines and sends weight sync there, surfacing as an unrelated-looking `Invalid device_uuid` error mid-training.

## Fix

Make the scan start configurable via `MILES_ROLLOUT_START_PORT` so concurrent runs on one host can use disjoint ranges (e.g. `export MILES_ROLLOUT_START_PORT=16000` for the second run). Default stays `15000` — behavior is unchanged unless the variable is set.

Split out of the cosmos3 branch: this is host-level ops, orthogonal to any model adaptation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)