### PR TITLE
fix(fsdp): serialize weight-sync buckets only on the gather src to stop CUDA-IPC pinning

### DIFF
--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -106,6 +106,7 @@ class DiffusionUpdateWeight(abc.ABC):
         self.args = args
         self.models = models
         self.weight_version = 0
+        self._sync_bucket_count = 0
 
     @abc.abstractmethod
     def connect_rollout_engines(
@@ -206,6 +207,10 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
         weight_version=None,
         weight_update_mode: str | None = None,
     ) -> None:
+        # Serializing pins the storage until the payload is deserialized somewhere and released;
+        # only the src rank's payload is ever consumed, so no other rank may serialize.
+        if dist.get_rank() != self._ipc_gather_src:
+            return
         monkey_patch_torch_reductions()
         logger.info("Using flattened tensor bucket (diffusion updater, module=%s)", target_module)
         named_tensors_by_dtypes = {}
@@ -215,7 +220,6 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
                 named_tensors_by_dtypes[dtype] = []
             named_tensors_by_dtypes[dtype].append((name, tensor))
 
-        serialized_tensors = []
         for _dtype, named_tensors in named_tensors_by_dtypes.items():
             flattened_tensor_bucket = FlattenedTensorBucket(named_tensors=named_tensors)
             metadata = flattened_tensor_bucket.get_metadata()
@@ -230,37 +234,28 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
                     "metadata": metadata,
                 }
             }
-            serialized_tensors.append(MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True))
+            kwargs = {
+                "serialized_named_tensors": [
+                    MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True)
+                ],
+                "load_format": "flattened_bucket",
+                "target_modules": [target_module],
+                "weight_version": str(weight_version),
+            }
+            if weight_update_mode is not None:
+                kwargs["weight_update_mode"] = weight_update_mode
+                kwargs["lora_alpha"] = self.args.lora_alpha
+                kwargs["lora_rank"] = self.args.lora_rank
+            ref = self._ipc_engine.update_weights_from_tensor.remote(**kwargs)
+            ray.get(ref)
 
-        if self._ipc_gather_src == dist.get_rank():
-            gathered_serialized_batches = [None for _ in range(dist.get_world_size(self._ipc_gather_group))]
-        else:
-            gathered_serialized_batches = None
-
-        dist.gather_object(
-            obj=serialized_tensors,
-            object_gather_list=gathered_serialized_batches,
-            dst=self._ipc_gather_src,
-            group=self._ipc_gather_group,
-        )
-
-        if dist.get_rank() == self._ipc_gather_src:
-            # TODO: here we assume all ranks have the same number of dtypes.
-            num_dtypes = len(gathered_serialized_batches[0])
-            assert num_dtypes > 0
-            for i in range(num_dtypes):
-                kwargs = {
-                    "serialized_named_tensors": [tensors[i] for tensors in gathered_serialized_batches],
-                    "load_format": "flattened_bucket",
-                    "target_modules": [target_module],
-                    "weight_version": str(weight_version),
-                }
-                if weight_update_mode is not None:
-                    kwargs["weight_update_mode"] = weight_update_mode
-                    kwargs["lora_alpha"] = self.args.lora_alpha
-                    kwargs["lora_rank"] = self.args.lora_rank
-                ref = self._ipc_engine.update_weights_from_tensor.remote(**kwargs)
-                ray.get(ref)
+        self._sync_bucket_count += 1
+        if self._sync_bucket_count % 16 == 1:
+            logger.info(
+                "[wsync-mem] bucket=%d allocated=%.2fGB",
+                self._sync_bucket_count,
+                torch.cuda.memory_allocated() / 2**30,
+            )
 
 
 # TODO: update weights only for sgl-d LoRA params


### PR DESCRIPTION
## Problem

`MultiprocessingSerializer.serialize` pins a CUDA storage **at serialize time**: the producer-side reduction exports an IPC handle and accounts for the in-flight message, and the pin is released only after the payload is deserialized somewhere and that object dies. A payload that is never deserialized pins its storage forever — `torch.cuda.ipc_collect()` cannot reclaim it. Verified with a no-consumer probe: serialize-and-discard leaks the full bucket every time, with `ipc_collect` running every bucket.

`update_bucket_weights` serializes every bucket on **every rank of the gather group**, then sends the collected payloads to the engine. All ranks hold identical full weights after the all-gather, so at most one copy is ever needed; the transport silently relies on the engine deserializing every copy it produces. The moment payload count exceeds what the engine consumes, the extras pin one flattened bucket (~2GB) per bucket per rank, permanently. That is what happened during the 64B bring-up (TP-2 engines, single-payload form): the non-consumed ranks leaked one model's worth of memory per sync and the trainer OOMed three times at the same allocation, 67.5GB ≈ 34 buckets, only on those ranks. Even in configurations where the counts happen to match, serializing N identical copies is pure redundant work.

## Fix

Only the gather src serializes and talks to the engine; other ranks return after their collective all-gather work. This makes the invariant structural: the only payload ever produced is the one the engine consumes. The `gather_object` step is deleted outright — it existed to collect N identical copies of the same bytes. Each dtype group is serialized and synchronously consumed (`ray.get`) one at a time, so at most one payload is in flight. The engine side already supports single-payload requests regardless of its TP size (`serialized_named_tensors` of length 1 or tp_size; workers replicate internally).

Also logs trainer `memory_allocated` every 16 buckets (`[wsync-mem]`), so any future pinning regression shows up as a rising line instead of a mystery OOM.

## Benchmarks

Mechanism probes (2GB bf16 buckets, single H200, `ipc_collect` every bucket):

| scenario | trainer memory |
|---|---|
| serialize, payload never deserialized (pre-fix non-consumed rank) | +2GB/bucket, unbounded — the production signature |
| serialize, consumer deserializes and releases | flat |

This PR, real `update_bucket_weights` over ray against a consumer replicating the sgl-d flattened-bucket path, 12 buckets, payload checksums verified:

| path | result |
|---|---|
| src rank, engine releases per call (current sgl-d behavior) | flat, 57 ms/bucket |
| non-src rank | no serialization at all: 0 GB, ~0 ms |
| mixed bf16+fp32 buckets | correct, zero NaNs (payloads never share memory) |
| src rank, engine hypothetically retaining every payload | leaks by design of CUDA IPC; not defended — the engine releases within the call frame today, and `[wsync-mem]` flags any regression |

In the real 64B run the previous revision of this fix took a full 128GB sync from OOM to a flat `[wsync-mem]` line; this revision removes the leaked payloads at the source instead of parking them in a persistent staging buffer.

## Notes

1-GPU-per-engine layouts (every rank is a gather src) never produced orphaned payloads, which is why smaller runs hid this. An earlier revision of this PR bounded the exposure with a persistent staging buffer; superseded by not producing unconsumed payloads in the first place.