### PR TITLE
ci(docker): build the CI image on the PR and run the GPU matrix inside it

### DIFF
--- a/.github/workflows/docker-pr-tag-cleanup.yml
+++ b/.github/workflows/docker-pr-tag-cleanup.yml
@@ -1,0 +1,29 @@
+name: Docker PR tag cleanup
+
+# Deletes the `pr-<num>` tag that pr-test.yml's docker-build job pushed.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  delete-pr-tag:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          TOKEN=$(python3 -c "
+          import json, urllib.request
+          req = urllib.request.Request('https://hub.docker.com/v2/users/login/',
+              data=json.dumps({'username': '${{ secrets.DOCKERHUB_USERNAME }}',
+                               'password': '${{ secrets.DOCKERHUB_TOKEN }}'}).encode(),
+              headers={'Content-Type': 'application/json'})
+          print(json.load(urllib.request.urlopen(req))['token'])")
+          curl -s -X DELETE \
+            -H "Authorization: JWT ${TOKEN}" \
+            "https://hub.docker.com/v2/repositories/rockdu/miles_diffusion/tags/pr-${{ github.event.pull_request.number }}/" \
+            || true

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,6 +9,7 @@ name: PR Test
 #   * `resolve-ci-image` resolves a `rockdu/miles_diffusion:<tag>`
 #     container (default `latest`), overridable via the `ci-image-tag:`
 #     PR-body line or the `ci_image_tag` dispatch input.
+#   * `docker-paths` + `docker-build` build a `pr-<num>` image on docker PRs.
 #   * `ci_megatron_pr` workflow_dispatch input removed — miles-D source has
 #     zero `from megatron` imports.
 #   * No `schedule` trigger yet (miles main runs a nightly full CI).
@@ -50,8 +51,68 @@ concurrency:
 # every enabled test in the suite.
 
 jobs:
+  # Nothing rebuilds the CI image for a PR, so a docker PR would otherwise be tested inside the old `latest`.
+  docker-paths:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: diff
+        shell: bash
+        run: |
+          git fetch --depth 1 origin "${{ github.event.pull_request.base.sha }}"
+          # Assigned outside the `if` so a failed diff fails the step instead of reading as no change.
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
+          # Same paths as docker-build.yml's post-merge filter.
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(docker/Dockerfile|requirements\.txt)$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Docker PRs: build the image first, then run every GPU suite inside it.
+  docker-build:
+    needs: [docker-paths]
+    if: needs.docker-paths.outputs.changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
+    timeout-minutes: 180
+    steps:
+      # Container CI jobs leave root-owned files in the shared workspace; reclaim it before checkout cleans.
+      - name: Fix workspace ownership
+        run: docker run --rm -v "${{ github.workspace }}:/ws" alpine:3 chown -R "$(id -u):$(id -g)" /ws
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          IMAGE="rockdu/miles_diffusion:pr-${{ github.event.pull_request.number }}"
+          # --no-cache --pull: the Dockerfile fetches branch tips, so cached layers would pin stale sources.
+          docker build --no-cache --pull -f docker/Dockerfile . -t "${IMAGE}"
+          docker push "${IMAGE}"
+
+      # Each no-cache build leaves a full new layer set locally; keep the runner disk from filling up.
+      - name: Prune local build leftovers
+        if: always()
+        run: docker image prune -f
+
   resolve-ci-image:
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    needs: [docker-build]
+    # A failed build must skip this job so the GPU stages' `success` guard stops the matrix.
+    if: |
+      always() && !cancelled() &&
+      (needs.docker-build.result == 'success' || needs.docker-build.result == 'skipped') &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     runs-on: ubuntu-latest
     outputs:
       container_image: ${{ steps.resolve.outputs.container_image }}
@@ -62,8 +123,12 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
           INPUT_CI_IMAGE_TAG: ${{ github.event.inputs.ci_image_tag || '' }}
+          DOCKER_BUILT: ${{ needs.docker-build.result == 'success' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         run: |
           CI_IMAGE_TAG="${INPUT_CI_IMAGE_TAG}"
+          # A freshly built PR image outranks the `ci-image-tag:` directive.
+          [ -z "$CI_IMAGE_TAG" ] && [ "$DOCKER_BUILT" = "true" ] && CI_IMAGE_TAG="pr-${PR_NUMBER}"
           if [ -n "$PR_BODY" ]; then
             PR_CI_IMAGE_TAG=$(echo "$PR_BODY" | grep -m1 -oP '^ci-image-tag:\s+\K\S+' || true)
             [ -z "$CI_IMAGE_TAG" ] && [ -n "$PR_CI_IMAGE_TAG" ] && CI_IMAGE_TAG="$PR_CI_IMAGE_TAG"

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,15 @@ just build-local
 Builds `radixark/miles-diffusion:<version>-local` locally without pushing.
 (`<version>` is read from `docker/version.txt`.)
 
+## PR build check (in `pr-test.yml`)
+
+A PR touching `docker/Dockerfile` or `requirements.txt` builds and pushes
+`rockdu/miles_diffusion:pr-<num>` (`docker-paths` then `docker-build`), and every GPU
+suite then runs inside it instead of `latest`; a failed build stops the matrix.
+The fresh build outranks a `ci-image-tag:` PR-body directive.
+`docker-pr-tag-cleanup.yml` deletes the tag when the PR closes. Fork PRs skip the
+build and stay on `latest`.
+
 ## Release rule
 
 _TBD._


### PR DESCRIPTION
## What

A PR touching `docker/Dockerfile` or `requirements.txt` now builds and pushes
`rockdu/miles_diffusion:pr-<num>`, and every GPU suite runs inside that image instead of
`latest`. A failed build leaves `resolve-ci-image` skipped, which stops the GPU matrix.
`docker-pr-tag-cleanup.yml` drops the tag when the PR closes. Fork PRs skip the build and
stay on `latest`; non-docker PRs are unaffected.

Ported from radixark/miles #1791.

## Why

`docker-build.yml` runs only after the merge, and the GPU suites install the PR source with
`pip install -e . --no-deps` (`_run-ci.yml`), so a bumped pin never reaches the container.
The in-flight `diffusers` 0.37.0 -> 0.38.0 bump is the concrete case: only the CPU stages
would see the new pin, every GPU test would keep importing 0.37.0.

## Files

- `.github/workflows/pr-test.yml` — `docker-paths` + `docker-build` jobs; `resolve-ci-image`
  gains the build gate and the `pr-<num>` precedence rule
- `.github/workflows/docker-pr-tag-cleanup.yml` — new
- `docker/README.md` — short note on the flow

## One divergence from miles

`docker-paths` assigns the diff to a variable before testing it. In miles the `git diff` sits
in the `if` condition, where bash suspends errexit — a failing diff reads as "no docker
change", the build is skipped and the matrix silently runs on the stale image. Assigning
first turns that into a red `docker-paths`.

Note this only makes the failure loud, it does not gate on it: if `docker-paths` fails,
`docker-build` is skipped and `resolve-ci-image` still resolves `latest`. The PR is red, so it
should not be mergeable, and I did not add a second guard for it.

## Validation

- `pre-commit run --files <changed files>` passes.
- Path filter checked locally against real diffs: the `diffusers` 0.38.0 branch
  (`requirements.txt`) matches; this branch matches nothing, so `docker-build` skips.
- Failure path checked locally: a bad base sha now exits 128 instead of printing
  `changed=false`.
- Previous push of this branch ran the full matrix on the non-docker path: `docker-paths`
  success, `docker-build` skipped, `resolve-ci-image` success, stage-a/stage-b CPU green,
  `stage-b-3-gpu-h200` green.
- **The build path itself is not exercised here** — this PR touches no image-content path.
  First real exercise is the `diffusers` 0.38.0 bump PR.

## Checklist

- [x] `pre-commit run --all-files` passes — run scoped to the changed files
- [ ] Added/updated tests for new behaviour — **no tests added**: the change is Actions job
      graph + `if:` expressions, which this repo has no harness for
- [ ] `pytest -x` is green — **not run**: no Python touched
- [ ] If launch flags changed, `python3 train.py --help` still parses — n/a
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a
- [ ] If an example was added, it has a real walkthrough — n/a
