### PR TITLE
ci: chain stage-a to stage-b to stage-c via a fan-in job

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -157,6 +157,7 @@ jobs:
   # CPU tests that don't fit stage-a-cpu's fast budget). Always runs on PR.
   # Empty result exits 0 in run_suite.py.
   stage-b-cpu:
+    needs: [stage-a-cpu]
     if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
@@ -167,16 +168,11 @@ jobs:
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
     secrets: inherit
 
-  # Stage B GPU: fast-gpu bucket, gates nothing yet but runs on every PR
-  # once stage-a-cpu is green (fast-fail: broken imports shouldn't burn GPU
-  # runner slots).
+  # Stage B GPU: fast-gpu bucket, runs once stage-a-cpu is green (fast-fail:
+  # broken imports shouldn't burn GPU runner slots).
   stage-b-3-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
-    if: |
-      always() && !cancelled() &&
-      needs.resolve-ci-image.result == 'success' &&
-      needs.stage-a-cpu.result == 'success' &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
       # Suite names match the runner split: 3gpu (GPUs 0-2) + 5gpu (GPUs 3-7).
@@ -188,16 +184,17 @@ jobs:
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
     secrets: inherit
 
+  # Fan-in so each stage-c needs one job instead of every stage-b.
+  stage-b:
+    needs: [stage-b-cpu, stage-b-3-gpu-h200]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   # Stage C GPU (3gpu runner): e2e suite for the 2-GPU SD3.5 OCR recipe.
-  # Shares the 3gpu runner with stage-b, so the two queue rather than run
-  # concurrently — acceptable for a 2-rollout smoke e2e.
   stage-c-3-gpu-h200:
-    needs: [resolve-ci-image, stage-a-cpu]
-    if: |
-      always() && !cancelled() &&
-      needs.resolve-ci-image.result == 'success' &&
-      needs.stage-a-cpu.result == 'success' &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+    needs: [resolve-ci-image, stage-b]
+    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "3gpu"]'
@@ -208,15 +205,10 @@ jobs:
         ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
     secrets: inherit
 
-  # Stage C GPU: e2e suite. A 2-gpu e2e runs on the 5gpu runner so it
-  # parallelizes with stage-b fast tests on the 3gpu runner.
+  # Stage C GPU: e2e suite on the 5gpu runner.
   stage-c-5-gpu-h200:
-    needs: [resolve-ci-image, stage-a-cpu]
-    if: |
-      always() && !cancelled() &&
-      needs.resolve-ci-image.result == 'success' &&
-      needs.stage-a-cpu.result == 'success' &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+    needs: [resolve-ci-image, stage-b]
+    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "5gpu"]'


### PR DESCRIPTION
## What

Chain the stages: stage-a -> stage-b -> stage-c.

- `stage-b-cpu` gains `needs: [stage-a-cpu]` (it ran unconditionally before).
- New `stage-b` fan-in job needs both stage-b jobs; each stage-c needs `stage-b` instead of
  listing them. Adding a stage-b job is one line in the fan-in, adding a stage-c job does not
  touch stage-b at all.
- The `always() && !cancelled() && needs.<job>.result == 'success'` blocks are gone from the
  stage jobs. That is the default `needs` behaviour written out by hand; `resolve-ci-image`
  still needs it because `docker-build` is legitimately skipped on non-docker PRs.

## Why

stage-c is the expensive tier -- two multi-GPU e2e runs on a two-runner node -- and it started
as soon as stage-a-cpu was green, so a red fast-gpu bucket did not stop it.

## Cost

`stage-c-5-gpu-h200` used to run on the 5gpu runner in parallel with `stage-b-3-gpu-h200` on
the 3gpu runner, so a fully green PR is now slower by about one stage-b. Less wall-clock on
green PRs, no wasted e2e on red ones.

## Paths, for reviewers

| situation | result |
| --- | --- |
| stage-a-cpu fails | stage-b jobs skipped, `stage-b` skipped, both stage-c skipped |
| stage-b-3-gpu-h200 fails | `stage-b` skipped, both stage-c skipped |
| docker-build fails (#66 path) | `resolve-ci-image` skipped, everything downstream skipped |
| workflow_dispatch | `resolve-ci-image` still succeeds via its own `always()`, chain runs in full |

## Files

- `.github/workflows/pr-test.yml` -- `needs` edits on four jobs, one new fan-in job

## Checklist

- [x] `pre-commit run --all-files` passes -- run scoped to the changed file
- [ ] Added/updated tests for new behaviour -- **no tests added**: Actions `needs` graph, no
      harness for it in this repo
- [ ] `pytest -x` is green -- **not run**: no Python touched
- [ ] If launch flags changed, `python3 train.py --help` still parses -- n/a
- [ ] If a public flag was added, it appears in the CLI reference docs -- n/a
- [ ] If an example was added, it has a real walkthrough -- n/a
