### PR TITLE
chore(deps): bump diffusers to 0.38.0 and safetensors to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate==1.12.0
 addict==2.4.0
 blobfile==3.0.0
 datasets==4.4.2
-diffusers==0.37.0
+diffusers==0.38.0
 fastapi==0.128.8
 httpx[http2]==0.28.1
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@780984275fd47128b02bef9b5c085404276866ee#subdirectory=packages/ltx-core
@@ -26,7 +26,7 @@ qwen_vl_utils==0.0.14
 ray[default]==2.53.0
 requests==2.32.5
 ring_flash_attn==0.1.8
-safetensors==0.7.0
+safetensors==0.8.0
 sglang-router==0.3.0
 tensorboard==2.20.0
 transformers==5.5.4


### PR DESCRIPTION
## What

`diffusers` 0.37.0 -> 0.38.0, and `safetensors` 0.7.0 -> 0.8.0 with it.

`safetensors` is not optional here: diffusers 0.38.0 requires `safetensors>=0.8.0-rc.0`, so
leaving the old pin fails resolution both in the Docker build and in the CPU stages.

## Why 0.38.0

FlashAttention4, whose deterministic mode is super fast.

## Why 0.38.0 is safe for the private APIs we use

Compared the two wheels file by file. Everything miles-D reaches into is unchanged:

| what we use | 0.38.0 |
| --- | --- |
| `models/attention_dispatch.py` flash module globals (`arguments.py`) | same names, same location; 0.38 only adds a ring-anything backend and a flash-4 hub entry |
| `dispatch_attention_fn` signature (the USP wrapper binds it) | byte-identical |
| `models/_modeling_parallel.ContextParallelOutput` (`plan.py`) | still there; 0.38 adds `ring_anything` and a custom `mesh` field |
| `_keep_in_fp32_modules`, `low_cpu_mem_usage`, `torch_dtype` (`model_backend.py`) | all present; `modeling_utils.py` changes are an additive flashpack path |
| `transformer_sd3.py`, flow-match euler scheduler | zero diff |
| `QwenEmbedRope` | caches the device transfer behind `lru_cache_unless_export`; freqs are still built on CPU at init, so values are unchanged |

Legacy pipelines (amused, unclip, wuerstchen, text_to_video_synthesis, ...) moved to
`pipelines/deprecated/`, but the top-level exports are intact and we do not import them.

`transformer_qwenimage.py` gained `joint_attention_mask = joint_attention_mask[:, None, None, :]`
before dispatch. This is numerically inert for both backends we run: `_native_attention` already
performed the identical `unsqueeze(1).unsqueeze(1)` on a 2D mask in 0.37 (that hunk is
unchanged), and the flash/sage varlen path funnels through `_normalize_attn_mask`, which
collapses a `[B, 1, 1, S]` mask back to `[B, S]` via `any(dim=(1, 2))`.

## Not covered by this PR

sglang main still pins `diffusers==0.37.0` for CUDA (only `pyproject_xpu.toml` moved to
0.38.0, in sgl-project/sglang#28443). sglang is installed `--no-deps`, so there is no
resolution conflict, but the rollout side is running a diffusers upstream has not validated
there. Neither e2e recipe (SD3.5 OCR, LTX-2.3) goes through QwenImage, so CI will not cover
that combination.

## Validation

Relies on #66: `docker-paths` sees `requirements.txt`, `docker-build` publishes
`rockdu/miles_diffusion:pr-<num>`, and the GPU suites run inside it — so this is also the first
real exercise of that path. Before merging, confirm in the logs:

- `docker-build` installed the new pins (`diffusers-0.38.0`, `safetensors-0.8.0`)
- `resolve-ci-image` printed `Resolved CI image: rockdu/miles_diffusion:pr-<num>`, not `:latest`

## Checklist

- [x] `pre-commit run --all-files` passes — `requirements-txt-fixer` leaves the file alone
      (still sorted)
- [ ] Added/updated tests for new behaviour — **no tests added**: a dependency bump, covered by
      the existing suites
- [ ] `pytest -x` is green — **not run locally**: needs the GPU image; CI is the check here
- [ ] If launch flags changed, `python3 train.py --help` still parses — n/a
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a
- [ ] If an example was added, it has a real walkthrough — n/a

ci-sglang-repo: sgl-project/sglang
ci-sglang-pr: #32420