### PR TITLE
fix(rollout): preserve stride when sgl-d offloads weights to pinned host memory

### DIFF
--- a/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
@@ -11,6 +11,7 @@ those groups before model construction.
   breaks bitwise SP-invariance (kernel choice depends on head/batch shape) —
   align the attention kernel via the attention-backend selection instead.
 - ``ltx``:  LTX rollout cond kwargs + AV cross-off (video-only train parity).
+- ``offload``: stride-preserving pinned-host offload; a fix, not a parity choice, so always on.
 
 Patch modules are imported inside ``apply_*`` only, so CPU-only Ray actors
 can import this package without pulling sglang triton kernels. Adding a
@@ -53,6 +54,13 @@ def apply_sgld_monkey_patches() -> None:
     patch_scale_residual_layernorm.apply()
     patch_mul_add.apply()
     patch_qk_norm_rope.apply()
+
+
+@register_rollout_patch_group("offload")
+def apply_offload_patches() -> None:
+    from miles.backends.sglang_diffusion_utils.monkey_patches import patch_pinned_offload_stride
+
+    patch_pinned_offload_stride.apply()
 
 
 @register_rollout_patch_group("ltx")

--- a/miles/backends/sglang_diffusion_utils/monkey_patches/patch_pinned_offload_stride.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/patch_pinned_offload_stride.py
@@ -1,0 +1,38 @@
+"""Preserve tensor stride when sgl-d offloads rollout weights to pinned host memory.
+
+sglang #32032 allocates the host buffer with ``torch.empty(t.shape, ...)``, which is always
+contiguous; ``ltx_2_vae`` then sees a non-channels_last weight and drops off the cuDNN NDHWC
+conv path. Same allocation as ``srt/utils/offloader.py`` (``empty_like`` takes no pin_memory).
+"""
+
+from __future__ import annotations
+
+import torch
+
+_APPLIED = False
+
+
+def _module_to_pinned_cpu(module: torch.nn.Module) -> None:
+    for t in list(module.parameters()) + list(module.buffers()):
+        if t.device.type == "cuda":
+            pin = torch.empty_strided(
+                size=t.size(),
+                stride=t.stride(),
+                dtype=t.dtype,
+                layout=t.layout,
+                device="cpu",
+                pin_memory=True,
+            )
+            pin.copy_(t.data, non_blocking=True)
+            t.data = pin
+
+
+def apply() -> None:
+    global _APPLIED
+    if _APPLIED:
+        return
+
+    from sglang.multimodal_gen.runtime.managers.memory_managers import memory_occupation_controller as moc
+
+    moc._module_to_pinned_cpu = _module_to_pinned_cpu
+    _APPLIED = True

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1402,7 +1402,8 @@ def miles_validate_args(args):
     if args.diffusion_log_image_interval < 1:
         raise ValueError(f"diffusion_log_image_interval must be >= 1, got {args.diffusion_log_image_interval}")
 
-    args.rollout_patch_groups = ["sgld"] if args.apply_sgld_monkey_patches else []
+    # offload is a fix, not a parity choice, so it is not gated on a flag.
+    args.rollout_patch_groups = ["offload"] + (["sgld"] if args.apply_sgld_monkey_patches else [])
 
     if getattr(args, "diffusion_model", None):
         from miles.utils.misc import load_function


### PR DESCRIPTION
## What

Add a rollout patch group `offload` that replaces sgl-d's `_module_to_pinned_cpu` with a
stride-preserving version, and select it unconditionally.

The only change is the host-buffer allocation:

```python
-pin = torch.empty(t.shape, dtype=t.dtype, device="cpu", pin_memory=True)
+pin = torch.empty_strided(t.shape, t.stride(), dtype=t.dtype, device="cpu", pin_memory=True)
```

The buffer stays pinned, so the async D2H/H2D benefit of the upstream change is kept; the
return path via `module.to(device)` already preserves the format.

## Why

sglang #32032 ("[Diffusion] offload rollout weights to pinned host memory", merged 2026-07-25
20:35Z) allocates the host buffer with `torch.empty(t.shape, ...)`, which is always contiguous.
The previous `module.to("cpu")` went through `Tensor.to()`, which preserves the memory format of
dense tensors. So a `channels_last_3d` weight comes back from one offload/onload cycle as
contiguous.

That matters because sgl-d branches on the layout at runtime. `vae_loader.py` converts Conv3d
weights to `channels_last_3d` for QwenImage, and for Wan/LTX-2 when `num_gpus == 1` (our LTX
recipe runs `--rollout-num-gpus-per-engine 1`), and `ltx_2_vae.py` then checks
`_weight_is_channels_last_3d()` to keep the cuDNN NDHWC conv path. Once the weight is contiguous
the conv silently drops to NCDHW -- same math, different kernel, different accumulation order.

How this surfaced: the LTX-2 e2e compares 8 metric series against a recorded standard with **zero
tolerance**. It was bitwise green at sglang `f5155d960` and red (16 mismatches) at `5f330004b`
with an identical image and an identical diffusers pin. Re-running reproduced the new values bit
for bit, and pinning sglang back to `f5155d960` on the same image went green again. In that
window `multimodal_gen/` has exactly one changed file: the one this patch targets. The SD3.5 e2e
stayed green throughout -- its VAE is 2D and not in `_should_use_channels_last_3d`'s list, which
is the discriminating observation.

## Why it is not gated on a flag

The existing groups (`sgld`, `ltx`) are train/rollout parity choices. This one is a fix: it keeps
sgl-d's own kernel selection stable across sleep/wake, independent of model family, so it is
appended to `rollout_patch_groups` unconditionally.

## Files

- `monkey_patches/patch_pinned_offload_stride.py` -- new patch; no-ops on sglang older than
  #32032, where `module.to()` already preserved stride
- `monkey_patches/__init__.py` -- register the `offload` group
- `miles/utils/arguments.py` -- select it unconditionally

## Validation

- `pre-commit run --files <changed files>` passes.
- **In flight**: `workflow_dispatch` on this branch with `ci_image_tag=pr-68` and sglang `main`
  (i.e. *with* #32032). If the LTX e2e goes bitwise green, that both fixes the regression and
  confirms the mechanism at runtime, which so far rests on code reading plus the controlled
  experiment above. Result will be posted here.
- Not verified directly: I have not printed `weight.stride()` around an offload/onload cycle.

Upstream should carry the same fix; a `sgl-project/sglang` issue/PR is being prepared separately.

## Checklist

- [x] `pre-commit run --all-files` passes -- run scoped to the changed files
- [ ] Added/updated tests for new behaviour -- **no test added**: the patched path only acts on
      CUDA tensors, so it cannot be exercised on the CPU suite; the LTX e2e is the real check
- [ ] `pytest -x` is green -- **not run locally**: no torch in this environment
- [ ] If launch flags changed, `python3 train.py --help` still parses -- n/a, no new flag
- [ ] If a public flag was added, it appears in the CLI reference docs -- n/a
- [ ] If an example was added, it has a real walkthrough -- n/a
