### PR TITLE
ci: restore status-check guards so GPU stages survive docker-build's skip

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -169,10 +169,16 @@ jobs:
     secrets: inherit
 
   # Stage B GPU: fast-gpu bucket, runs once stage-a-cpu is green (fast-fail:
-  # broken imports shouldn't burn GPU runner slots).
+  # broken imports shouldn't burn GPU runner slots). The always()/result
+  # guards are load-bearing: docker-build skips on non-docker PRs, and a bare
+  # `if` would inherit that skip and cascade it downstream (#67 regression).
   stage-b-3-gpu-h200:
     needs: [resolve-ci-image, stage-a-cpu]
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-image.result == 'success' &&
+      needs.stage-a-cpu.result == 'success' &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
       # Suite names match the runner split: 3gpu (GPUs 0-2) + 5gpu (GPUs 3-7).
@@ -187,6 +193,10 @@ jobs:
   # Fan-in so each stage-c needs one job instead of every stage-b.
   stage-b:
     needs: [stage-b-cpu, stage-b-3-gpu-h200]
+    if: |
+      always() && !cancelled() &&
+      needs.stage-b-cpu.result == 'success' &&
+      needs.stage-b-3-gpu-h200.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - run: 'true'
@@ -194,7 +204,11 @@ jobs:
   # Stage C GPU (3gpu runner): e2e suite for the 2-GPU SD3.5 OCR recipe.
   stage-c-3-gpu-h200:
     needs: [resolve-ci-image, stage-b]
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-image.result == 'success' &&
+      needs.stage-b.result == 'success' &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "3gpu"]'
@@ -208,7 +222,11 @@ jobs:
   # Stage C GPU: e2e suite on the 5gpu runner.
   stage-c-5-gpu-h200:
     needs: [resolve-ci-image, stage-b]
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    if: |
+      always() && !cancelled() &&
+      needs.resolve-ci-image.result == 'success' &&
+      needs.stage-b.result == 'success' &&
+      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "5gpu"]'


### PR DESCRIPTION
## What

- Restore the `always() && !cancelled() && needs.*.result == 'success'` guards on `stage-b-3-gpu-h200`, `stage-c-3-gpu-h200`, and `stage-c-5-gpu-h200` that #67 removed.
- Add the same guard to the new `stage-b` fan-in job, which shipped with no `if` at all.

## Validation

This change is self-validating: **this PR's own checks must show `stage-b-3-gpu-h200 / run`, `stage-c-3-gpu-h200 / run`, and `stage-c-5-gpu-h200 / run` actually executing** (this PR touches no docker paths, so `docker-build` skips — exactly the condition that broke #67). Please do not merge if any GPU stage shows "skipped".

## Files

- `.github/workflows/pr-test.yml` — the four `if` guards; two comments documenting why they are load-bearing.

## Follow-up (not in this PR)

Make one GPU job a branch-protection required check: a required check in "skipped" state blocks merging, so "all GPU skipped yet all green" can never merge silently again.

## Checklist

- [x] `pre-commit run` on the changed file passes (all hooks skip: none target workflow YAML; `--all-files` **not run** — unrelated to this change)
- [ ] Added/updated tests for new behaviour — **no tests added**; the CI run itself is the test (see Validation)
- [ ] `pytest -x` — **not run**; workflow-only change, no Python touched
- [x] No launch flags changed
- [x] No public flag added
- [x] No example added

ci-sglang-repo: sgl-project/sglang
ci-sglang-pr: #32420
