### PR TITLE
ci: compare PR merge commits with their current base

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -55,20 +55,18 @@ jobs:
   docker-paths:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          persist-credentials: false
       - id: diff
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # The PR's own files: a base..HEAD diff also flags paths the branch is merely behind the base on.
-          # Assigned outside the `if` so a failed lookup fails the step instead of reading as no change.
-          CHANGED_FILES=$(gh api --paginate -q '.[].filename' \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          # Compare the PR merge commit with its current base.
+          CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD)
           # Same paths as docker-build.yml's post-merge filter.
           if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(docker/Dockerfile|requirements\.txt)$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -55,18 +55,20 @@ jobs:
   docker-paths:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - id: diff
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git fetch --depth 1 origin "${{ github.event.pull_request.base.sha }}"
-          # Assigned outside the `if` so a failed diff fails the step instead of reading as no change.
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD)
+          # The PR's own files: a base..HEAD diff also flags paths the branch is merely behind the base on.
+          # Assigned outside the `if` so a failed lookup fails the step instead of reading as no change.
+          CHANGED_FILES=$(gh api --paginate -q '.[].filename' \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
           # Same paths as docker-build.yml's post-merge filter.
           if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(docker/Dockerfile|requirements\.txt)$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Compare the checked-out PR merge commit with its first parent (`HEAD^1`) when detecting Docker input changes.

## Why

The merge commit already includes current `main`; diffing it against `github.event.pull_request.base.sha` can include unrelated changes that landed on `main` (e.g., Dockerfile changes) and trigger unnecessary image builds.

## Test plan

- [x] `pre-commit run --files .github/workflows/pr-test.yml`
- [ ] Verified against #70's merge commit that `git diff HEAD^1 HEAD` excludes `requirements.txt`, while the old diff includes it.

ci-sglang-repo: sgl-project/sglang
ci-sglang-pr: #32420