### PR TITLE
ci: allow custom SGLang refs for e2e recording

### DIFF
--- a/.github/workflows/record-e2e-standards.yml
+++ b/.github/workflows/record-e2e-standards.yml
@@ -14,6 +14,14 @@ on:
         required: false
         type: string
         default: '["h200", "5gpu"]'
+      ci_sglang_pr:
+        description: 'SGLang branch, commit, or PR (default: main)'
+        required: false
+        type: string
+      ci_sglang_repo:
+        description: 'SGLang repository owner/name (default: sgl-project/sglang)'
+        required: false
+        type: string
 
 jobs:
   record:


### PR DESCRIPTION
Allow E2E standard recording runs to select an SGLang repository and branch, commit, or PR.