### PR TITLE
feat(rollout): send per-GPU weight-sync payloads to multi-GPU engines

### DIFF
--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -31,6 +31,8 @@ except ImportError as _e:
     compute_weights_checksum = None
     _checksum_import_error = _e
 
+from miles.ray.utils import get_physical_gpu_id
+
 
 logger = logging.getLogger(__name__)
 
@@ -233,24 +235,27 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
             serialized_tensors.append(MultiprocessingSerializer.serialize(flattened_tensor_data, output_str=True))
 
         if self._ipc_gather_src == dist.get_rank():
-            gathered_serialized_batches = [None for _ in range(dist.get_world_size(self._ipc_gather_group))]
+            gathered_batches = [None for _ in range(dist.get_world_size(self._ipc_gather_group))]
         else:
-            gathered_serialized_batches = None
+            gathered_batches = None
 
         dist.gather_object(
-            obj=serialized_tensors,
-            object_gather_list=gathered_serialized_batches,
+            obj=(get_physical_gpu_id(), serialized_tensors),
+            object_gather_list=gathered_batches,
             dst=self._ipc_gather_src,
             group=self._ipc_gather_group,
         )
 
         if dist.get_rank() == self._ipc_gather_src:
+            payload_gpu_uuids = [gpu_uuid for gpu_uuid, _ in gathered_batches]
+            gathered_serialized_batches = [tensors for _, tensors in gathered_batches]
             # TODO: here we assume all ranks have the same number of dtypes.
             num_dtypes = len(gathered_serialized_batches[0])
             assert num_dtypes > 0
             for i in range(num_dtypes):
                 kwargs = {
                     "serialized_named_tensors": [tensors[i] for tensors in gathered_serialized_batches],
+                    "payload_gpu_uuids": payload_gpu_uuids,
                     "load_format": "flattened_bucket",
                     "target_modules": [target_module],
                     "weight_version": str(weight_version),

--- a/miles/backends/sglang_diffusion_utils/arguments.py
+++ b/miles/backends/sglang_diffusion_utils/arguments.py
@@ -93,6 +93,13 @@ def add_sglang_diffusion_arguments(parser):
 
 
 def validate_args(args):
+    if args.sglang_tp_size is not None and args.sglang_sp_degree is not None:
+        if args.sglang_tp_size * args.sglang_sp_degree != args.rollout_num_gpus_per_engine:
+            raise ValueError(
+                f"--sglang-tp-size ({args.sglang_tp_size}) * --sglang-sp-degree ({args.sglang_sp_degree}) "
+                f"must equal --rollout-num-gpus-per-engine ({args.rollout_num_gpus_per_engine})"
+            )
+
     # `sglang_dp_size` is used by rollout port allocation; default to 1 if
     # SGL-D's ServerArgs didn't register the CLI arg in this build.
     if not hasattr(args, "sglang_dp_size"):

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -165,14 +165,15 @@ class SGLangDiffusionEngine(RayActor):
     def _pin_to_assigned_gpu(self):
         if self.base_gpu_id is None:
             return
+        span = self.args.rollout_num_gpus_per_engine
         cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
         if not cvd:
-            # No ambient device list (full-node multi-node ray start): pin to the physical GPU.
-            os.environ["CUDA_VISIBLE_DEVICES"] = str(self.base_gpu_id)
+            # No ambient device list (full-node multi-node ray start): pin to the physical GPUs.
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(self.base_gpu_id + i) for i in range(span))
             return
         visible = [x.strip() for x in cvd.split(",") if x.strip()]
         local_idx = _to_local_gpu_id(self.base_gpu_id)
-        pinned = visible[local_idx]
+        pinned = ",".join(visible[local_idx : local_idx + span])
         os.environ["CUDA_VISIBLE_DEVICES"] = pinned
         logger.info(
             f"Engine rank={self.rank}: pinned CUDA_VISIBLE_DEVICES={pinned} "
@@ -226,6 +227,7 @@ class SGLangDiffusionEngine(RayActor):
     def update_weights_from_tensor(
         self,
         serialized_named_tensors: list[str],
+        payload_gpu_uuids: list[str],
         load_format: str | None = None,
         target_modules: list[str] | None = None,
         weight_version: str | None = None,
@@ -241,6 +243,7 @@ class SGLangDiffusionEngine(RayActor):
         """
         payload = {
             "serialized_named_tensors": serialized_named_tensors,
+            "payload_gpu_uuids": payload_gpu_uuids,
             "load_format": load_format,
         }
         if target_modules is not None:
@@ -310,8 +313,9 @@ def _compute_server_args(args, host, port, nccl_port):
         "nccl_port": nccl_port,
         # Distinct per engine so concurrent settle_port() probes don't race on the default.
         "master_port": nccl_port + 10000 if nccl_port is not None else None,
-        # Must match rollout allocation, not user CLI.
-        "tp_size": args.rollout_num_gpus_per_engine,
+        # SGL-D runs one worker per num_gpus; tp_size * sp_degree splits that span.
+        "num_gpus": args.rollout_num_gpus_per_engine,
+        "tp_size": args.sglang_tp_size,
         "sp_degree": args.sglang_sp_degree,
         "enable_cfg_parallel": args.sglang_enable_cfg_parallel,
         # Skip warmup to avoid timeout during RL rollouts.


### PR DESCRIPTION
## What

- Weight sync labels each CUDA-IPC payload with the GPU UUID it was exported from (`payload_gpu_uuids`), so every sgl-d worker imports the payload of the training rank on its own GPU.
- Rollout engines may span several GPUs: `num_gpus` is the span, `tp_size` comes from `--sglang-tp-size` instead of being pinned to it, and the engine pins the whole span.
- `validate_args` rejects `--sglang-tp-size * --sglang-sp-degree != --rollout-num-gpus-per-engine`.

## Why

`--rollout-num-gpus-per-engine > 1` used to mean TP only: `tp_size` was pinned to the span and `num_gpus` was never sent, so `--sglang-sp-degree` could not be satisfied.

The gathered payload list is ordered by training rank, so a worker only gets its co-located rank's buffer when the engine's span happens to be ordered the same way. Labelling by GPU makes the pairing explicit and turns a mismatch into a hard error instead of a silent peer-GPU import.

## Related

Engine side: sgl-project/sglang#32685 consumes `payload_gpu_uuids`. Land it first — a build without the field drops it and the worker falls back to world-rank indexing.

## Validation

8xH200 (NVLink `NV18`), against sgl-project/sglang#32685. Rollout SP is enabled on an existing recipe with `--rollout-num-gpus-per-engine 2 --sglang-sp-degree 2`; no new recipe is added here. A temporary engine probe logged the claimed payload index next to the index this worker's UUID resolves to.

| Setup | Engine args | Sync path | Result |
|---|---|---|---|
| Wan2.2-A14B, GPUs 4-5 (`base_gpu_id=4`) | `num_gpus=2, tp=1, sp=2` | LoRA IPC (`lora_merge`) | rank0/1 -> 0/2, 1/2; both experts `skipped 0` |
| Wan2.2-A14B, GPUs 0-3 | `num_gpus=4, tp=2, sp=2` | LoRA IPC (`lora_merge`) | rank0..3 -> 0/4..3/4 distinct; `skipped 0` |
| LTX-2.3, 2 engines x 2 GPUs | `num_gpus=2, tp=1, sp=2` | merged full weights, 8-14 buckets/sync | 4 consecutive syncs, `skipped 0` |

No `no payload was exported from this worker's GPU`, no `Skipping weight update`. TP x SP shows UUID claiming composes with TP sharding: the worker gets the full tensor from its co-located rank and `weight_loader` narrows it by `tp_rank`.

Backward compatibility: the pre-change producer (`30681a3`, no labels) syncs identically against the patched engine (54.5 s) and stock sgl-d (53.5 s), both `skipped 0`.

Cost of claiming the wrong payload — same LTX run, only the claim rule flipped:

| `Timer update_weights` | UUID-aligned | Forced peer payload |
|---|---|---|
| per sync | 13.7 / 13.9 / 13.6 / 14.6 s | 19.1 / 14.8 / 15.5 / 13.8 s |
| mean (excl. warm-up) | 13.95 s (14.03 s) | 15.80 s (14.70 s) |

Overlapping at n=4, so not a reliable speedup: the sync is dominated by all-gather, serialization and name matching, not the copy (microbenchmark: 0.51 ms same-GPU vs 2.72 ms peer-GPU per GiB fp32). The value here is correctness and a loud failure on misalignment.

Not verified: end-to-end to the first train step.

CFG-parallel engines are out of scope here and untested; support lands separately.

## Checklist

- [x] `pre-commit run` passes on the touched files
- [ ] Added/updated tests — **none added**
- [ ] `pytest -x` — **not run**
- [x] Launch flags still parse — **no new flags, only existing `--sglang-*`**
- [x] No new example/recipe — existing recipes take the two flags directly
