### PR TITLE
fix(dashboard): isolate telemetry per training run

### DIFF
--- a/miles/dashboard/backend.py
+++ b/miles/dashboard/backend.py
@@ -6,6 +6,7 @@ import logging
 import time
 
 from miles.dashboard.collector import COLLECTOR_ACTOR_NAME, CollectorConfig
+from miles.dashboard.store import run_dir
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +28,11 @@ def init_dashboard(args) -> bool:
 
     from miles.dashboard.collector import DashboardCollector
 
+    start_ts = time.time()
     config = CollectorConfig(
-        workspace=args.miles_dashboard_workspace,
+        workspace=str(run_dir(args.miles_dashboard_workspace, start_ts)),
         run_name="miles-diffusion",
-        start_ts=time.time(),
+        start_ts=start_ts,
         args_snapshot=dict(vars(args)),
     )
     handle = None

--- a/miles/dashboard/collector.py
+++ b/miles/dashboard/collector.py
@@ -41,6 +41,10 @@ class DashboardCollector:
     def ping(self) -> bool:
         return True
 
+    def workspace(self) -> str:
+        """This run's directory, for workers that write telemetry files themselves."""
+        return self.config.workspace
+
     def start(self) -> None:
         if self._flush_thread is not None:
             return

--- a/miles/dashboard/hooks.py
+++ b/miles/dashboard/hooks.py
@@ -138,7 +138,7 @@ def register_train_actor(args, role: str) -> None:
     attach_phase_sink(handle, role)
     global _GPU_SAMPLER
     if dist.get_rank() == 0 and _GPU_SAMPLER is None:
-        _GPU_SAMPLER = GpuUtilSampler(args.miles_dashboard_workspace)
+        _GPU_SAMPLER = GpuUtilSampler(_ray_get(handle.workspace.remote()))
         _GPU_SAMPLER.start()
 
 

--- a/miles/dashboard/store.py
+++ b/miles/dashboard/store.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from miles.dashboard.events import PhaseEvent, TrajectoryEvent
 
 
+RUN_DIR_PREFIX = "run_"
+
+
 class Stream(StrEnum):
     PHASES = "phases"
     TRAJECTORIES = "trajectories"
@@ -33,6 +36,18 @@ def _timestamp(record: Record) -> float:
 
 def _hour_key(timestamp: float) -> str:
     return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime("%Y%m%d_%H")
+
+
+def run_dir(base: str, start_ts: float) -> Path:
+    """One directory per training launch, under the base workspace."""
+    stamp = datetime.fromtimestamp(start_ts, tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return Path(base) / f"{RUN_DIR_PREFIX}{stamp}"
+
+
+def resolve_run_dir(base: str) -> Path:
+    """Newest run under the base workspace (names sort by time), or base itself if it holds no runs."""
+    runs = sorted(path for path in Path(base).glob(f"{RUN_DIR_PREFIX}*") if path.is_dir())
+    return runs[-1] if runs else Path(base)
 
 
 class DashboardStore:

--- a/miles/dashboard/viewer.py
+++ b/miles/dashboard/viewer.py
@@ -12,6 +12,7 @@ import os
 from collections import defaultdict
 
 from miles.dashboard.events import SPAN_KINDS
+from miles.dashboard.store import resolve_run_dir
 
 
 def _read_jsonl(paths):
@@ -324,7 +325,7 @@ def serve(workspace: str, host: str, port: int, title: str) -> None:
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--workspace", required=True, help="miles dashboard workspace")
+    ap.add_argument("--workspace", required=True, help="miles dashboard workspace, or one run directory in it")
     ap.add_argument("--out", default="dashboard.html")
     ap.add_argument("--title", default="miles-D rollout dashboard")
     ap.add_argument(
@@ -334,10 +335,11 @@ def main():
     ap.add_argument("--port", type=int, default=8000)
     args = ap.parse_args()
 
+    workspace = str(resolve_run_dir(args.workspace))
     if args.serve:
-        serve(args.workspace, args.host, args.port, args.title)
+        serve(workspace, args.host, args.port, args.title)
         return
-    phases, gpu, life = load_streams(args.workspace)
+    phases, gpu, life = load_streams(workspace)
     html = build_html(phases, gpu, life, title=args.title)
     with open(args.out, "w") as f:
         f.write(html)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1105,7 +1105,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--miles-dashboard-workspace",
                 type=str,
                 default="./miles_dashboard",
-                help="Directory for miles dashboard telemetry.",
+                help="Base directory for miles dashboard telemetry; each launch writes to its own run_<ts> subdir.",
             )
             return parser
 

--- a/tests/fast/dashboard/test_async_collector.py
+++ b/tests/fast/dashboard/test_async_collector.py
@@ -80,7 +80,6 @@ def test_collector_startup_failure_disables_dashboard(monkeypatch, tmp_path, cap
     monkeypatch.setitem(sys.modules, "ray", ray_module)
     monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", strategies_module)
     monkeypatch.setattr(backend, "_handle", None)
-    monkeypatch.setattr(backend, "_is_primary", False)
 
     args = SimpleNamespace(
         use_miles_dashboard=True,

--- a/tests/fast/dashboard/test_run_isolation.py
+++ b/tests/fast/dashboard/test_run_isolation.py
@@ -1,0 +1,71 @@
+import sys
+import types
+from types import SimpleNamespace
+
+from miles.dashboard import backend
+from miles.dashboard.collector import CollectorConfig, DashboardCollector
+from miles.dashboard.events import PhaseEvent
+from miles.dashboard.store import resolve_run_dir, run_dir
+from miles.dashboard.viewer import load_streams
+
+
+def _write_run(base, start_ts: float, phase_name: str):
+    workspace = run_dir(str(base), start_ts)
+    collector = DashboardCollector(CollectorConfig(workspace=str(workspace), run_name="test", start_ts=start_ts))
+    collector.push_phases(
+        [PhaseEvent(name=phase_name, t0=start_ts, t1=start_ts + 1, role="actor", pid=10, node="n", gpus=[2], rank=7)]
+    )
+    collector.flush()
+    return workspace
+
+
+def test_relaunch_does_not_merge_metrics(tmp_path):
+    first = _write_run(tmp_path, 1_800_000_000.0, "first_run_phase")
+    second = _write_run(tmp_path, 1_800_000_060.0, "second_run_phase")
+
+    assert first != second
+    assert [phase["name"] for phase in load_streams(str(first))[0]] == ["first_run_phase"]
+    assert [phase["name"] for phase in load_streams(str(second))[0]] == ["second_run_phase"]
+
+
+def test_resolve_run_dir_picks_newest_run(tmp_path):
+    _write_run(tmp_path, 1_800_000_000.0, "old")
+    newest = _write_run(tmp_path, 1_800_000_060.0, "new")
+
+    assert resolve_run_dir(str(tmp_path)) == newest
+    assert resolve_run_dir(str(newest)) == newest
+
+    flat = tmp_path / "no_runs_inside"
+    (flat / "phases").mkdir(parents=True)
+    assert resolve_run_dir(str(flat)) == flat
+
+
+def test_init_dashboard_writes_under_the_given_workspace(tmp_path, monkeypatch):
+    created = []
+
+    class FakeHandle:
+        ping = start = SimpleNamespace(remote=lambda *a, **kw: None)
+
+    class RemoteClass:
+        def options(self, **kwargs):
+            return self
+
+        def remote(self, config):
+            created.append(config)
+            return FakeHandle()
+
+    ray_module = types.ModuleType("ray")
+    ray_module.remote = lambda cls: RemoteClass()
+    ray_module.get_runtime_context = lambda: SimpleNamespace(get_node_id=lambda: "driver-node")
+    ray_module.get = lambda ref: ref
+    strategies_module = types.ModuleType("ray.util.scheduling_strategies")
+    strategies_module.NodeAffinitySchedulingStrategy = lambda **kwargs: kwargs
+    monkeypatch.setitem(sys.modules, "ray", ray_module)
+    monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", strategies_module)
+    monkeypatch.setattr(backend, "_handle", None)
+
+    args = SimpleNamespace(use_miles_dashboard=True, miles_dashboard_workspace=str(tmp_path))
+    assert backend.init_dashboard(args) is True
+
+    assert created[0].workspace == str(run_dir(str(tmp_path), created[0].start_ts))
+    assert args.miles_dashboard_workspace == str(tmp_path)


### PR DESCRIPTION
## What

- Dashboard telemetry now lands in a per-launch subdirectory `<workspace>/run_<UTC timestamp>/` instead of directly in the workspace root.
- `python -m miles.dashboard.viewer --workspace <dir>` resolves to the newest `run_*` subdirectory; pass a specific `run_*` directory to look at an older run.
- No flag added or removed. `--miles-dashboard-workspace` keeps its meaning (it is the base directory) and is never rewritten behind the user's back.

## Why

`DashboardStore` partitions each stream by UTC hour and appends (`phases/20260728_22.jsonl`, ...), and `meta.json` is written once per collector. Relaunching training with the same `--miles-dashboard-workspace` therefore appended the new run's phases, trajectories and GPU samples into the previous run's files and overwrote `meta.json`, so the viewer drew two runs as a single timeline — the reported symptom.

Two design points worth a look during review:

- The run directory is derived on the driver only. Instead of rewriting `args.miles_dashboard_workspace` (that would silently change a user-supplied path, and every worker would inherit the mutated value), the collector owns the run directory and exposes it through `DashboardCollector.workspace()`. The rank-0 `GpuUtilSampler` — the only worker that writes telemetry files itself — asks the collector for it; phase and trajectory events already flow through the collector, so nothing else needs the path.
- Run directory names are second-granular and sort lexicographically, which is what `resolve_run_dir` relies on to pick "newest".

For reference, miles core does not handle this inside the dashboard either: its telemetry directory is `{dump_details}/dashboard` with `--dump-details` asserted as required, and per-run uniqueness comes from the launcher (`--dump-details {output_dir}/{run_id}/dump_details`, `run_id` = UTC timestamp plus a random suffix). miles-diffusion has no such layer — no example or script passes `--dump-details` — and its viewer reads only the JSONL streams, so deriving the workspace from `--dump-details` would force heavyweight per-rollout `.pt` dumping for no benefit. This PR is the same idea one level down: one timestamped directory per launch, owned by the dashboard instead of the launcher.

Known limits, deliberately not addressed here:

- Two launches whose start timestamps land in the same UTC second compute the same run directory and merge. A sequential relaunch cannot realistically hit this; two drivers started concurrently can. There is no arbitration today: the driver only derives the path, the directory itself is created lazily by `DashboardStore.write_meta` with `exist_ok=True`. Guarding it means having the driver create the directory with `exist_ok=False` and fall back to a `-N` suffix.
- Telemetry written into the workspace root before this change stays there; once any `run_*` directory exists the viewer resolves to that instead, so point `--workspace` at the old directory itself to read it.

## Files

- `miles/dashboard/store.py` — `run_dir()` (launch timestamp to directory) and `resolve_run_dir()` (workspace to newest run).
- `miles/dashboard/backend.py` — the driver points the collector config at this launch's run directory.
- `miles/dashboard/collector.py` — `workspace()` accessor so a worker can locate the run directory.
- `miles/dashboard/hooks.py` — rank-0 GPU sampler writes into the collector's run directory.
- `miles/dashboard/viewer.py` — `--workspace` resolves to the newest run.
- `miles/utils/arguments.py` — help text for `--miles-dashboard-workspace`.
- `tests/fast/dashboard/test_run_isolation.py` — new: a relaunch does not merge metrics, newest-run resolution (including a workspace that holds no runs), and `init_dashboard` leaving the workspace arg untouched.
- `tests/fast/dashboard/test_async_collector.py` — drop a stale `monkeypatch.setattr(backend, "_is_primary", ...)`; the attribute no longer exists, so that test was erroring on `main` as well.

## Validation

- `pytest tests/fast/dashboard -q` → 11 passed (8 existing, 3 new).
- Manual viewer check: created two run directories under one workspace; `--workspace <base>` rendered only the newest run's phase span, `--workspace <base>/run_<older>` rendered the older one.
- Not run locally: the full `tests/fast` suite and `train_diffusion.py --help` — this checkout has no `ray`/`torch`, so collection fails at import for both. Both need CI or a GPU box.

## Checklist

- [x] `pre-commit run --all-files`
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green
- [ ] If launch flags changed, `python3 train.py --help` still parses — **not run** (needs `ray`); no flag was added or removed, only the help text of an existing one
- [x] If a public flag was added, it appears in the CLI reference docs — n/a, no new flag
- [x] If an example was added, it has a real walkthrough — n/a, no example
