### PR TITLE
docker: fail the image build when requirements.txt is not satisfied

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,7 @@ on:
       - main
     paths:
       - 'docker/Dockerfile'
+      - 'docker/check_requirements.py'
       - 'requirements.txt'
 
 concurrency:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -68,7 +68,7 @@ jobs:
           # Compare the PR merge commit with its current base.
           CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD)
           # Same paths as docker-build.yml's post-merge filter.
-          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(docker/Dockerfile|requirements\.txt)$'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^(docker/Dockerfile|docker/check_requirements\.py|requirements\.txt)$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,5 +79,12 @@ RUN git clone https://github.com/radixark/miles_diffusion.git /root/miles_diffus
 # =========================================== Pre-download ===============================================
 
 # Pre-download PaddleOCR (en) det+rec+cls models so the OCR-reward actors don't
-# race-download them from bcebos at runtime. 
+# race-download them from bcebos at runtime.
 RUN python -c "from paddleocr import PaddleOCR; PaddleOCR(use_angle_cls=False, lang='en', use_gpu=False, show_log=False)"
+
+# ========================================= Sanity checks ================================================
+
+# Fail the build if any requirements.txt entry ended up missing or stomped by a
+# later --no-deps install, or if the top-level package no longer imports.
+COPY docker/check_requirements.py /tmp/check_requirements.py
+RUN python /tmp/check_requirements.py /tmp/requirements.txt && python -c "import miles"

--- a/docker/check_requirements.py
+++ b/docker/check_requirements.py
@@ -1,0 +1,27 @@
+"""Fail the image build if any requirements.txt entry is missing or
+version-mismatched (later --no-deps installs can silently stomp them)."""
+
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+from packaging.requirements import Requirement
+
+failures = []
+for raw in open(sys.argv[1]):
+    line = raw.split("#", 1)[0].strip()
+    if not line or line.startswith("-"):
+        continue
+    req = Requirement(line)
+    if req.marker is not None and not req.marker.evaluate():
+        continue
+    try:
+        installed = version(req.name)
+    except PackageNotFoundError:
+        failures.append(f"{req.name}: not installed")
+        continue
+    if req.specifier and not req.specifier.contains(installed, prereleases=True):
+        failures.append(f"{req.name}: installed {installed}, required {req.specifier}")
+
+if failures:
+    sys.exit("requirements not satisfied in image:\n  " + "\n  ".join(failures))
+print(f"requirements OK ({sys.argv[1]})")


### PR DESCRIPTION
## What
- `docker/check_requirements.py` + a final `RUN` in the Dockerfile: after all installs, verify every `requirements.txt` entry is present at a satisfying version (handles extras, git URLs, and platform markers), then smoke `import miles`. A stomped or missing requirement now fails the build instead of shipping a broken `pr-N`/`latest`.
- Path filters (`docker-paths` in pr-test.yml, push paths in docker-build.yml) also watch the checker script.

## Why
- The image installs several components with `--no-deps` (sglang, wheels) after `pip install -r requirements.txt`, so a requirement can be silently downgraded or removed; nothing validated the final state. Whole-env `pip check` is not usable as a gate — the `--no-deps` installs make it noisy by design (15+ pre-existing complaints in the current image).

## Validation
- Checker run inside the live `rockdu/miles_diffusion:latest`: current requirements pass; a seeded version mismatch and a missing package both fail with exit 1 and a per-entry report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
