### PR TITLE
fix(rollout): pass warmup_mode=off after sglang removed the warmup server arg

### DIFF
--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -315,7 +315,7 @@ def _compute_server_args(args, host, port, nccl_port):
         "sp_degree": args.sglang_sp_degree,
         "enable_cfg_parallel": args.sglang_enable_cfg_parallel,
         # Skip warmup to avoid timeout during RL rollouts.
-        "warmup": False,
+        "warmup_mode": "off",
     }
 
     if getattr(args, "diffusion_flow_shift", None) is not None:


### PR DESCRIPTION
## What

`sglang_diffusion_engine.py`: `"warmup": False` → `"warmup_mode": "off"` in the engine ServerArgs. One line.

## Why

sglang upstream removed the `warmup` server argument (replaced by `warmup_mode=request|off`). CI installs sglang `main` at job time, so every GPU e2e now dies before training starts:

```
ValueError: Removed server argument(s): warmup -> warmup_mode=request or warmup_mode=off
ray.exceptions.ActorDiedError: RolloutManager.__init__ ...
```

First seen on [#98's stage-c run](https://github.com/radixark/miles_diffusion/actions/runs/31134602438/job/92732689396) (`Resolved: sglang repo=sgl-project/sglang ref=main`); unrelated to that PR's content. Every PR without a `ci-sglang-pr:` pin fails identically until this lands.

Semantics unchanged: warmup stays disabled for RL rollouts, only the argument name follows upstream. Checkouts older than the sglang rename will reject `warmup_mode` the same way they now reject nothing — the repo's Dockerfile and CI both track sglang `main`, which has the rename.

## Validation

This PR's own GPU stages run against sglang main tip and exercise engine startup; green checks here are the regression test.

Follow-up worth considering (not in this PR): pin the CI default sglang ref and bump it explicitly, with a nightly canary tracking main — upstream renames currently break all open PRs asynchronously.
