### PR TITLE
fix(fsdp): keep hybrid shard CI always enabled

### DIFF
--- a/tests/fast-gpu/backends/fsdp_utils/_hybrid_shard_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_hybrid_shard_worker.py
@@ -14,10 +14,7 @@ from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.fsdp._fully_shard._fsdp_common import HSDPMeshInfo
 from torch.distributed.tensor import DTensor, Replicate
 
-from miles.backends.fsdp_utils.checkpoint import (
-    broadcast_full_state_to_fsdp,
-    ModelState,
-)
+from miles.backends.fsdp_utils.checkpoint import ModelState, broadcast_full_state_to_fsdp
 from miles.backends.fsdp_utils.parallel import create_fsdp_parallel_state
 from miles.backends.fsdp_utils.sequence_parallel.plan import SequenceParallelPlan, apply_sequence_parallel
 from miles.utils.distributed_utils import init_gloo_group

--- a/tests/fast-gpu/backends/fsdp_utils/_hybrid_shard_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_hybrid_shard_worker.py
@@ -14,8 +14,10 @@ from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.fsdp._fully_shard._fsdp_common import HSDPMeshInfo
 from torch.distributed.tensor import DTensor, Replicate
 
-from miles.backends.fsdp_utils.actor import load_sharded_model
-from miles.backends.fsdp_utils.checkpoint import ModelState
+from miles.backends.fsdp_utils.checkpoint import (
+    broadcast_full_state_to_fsdp,
+    ModelState,
+)
 from miles.backends.fsdp_utils.parallel import create_fsdp_parallel_state
 from miles.backends.fsdp_utils.sequence_parallel.plan import SequenceParallelPlan, apply_sequence_parallel
 from miles.utils.distributed_utils import init_gloo_group
@@ -145,7 +147,7 @@ def main():
 
     torch.manual_seed(0)
     model = Tiny().cuda()
-    # Doubles as the rank0 full state dict, which load_sharded_model expects on CPU.
+    # Doubles as the rank0 full state dict, which the broadcast expects on CPU.
     reference = {k: v.detach().clone().cpu() for k, v in model.state_dict().items()}
     mp_policy = MixedPrecisionPolicy(param_dtype=torch.float32, reduce_dtype=torch.float32)
     for block in model.blocks:
@@ -157,7 +159,11 @@ def main():
     check_fully_shard_topology(model, args.dp_replicate_size, world_size)
 
     # set_model_state_dict moves rank0's tensors onto the device, so hand it a copy.
-    load_sharded_model(model, {k: v.clone() for k, v in reference.items()} if rank == 0 else {}, cpu_offload=False)
+    broadcast_full_state_to_fsdp(
+        model,
+        {k: v.clone() for k, v in reference.items()} if rank == 0 else {},
+        cpu_offload=False,
+    )
     for name, param in model.named_parameters():
         torch.testing.assert_close(param.full_tensor().cpu(), reference[name])
 

--- a/tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py
+++ b/tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py
@@ -5,7 +5,6 @@ from tests.ci.ci_register import register_cuda_ci
 register_cuda_ci(
     est_time=90,
     suite="stage-c-5-gpu-h200",
-    labels=["fsdp"],
 )
 
 import os

--- a/tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py
+++ b/tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py
@@ -4,7 +4,7 @@ from tests.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(
     est_time=90,
-    suite="stage-c-5-gpu-h200",
+    suite="stage-b-5-gpu-h200",
 )
 
 import os


### PR DESCRIPTION
## What

- Run the Hybrid Shard regression in `stage-b-5-gpu-h200` on every PR instead of gating it behind `run-ci-fsdp`.
- Update the worker to use `broadcast_full_state_to_fsdp` after the state-loading helper moved out of `actor.py`.

## Why

Hybrid Shard validates foundational FSDP topology, gradient scaling, weight synchronization, and checkpoint behavior, so it should not depend on an opt-in domain label. The previous label filtering hid a stale import introduced by the backend refactor.

## Validation

- `PYTHONPATH=/tmp/miles_hybrid_fix_20260807 python tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py`
- All four 4-GPU configurations passed on H200: flat DP4, DP2+SP2, HSDP 2x2, and HSDP 2x1+SP2.

## Files

- `tests/fast-gpu/backends/fsdp_utils/test_hybrid_shard.py`: move the suite to stage B and make it unconditional.
- `tests/fast-gpu/backends/fsdp_utils/_hybrid_shard_worker.py`: use the current state broadcast helper.

## Checklist

- [ ] `pre-commit run --all-files` passes — not run locally.
- [x] Added/updated tests for new behaviour.
- [ ] `pytest -x` is green — full suite not run; the targeted four-case GPU suite passes.
- [x] If launch flags changed, `python3 train.py --help` still parses — not applicable.
- [x] If a public flag was added, it appears in the CLI reference docs — not applicable.
- [x] If an example was added, it has a real walkthrough — not applicable.

This PR was authored with Claude.

Made with [Cursor](https://cursor.com)