### PR TITLE
refactor(fsdp)(4.4/5): organize monkey patch modules

### DIFF
--- a/miles/backends/fsdp_utils/monkey_patches/__init__.py
+++ b/miles/backends/fsdp_utils/monkey_patches/__init__.py
@@ -1,0 +1,1 @@
+"""Version-specific runtime patches for FSDP dependencies."""

--- a/miles/backends/fsdp_utils/monkey_patches/_fsdp_param_dtype_patch_2_11.py
+++ b/miles/backends/fsdp_utils/monkey_patches/_fsdp_param_dtype_patch_2_11.py
@@ -40,7 +40,7 @@ from torch.distributed.fsdp._fully_shard._fsdp_param_group import (
 )
 from torch.distributed.tensor import DTensor, Shard
 
-from miles.backends.fsdp_utils.fsdp_param_dtype_patch import ParamDtypeMixedPrecisionPolicy
+from miles.backends.fsdp_utils.monkey_patches.fsdp_param_dtype_patch import ParamDtypeMixedPrecisionPolicy
 
 if TYPE_CHECKING:
     from torch.distributed.fsdp._fully_shard._fsdp_collectives import (

--- a/miles/backends/fsdp_utils/monkey_patches/fsdp_param_dtype_patch.py
+++ b/miles/backends/fsdp_utils/monkey_patches/fsdp_param_dtype_patch.py
@@ -15,7 +15,7 @@ class ParamDtypeMixedPrecisionPolicy(MixedPrecisionPolicy):
 def apply_param_dtype_map_patch() -> None:
     torch_version = torch.__version__.partition("+")[0]
     if torch_version == "2.11.0":
-        from miles.backends.fsdp_utils._fsdp_param_dtype_patch_2_11 import (
+        from miles.backends.fsdp_utils.monkey_patches._fsdp_param_dtype_patch_2_11 import (
             apply_param_dtype_map_patch as apply_torch_2_11_patch,
         )
 

--- a/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_adversarial_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_adversarial_worker.py
@@ -39,7 +39,7 @@ from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import fully_shard
 
-from miles.backends.fsdp_utils import fsdp_param_dtype_patch
+from miles.backends.fsdp_utils.monkey_patches import fsdp_param_dtype_patch
 
 
 @dataclass(frozen=True)

--- a/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_validation_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_validation_worker.py
@@ -43,7 +43,7 @@ from torch import nn
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.tensor import DTensor
 
-from miles.backends.fsdp_utils import fsdp_param_dtype_patch
+from miles.backends.fsdp_utils.monkey_patches import fsdp_param_dtype_patch
 
 
 class MixedParamDtypeModel(nn.Module):

--- a/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_worker.py
@@ -47,7 +47,7 @@ from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.tensor import DTensor
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from miles.backends.fsdp_utils import fsdp_param_dtype_patch
+from miles.backends.fsdp_utils.monkey_patches import fsdp_param_dtype_patch
 
 MODEL_NAMES = ("wan2_2", "ltx2_3")
 TOPOLOGIES = ("fully_shard_1x4", "hybrid_shard_2x2")

--- a/tests/fast-gpu/backends/fsdp_utils/torch_ported/sitecustomize.py
+++ b/tests/fast-gpu/backends/fsdp_utils/torch_ported/sitecustomize.py
@@ -1,6 +1,6 @@
 import torch
 
-from miles.backends.fsdp_utils.fsdp_param_dtype_patch import apply_param_dtype_map_patch
+from miles.backends.fsdp_utils.monkey_patches.fsdp_param_dtype_patch import apply_param_dtype_map_patch
 
 apply_param_dtype_map_patch()
 torch.use_deterministic_algorithms(True)

--- a/tests/fast/backends/fsdp_utils/test_fsdp_param_dtype_patch.py
+++ b/tests/fast/backends/fsdp_utils/test_fsdp_param_dtype_patch.py
@@ -8,11 +8,11 @@ import pytest
 import torch
 from torch import nn
 
-from miles.backends.fsdp_utils import fsdp_param_dtype_patch
+from miles.backends.fsdp_utils.monkey_patches import fsdp_param_dtype_patch
 
 
 def test_patch_rejects_unpinned_torch(monkeypatch):
-    implementation_module = "miles.backends.fsdp_utils._fsdp_param_dtype_patch_2_11"
+    implementation_module = "miles.backends.fsdp_utils.monkey_patches._fsdp_param_dtype_patch_2_11"
     monkeypatch.delitem(sys.modules, implementation_module, raising=False)
     monkeypatch.setattr(torch, "__version__", "2.12.0+cu130")
 
@@ -22,7 +22,7 @@ def test_patch_rejects_unpinned_torch(monkeypatch):
 
 
 def test_patch_rejects_source_drift(monkeypatch):
-    from miles.backends.fsdp_utils import _fsdp_param_dtype_patch_2_11
+    from miles.backends.fsdp_utils.monkey_patches import _fsdp_param_dtype_patch_2_11
 
     monkeypatch.setitem(
         _fsdp_param_dtype_patch_2_11._SOURCE_HASHES,
@@ -54,7 +54,7 @@ def test_param_dtype_policy_keeps_exact_sparse_map():
 
 
 def test_resolve_param_dtype_map_broadcasts_duplicate_fqns():
-    from miles.backends.fsdp_utils import _fsdp_param_dtype_patch_2_11
+    from miles.backends.fsdp_utils.monkey_patches import _fsdp_param_dtype_patch_2_11
 
     modules = tuple(nn.LayerNorm(8) for _ in range(2))
     params = [param for module in modules for param in module.parameters()]


### PR DESCRIPTION
File organization only: move the FSDP runtime patch modules into a dedicated `monkey_patches` package; authored with Claude.