### PR TITLE
fix(sft): drop the cond cast deleted with loss_hub.utils

### DIFF
--- a/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
+++ b/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
@@ -73,7 +73,6 @@ def prepare_flow_grpo_batch(
         if use_cfg
         else None
     )
-    # Cond dtypes are set at the model boundary by the family input_dtype_policy (see actor).
     cfg_batching = use_cfg and bool(args.fsdp_cfg_batching)
     joint_cond = pos_cond = neg_cond = None
     if cfg_batching:

--- a/miles/backends/fsdp_utils/loss_hub/nft.py
+++ b/miles/backends/fsdp_utils/loss_hub/nft.py
@@ -37,7 +37,6 @@ def prepare_nft_batch(
 
     component_name, model = next(iter(ctx.models.items()))
     pos_list = [config.prepare_cond_kwargs(batch[i]["denoising_env"].pos_cond_kwargs, device) for i in range(bsz)]
-    # Cond dtypes are set at the model boundary by the family input_dtype_policy (see actor).
     pos_cond = config.collate_cond_for_sample_batch(pos_list, device, pad_to_len=pad_to_len)
 
     num_train_timesteps = ctx.scheduler.config.num_train_timesteps

--- a/miles/backends/fsdp_utils/loss_hub/sft.py
+++ b/miles/backends/fsdp_utils/loss_hub/sft.py
@@ -8,7 +8,6 @@ import torch
 import torch.nn as nn
 
 from miles.backends.fsdp_utils.loss_hub.types import DiffusionLossContext, PreparedBatch
-from miles.backends.fsdp_utils.loss_hub.utils import cast_cond_to_dtype
 from miles.utils.metric_buffer import MetricBuffer
 
 
@@ -90,10 +89,7 @@ def prepare_sft_batch(
         timesteps_for_model = timesteps
 
     cond_list = [{key: value.to(device) for key, value in pair["cond_kwargs"].items()} for pair in batch]
-    pos_cond = cast_cond_to_dtype(
-        config.collate_cond_for_sample_batch(cond_list, device, pad_to_len=pad_to_len),
-        ctx.forward_dtype,
-    )
+    pos_cond = config.collate_cond_for_sample_batch(cond_list, device, pad_to_len=pad_to_len)
 
     return PreparedBatch(
         latents=latents,


### PR DESCRIPTION
## What

- Remove `loss_hub/sft.py`'s import of the deleted `loss_hub.utils.cast_cond_to_dtype` and its cond pre-cast, mirroring what #103 did to `flow_grpo`/`nft` (whose leftover comment lines are dropped too).

## Why

#90 (SFT) merged first and imports `loss_hub.utils`; #103 merged after and deleted it — both PRs were green, but every stage-a-cpu run on the merged main now fails at collection with `ModuleNotFoundError`. Boundary input dtypes are family `input_dtype_policy` territory since #103, and SFT batches flow through the same actor boundary; Wan declares no policy today, deliberately left as a separate family decision.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour — **none needed: this restores collection of the existing `test_loss_hub_sft.py`**
- [ ] `pytest -x` is green — **not run locally (no local torch)**; stage-a-cpu re-runs the suite
- [x] Remaining items — **no flags/docs/examples touched**
