### PR TITLE
refactor(args): move cfg_batching from a CLI flag to TrainPipelineConfig

### DIFF
--- a/miles/backends/fsdp_utils/configs/qwen_image.py
+++ b/miles/backends/fsdp_utils/configs/qwen_image.py
@@ -57,6 +57,7 @@ def _rebuild_pos_embed_freqs_on_cuda(model) -> None:
 @register_train_pipeline_config("qwen_image")
 class QwenImageTrainPipelineConfig(TrainPipelineConfig):
     hf_ckpt_name_patterns = ("qwen-image",)
+    cfg_batching = False
 
     lora_target_modules = [
         "to_q",

--- a/miles/backends/fsdp_utils/configs/sd3.py
+++ b/miles/backends/fsdp_utils/configs/sd3.py
@@ -14,6 +14,7 @@ class SD3TrainPipelineConfig(TrainPipelineConfig):
     """Training-side adapters for diffusers SD3Transformer2DModel."""
 
     hf_ckpt_name_patterns = ("stable-diffusion-3", "sd3")
+    cfg_batching = False
 
     lora_target_modules = [
         "attn.to_q",

--- a/miles/backends/fsdp_utils/configs/train_pipeline_config.py
+++ b/miles/backends/fsdp_utils/configs/train_pipeline_config.py
@@ -83,6 +83,7 @@ class TrainPipelineConfig(abc.ABC):
     # Case-insensitive substrings matched against the checkpoint name (--diffusion-model).
     hf_ckpt_name_patterns: tuple[str, ...] = ()
     supports_cfg_training: bool = True
+    cfg_batching: bool = False
     # Model-boundary input dtypes (see input_dtype_policy); families opt into casts explicitly.
     input_dtype_policy: dict = {"latents": None, "cond": None, "timestep": None}
     # Default component paths (miles custom-function style); CLI args override.

--- a/miles/backends/fsdp_utils/configs/train_pipeline_config.py
+++ b/miles/backends/fsdp_utils/configs/train_pipeline_config.py
@@ -83,6 +83,7 @@ class TrainPipelineConfig(abc.ABC):
     # Case-insensitive substrings matched against the checkpoint name (--diffusion-model).
     hf_ckpt_name_patterns: tuple[str, ...] = ()
     supports_cfg_training: bool = True
+    # Mirrors serial sgl-d serving; not valid when the rollout engine runs --enable-cfg-parallel (branches split per rank, different combine formula).
     cfg_batching: bool = False
     # Model-boundary input dtypes (see input_dtype_policy); families opt into casts explicitly.
     input_dtype_policy: dict = {"latents": None, "cond": None, "timestep": None}

--- a/miles/backends/fsdp_utils/configs/wan2_2.py
+++ b/miles/backends/fsdp_utils/configs/wan2_2.py
@@ -11,6 +11,7 @@ from .train_pipeline_config import TrainPipelineConfig, register_train_pipeline_
 @register_train_pipeline_config("wan2_2")
 class Wan2_2TrainPipelineConfig(TrainPipelineConfig):
     hf_ckpt_name_patterns = ("wan2.2", "wan-2.2")
+    cfg_batching = False
     # High-noise expert ("transformer") handles t >= boundary, low-noise expert
     # ("transformer_2") the rest.
     boundary_ratio = 0.875

--- a/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
+++ b/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
@@ -73,7 +73,7 @@ def prepare_flow_grpo_batch(
         if use_cfg
         else None
     )
-    cfg_batching = use_cfg and bool(args.fsdp_cfg_batching)
+    cfg_batching = use_cfg and config.cfg_batching
     joint_cond = pos_cond = neg_cond = None
     if cfg_batching:
         joint_cond = config.collate_cond_for_sample_batch(pos_list + neg_list, device, pad_to_len=pad_to_len)

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -151,19 +151,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
-                "--fsdp-cfg-batching",
-                action=argparse.BooleanOptionalAction,
-                default=False,
-                help=(
-                    "Batch positive and negative CFG branches into a single DiT "
-                    "forward (concat along batch dim, one forward, then chunk). "
-                    "Default False = two separate forwards. Set True to bit-exact "
-                    "match sgl-d models that join CFG into one batched forward "
-                    "(e.g. Flux variants); leave False for split-CFG models like "
-                    "Qwen-Image."
-                ),
-            )
-            parser.add_argument(
                 "--fsdp-master-dtype",
                 type=str,
                 default="fp32",


### PR DESCRIPTION
## What

- Adds `cfg_batching` to `TrainPipelineConfig`, declared per model family next to `supports_cfg_training`.
- `prepare_flow_grpo_batch` reads it off the config it already holds instead of off `args`.
- Removes `--fsdp-cfg-batching`.

## Why

CFG batching is a property of how sgl-d serves each model, not a per-run choice, and a
wrong value does not fail loudly — the trainer's `noise_pred` silently diverges from
the rollout engine's. The CLI flag hid this behind one global default: correct today
only because SD3.5, Qwen-Image and Wan2.2 all split, wrong the day a joined family
(LTX-2 `[neg, pos]`, Cosmos3, Hunyuan3D-2, SANA-WM) lands.

## Behaviour

No-op: all four families keep `False`. LTX short-circuits via
`supports_cfg_training = False`; its future value is `True` with `[neg, pos]` order.
Under `--enable-cfg-parallel` sgl-d splits branches per rank and combines as
`g*pos + (1-g)*neg` — such deployments keep `False` and mirror that formula (follow-up).

## Files

| File | Role |
|---|---|
| `configs/train_pipeline_config.py` | New `cfg_batching` base field |
| `configs/sd3.py`, `configs/qwen_image.py`, `configs/wan2_2.py` | Per-family value |
| `loss_hub/flow_grpo.py` | Read from the config instead of `args` |
| `utils/arguments.py` | Drop `--fsdp-cfg-batching` |

## Checklist

- [ ] `pre-commit run --all-files` — **not run** (no local env)
- [ ] Added/updated tests — **no tests added**; the change is a value-source swap with no new behaviour
- [ ] `pytest -x` is green — **not run**; no torch/sglang/ray locally
- [x] Launch flags changed and the parser still builds (`py_compile` on the touched modules; full `--help` needs the runtime deps)
- [x] No public flag added — one removed, and it appears in no recipe or test
- [ ] Example walkthrough — n/a

Opening as a draft: the no-op claim rests on reading the four family configs, and
should get one real run on a recipe before merge.
