### PR TITLE
chore(args)(1/10): remove eight arguments nothing reads

### DIFF
--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -28,7 +28,6 @@ class FSDPArgs:
     # diffusion comparisons.
     adam_beta2: float = 0.999
     adam_eps: float = 1e-8
-    warmup_ratio: float = 0.03
 
     attn_implementation: str = "flash_attention_2"
 
@@ -37,14 +36,12 @@ class FSDPArgs:
 
     # Logging
     wandb_project: str = "miles-fsdp"
-    wandb_run_name: str | None = None
 
     # Precision
     gradient_checkpointing: bool = False
     fp16: bool = False
 
     # FSDP configuration
-    fsdp_state_dict_cpu_offload: bool = True  # If True, offload full state dict to CPU during collection.
     fsdp_cpu_offload: bool = (
         False  # If True, offload parameters, gradients, and optimizer states to CPU (optimizer runs on CPU)
     )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -206,12 +206,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Extra environment variables for training process, e.g. PyTorch memory management ones.",
             )
             parser.add_argument(
-                "--train-memory-margin-bytes",
-                type=int,
-                default=1024**3,
-                help="Add margin for train memory allocation. By default we will reserve 1GB as margin.",
-            )
-            parser.add_argument(
                 "--recompute-loss-function",
                 action="store_true",
                 help="Whether to disable recompute loss function to save memory during training.",
@@ -277,12 +271,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default=None,
                 help="Model loading function path; default from the family config.",
-            )
-            parser.add_argument(
-                "--diffusion-device",
-                type=str,
-                default=None,
-                help="Device for diffusion rollout, e.g. cuda or cpu. Defaults to auto.",
             )
             parser.add_argument(
                 "--diffusion-num-steps",
@@ -440,11 +428,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Set rollout_debug_mode=true on POST /rollout/generate.",
             )
             parser.add_argument(
-                "--diffusion-return-prev-latents-mean",
-                action="store_true",
-                help="Whether to store prev_latents_mean for KL regularization.",
-            )
-            parser.add_argument(
                 "--diffusion-reward",
                 type=str,
                 default="pickscore",
@@ -596,12 +579,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "buffer size for update weight, in bytes. "
                     "This is used for updating weights by chunk and should be useful for MoE models."
                 ),
-            )
-            parser.add_argument(
-                "--update-weights-interval",
-                type=int,
-                default=1,
-                help="Interval for updating the weights",
             )
             return parser
 
@@ -1116,12 +1093,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
 
             # LoRA
-            parser.add_argument(
-                "--diffusion-ignore-last",
-                type=int,
-                default=0,
-                help="Skip last N denoising steps for training (avoids small-sigma numerical issues). FlowGRPO/DanceGRPO use 1.",
-            )
             parser.add_argument(
                 "--use-lora", action="store_true", default=False, help="Use LoRA adapters instead of full finetune."
             )
@@ -1697,9 +1668,6 @@ def miles_validate_args(args):
             args.actor_num_nodes = args.rollout_num_gpus // args.actor_num_gpus_per_node
         args.colocate = False
         args.offload_train = args.offload_rollout = False
-        if args.train_memory_margin_bytes > 0:
-            logger.warning("Force train_memory_margin_bytes=0 since debug_rollout_only does not support it")
-            args.train_memory_margin_bytes = 0
 
     if getattr(args, "diffusion_model", None):
         from miles.backends.fsdp_utils.arguments import validate_hybrid_shard_args, validate_sp_args

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -110,7 +110,6 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --update-weight-buffer-size 2147483648 \
   --diffusion-guidance-scale 4.5 \
   --diffusion-noise-level 0.7 \
-  --diffusion-ignore-last 1 \
   --diffusion-height 512 \
   --diffusion-width 512 \
   --global-batch-size 64 \


### PR DESCRIPTION
## What

Eight flags, their one dead validation block, and the one recipe line that passed one of
them. 3 files, 36 deletions, no additions.

| Flag | Declared in | In miles |
|---|---|---|
| `--train-memory-margin-bytes` | `utils/arguments.py` | alive, Megatron actor |
| `--diffusion-device` | `utils/arguments.py` | not present |
| `--diffusion-return-prev-latents-mean` | `utils/arguments.py` | not present |
| `--update-weights-interval` | `utils/arguments.py` | alive, Megatron actor |
| `--diffusion-ignore-last` | `utils/arguments.py` | not present |
| `--warmup-ratio` | `FSDPArgs` | present, dead there too |
| `--wandb-run-name` | `FSDPArgs` | present, dead there too |
| `--fsdp-state-dict-cpu-offload` | `FSDPArgs` | present, dead there too |

The ones alive upstream are alive on paths this repo does not have — they feed the
Megatron actor, which diffusion training never runs. The three dead in both are
candidates for a matching cleanup upstream.

## Why

Two are worth a closer look.

**`--diffusion-ignore-last`** is passed by the SD3 OCR recipe as
`--diffusion-ignore-last 1`, but nothing reads it, so the "skip the last N denoising
steps" behaviour it implies has never happened. Removing the flag and the recipe line
together makes that explicit instead of leaving a knob that reads as active.

**`--fsdp-state-dict-cpu-offload`** sits next to the live `--fsdp-cpu-offload` and is
easy to mistake for it. Every CPU-offload site reads `--fsdp-cpu-offload`: the FSDP2
`CPUOffloadPolicy` (`actor.py:146`), the `StateDictOptions` in
`broadcast_full_state_to_fsdp` (`actor.py:152`), and the `offload_train` guard
(`actor.py:88`). Checkpoint save passes no `StateDictOptions` at all. It is also a bool
field, and `parse_fsdp_cli` gives every bool `action="store_true"` with no `default`, so
its declared `True` was already reaching the run as `False`.

`--train-memory-margin-bytes` takes a validation block with it: the `debug_rollout_only`
branch existed only to force the unread value back to zero.

## How this was checked

Each flag was grepped in all four forms it can take: `args.<name>`,
`getattr(args, "<name>")`, a bare string key, and `--flag-name` in scripts and tests. The
flag spelling alone finds nothing outside the definition — argparse rewrites hyphens to
underscores, so consuming code never contains it.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the change only deletes unread arguments
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors` before and after (all pre-existing, from torch/sglang/ray missing locally)
- [x] Launch flags changed and the parser still builds (`py_compile`; `bash -n` on the touched recipe)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: the local environment cannot import torch, sglang or ray, so the evidence is
static analysis plus an unchanged fast-test result.
