### PR TITLE
chore(args)(2/10): remove six arguments their subsystem never brought over

### DIFF
--- a/miles/backends/fsdp_utils/arguments.py
+++ b/miles/backends/fsdp_utils/arguments.py
@@ -29,8 +29,6 @@ class FSDPArgs:
     adam_beta2: float = 0.999
     adam_eps: float = 1e-8
 
-    attn_implementation: str = "flash_attention_2"
-
     # diffusers set_attention_backend value; None keeps the default. Ring attention accepts the RING_KERNELS subset.
     fsdp_attention_backend: str | None = None
 
@@ -39,7 +37,6 @@ class FSDPArgs:
 
     # Precision
     gradient_checkpointing: bool = False
-    fp16: bool = False
 
     # FSDP configuration
     fsdp_cpu_offload: bool = (

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -231,16 +231,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
-                "--model-name",
-                type=str,
-                default=None,
-                help=(
-                    "The name of the model, this is used to convert the megatron weights into huggingface format. "
-                    "If not set, we will use `type(AutoConfig.from_pretrained(args.hf_checkpoint)).__name__.lower()` as model_name. "
-                    "Also, sometimes this will help alleviate the bug that transformers cannot find certain model."
-                ),
-            )
-            parser.add_argument(
                 "--rollout-function-path",
                 type=str,
                 default="miles.rollout.sglang_rollout.generate_rollout",
@@ -426,18 +416,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
                 help="Set rollout_debug_mode=true on POST /rollout/generate.",
-            )
-            parser.add_argument(
-                "--diffusion-reward",
-                type=str,
-                default="pickscore",
-                help="Reward function name for diffusion rollout.",
-            )
-            parser.add_argument(
-                "--diffusion-reward-device",
-                type=str,
-                default=None,
-                help="Device for diffusion reward model, defaults to diffusion-device.",
             )
             parser.add_argument(
                 "--diffusion-log-images",
@@ -1227,12 +1205,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             parser.add_argument(
                 "--group-rm", action="store_true", default=False, help="Whether to do rm on a whole group."
-            )
-            parser.add_argument(
-                "--rm-url",
-                type=str,
-                default=None,
-                help="URL for the reward model service for --rm-type remote_rm, e.g. http://localhost:8000",
             )
             parser.add_argument(
                 "--ocr-num-workers",

--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -87,7 +87,6 @@ fi
   --advantage-estimator grpo \
   --globalize-reward-std \
   --rm-type pickscore \
-  --diffusion-reward pickscore:1.0 \
   --pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K \
   --pickscore-model-path yuvalkirstain/PickScore_v1 \
   --pickscore-num-frames 3 \

--- a/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
@@ -81,7 +81,6 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --sglang-attention-backend torch_sdpa \
   --update-weight-buffer-size 2147483648 \
   --diffusion-model Qwen/Qwen-Image \
-  --diffusion-reward pickscore:1.0 \
   --advantage-estimator grpo \
   --globalize-reward-std \
   --rm-type pickscore \

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -95,7 +95,6 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --weight-decay 1e-4 \
   --diffusion-kl-beta 0.04 \
   --diffusion-model "${SD3_MODEL}" \
-  --diffusion-reward ocr:1.0 \
   --advantage-estimator grpo \
   --globalize-reward-std \
   --rm-type ocr \

--- a/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
+++ b/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
@@ -95,7 +95,6 @@ WAN_LORA_TARGET_MODULES=(
   --sglang-server-concurrency 8 \
   --update-weight-buffer-size 2147483648 \
   --update-weight-target-module transformer,transformer_2 \
-  --diffusion-reward pickscore:1.0 \
   --advantage-estimator grpo \
   --rm-type pickscore \
   --pickscore-num-workers 1 \

--- a/scripts/run-diffusion-nft-sd3-pickscore.sh
+++ b/scripts/run-diffusion-nft-sd3-pickscore.sh
@@ -43,7 +43,6 @@ if [[ "${SMOKE}" == "1" ]]; then
     --local-dir "${DATASETS_DIR}"
   PROMPT_DATA="${DATASETS_DIR}/flowgrpo_ocr/train.jsonl"
   REWARD_ARGS=(
-    --diffusion-reward ocr:1.0
     --rm-type ocr
   )
   # 2-GPU smoke: tiny batch, no dedicated reward GPU.
@@ -66,7 +65,6 @@ else
     --local-dir "${DATASETS_DIR}"
   PROMPT_DATA="${DATASETS_DIR}/flowgrpo_pickscore/train.jsonl"
   REWARD_ARGS=(
-    --diffusion-reward pickscore:1.0
     --rm-type pickscore
     --pickscore-num-workers 1
     --pickscore-num-gpus-per-worker 1.0


### PR DESCRIPTION
This PR is stacked on #112.

## What

Six flags and the five recipes that still passed one of them. 7 files, 36 deletions,
no additions.

| Flag | Replaced here by | In miles |
|---|---|---|
| `--model-name` | – (Megatron-only concern) | alive: Megatron actor, `hf_export.py` |
| `--rm-url` | `--custom-rm-path` | alive: `rm_hub`, on-policy distillation |
| `--attn-implementation` | `--fsdp-attention-backend` | alive: FSDP actor `from_pretrained` |
| `--fp16` | `--fsdp-master-dtype` / `--diffusion-forward-dtype` | alive: FSDP precision policy |
| `--diffusion-reward` | `--rm-type` | not present |
| `--diffusion-reward-device` | – (Ray schedules reward actors) | not present |

## Why

The four that are alive upstream are alive on paths this repo does not have, so removing
them is not a divergence from miles — the subsystem simply never came over.

- `--model-name` drives Megatron-to-HuggingFace weight conversion. There is no Megatron
  backend here.
- `--rm-url` is the LLM remote-reward escape hatch: a JSON POST of
  `prompt`/`response`/`label`. Diffusion rewards are Ray actors handling image and video
  tensors, so the protocol does not carry over; `--custom-rm-path` is the equivalent hook.
- `--fp16` and `--attn-implementation` belong to the transformers-based FSDP path. The DiT
  is a diffusers `ModelMixin`: dtype comes from the three `--*-dtype` flags, attention from
  `--fsdp-attention-backend`.

`--attn-implementation` is worth singling out because it could not be wired up even
deliberately. diffusers has no `attn_implementation` argument anywhere in the package
(checked against 0.39.0); attention backends go through `ModelMixin.set_attention_backend`.
An unknown kwarg to `from_pretrained` lands in `unused_kwargs` and is passed to
`from_config`, so it would be dropped silently rather than raising.

`--diffusion-reward` is local to this repo and was superseded by `--rm-type` before
anything read it. Five recipes still pass it, always beside the `--rm-type` that replaced
it, with a `pickscore:1.0` weight syntax belonging to a multi-reward design that was never
built.

## How this was checked

Each flag grepped in all four forms it can take — `args.<name>`,
`getattr(args, "<name>")`, a bare string key, and `--flag-name` in scripts and tests — plus
the same sweep against miles to classify the upstream column.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the change only deletes unread arguments
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds (`py_compile`; `bash -n` on all five recipes)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so the evidence is static analysis plus an unchanged
fast-test result.
