### PR TITLE
refactor(args)(4/10): extract add_lora_arguments and rename the PEFT init flag

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -605,7 +605,7 @@ def apply_lora(model: torch.nn.Module, args: Namespace, train_pipeline_config) -
     on_meta = dist.get_rank() != 0
     # Per-model fallback when --lora-target-modules is unset (runtime inference: depends on loaded pipeline).
     targets = args.lora_target_modules or train_pipeline_config.lora_target_modules
-    init_lora_weight = args.diffusion_init_lora_weight
+    init_lora_weight = args.lora_init_weights
     if init_lora_weight == "kaiming-uniform":
         init_lora_weight = True  # namely kaiming-uniform
     model = get_peft_model(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -978,6 +978,41 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument("--wandb-run-id", type=str, default=None)
             return parser
 
+        def add_lora_arguments(parser):
+            parser.add_argument(
+                "--use-lora", action="store_true", default=False, help="Use LoRA adapters instead of full finetune."
+            )
+            parser.add_argument("--lora-rank", type=int, default=64)
+            parser.add_argument("--lora-alpha", type=int, default=64)
+            parser.add_argument(
+                "--lora-target-modules",
+                type=str,
+                nargs="+",
+                default=None,
+                help="Override LoRA target modules. Default: per-model from TrainPipelineConfig.",
+            )
+            parser.add_argument(
+                "--lora-init-weights",
+                type=str,
+                default="gaussian",
+                help=(
+                    "PEFT LoraConfig.init_lora_weights. flow_grpo's Qwen-Image uses 'gaussian' "
+                    "(N(0, 1/r) for lora_A, 0 for lora_B). 'kaiming-uniform' maps to PEFT's "
+                    "default Kaiming-uniform init. Other PEFT schemes ('olora', 'pissa', "
+                    "'pissa_niter_N', 'loftq', ...) pass through unchanged."
+                ),
+            )
+            parser.add_argument(
+                "--lora-ipc-weight-sync",
+                action="store_true",
+                default=False,
+                help=(
+                    "Sync only lora_A/lora_B to rollout via IPC with weight_update_mode=lora_merge "
+                    "(requires matching sglang-d LoRAPipeline support)."
+                ),
+            )
+            return parser
+
         # debug
         def add_debug_arguments(parser):
             parser.add_argument(
@@ -1037,28 +1072,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
 
-            # LoRA
-            parser.add_argument(
-                "--use-lora", action="store_true", default=False, help="Use LoRA adapters instead of full finetune."
-            )
-            parser.add_argument("--lora-rank", type=int, default=64)
-            parser.add_argument("--lora-alpha", type=int, default=64)
-            parser.add_argument(
-                "--lora-target-modules",
-                type=str,
-                nargs="+",
-                default=None,
-                help="Override LoRA target modules. Default: per-model from TrainPipelineConfig.",
-            )
-            parser.add_argument(
-                "--lora-ipc-weight-sync",
-                action="store_true",
-                default=False,
-                help=(
-                    "Sync only lora_A/lora_B to rollout via IPC with weight_update_mode=lora_merge "
-                    "(requires matching sglang-d LoRAPipeline support)."
-                ),
-            )
+            # EMA
             parser.add_argument(
                 "--ema-shadow",
                 action="store_true",
@@ -1102,17 +1116,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=int,
                 default=0,
                 help="EMA flat steps before warmup begins.",
-            )
-            parser.add_argument(
-                "--diffusion-init-lora-weight",
-                type=str,
-                default="gaussian",
-                help=(
-                    "PEFT LoraConfig.init_lora_weights. flow_grpo's Qwen-Image uses 'gaussian' "
-                    "(N(0, 1/r) for lora_A, 0 for lora_B). 'kaiming-uniform' maps to PEFT's "
-                    "default Kaiming-uniform init. Other PEFT schemes ('olora', 'pissa', "
-                    "'pissa_niter_N', 'loftq', ...) pass through unchanged."
-                ),
             )
 
             parser.add_argument(
@@ -1301,6 +1304,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_data_arguments(parser)
         parser = add_eval_arguments(parser)
         parser = add_algo_arguments(parser)
+        parser = add_lora_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_router_arguments(parser)
         parser = add_debug_arguments(parser)

--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -62,7 +62,7 @@ fi
   --use-lora \
   --lora-rank 64 \
   --lora-alpha 128 \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 2e-4 \
   --adam-beta2 0.999 \
   --weight-decay 1e-4 \

--- a/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
@@ -71,7 +71,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --lora-ipc-weight-sync \
   --lora-rank 64 \
   --lora-alpha 128 \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 3e-4 \
   --adam-beta2 0.999 \
   --diffusion-clip-range 1e-4 \

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -88,7 +88,7 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --lora-ipc-weight-sync \
   --lora-rank 32 \
   --lora-alpha 64 \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 3e-4 \
   --adam-beta2 0.999 \
   --diffusion-clip-range 1e-4 \

--- a/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
+++ b/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
@@ -86,7 +86,7 @@ WAN_LORA_TARGET_MODULES=(
   --lora-rank 64 \
   --lora-alpha 128 \
   --lora-target-modules "${WAN_LORA_TARGET_MODULES[@]}" \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 1e-4 \
   --adam-beta2 0.999 \
   --diffusion-clip-range 1e-4 \

--- a/scripts/run-diffusion-nft-sd3-pickscore.sh
+++ b/scripts/run-diffusion-nft-sd3-pickscore.sh
@@ -106,7 +106,7 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --lora-ipc-weight-sync \
   --lora-rank 32 \
   --lora-alpha 64 \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 3e-4 \
   --adam-beta2 0.999 \
   --weight-decay 1e-4 \

--- a/scripts/run-diffusion-sft-wan22.sh
+++ b/scripts/run-diffusion-sft-wan22.sh
@@ -70,7 +70,7 @@ WAN_LORA_TARGET_MODULES=(
   --lora-rank 64 \
   --lora-alpha 128 \
   --lora-target-modules "${WAN_LORA_TARGET_MODULES[@]}" \
-  --diffusion-init-lora-weight gaussian \
+  --lora-init-weights gaussian \
   --lr 1e-4 \
   --adam-beta2 0.999 \
   --weight-decay 1e-4 \


### PR DESCRIPTION
This PR is stacked on #116. First of the regrouping half of the stack; the deletions came
first so there is less to move.

## What

A new `add_lora_arguments` group, five arguments moved into it verbatim, one renamed, and
the call placed in miles' position. 8 files.

| Flag | Change |
|---|---|
| `--use-lora` | debug → lora |
| `--lora-rank` | debug → lora |
| `--lora-alpha` | debug → lora |
| `--lora-target-modules` | debug → lora |
| `--lora-ipc-weight-sync` | debug → lora |
| `--diffusion-init-lora-weight` | debug → lora, renamed to `--lora-init-weights` |

## Why the group

`add_debug_arguments` said nothing about what these do — LoRA is a training mode, not a
debugging aid. miles keeps them in `add_lora_arguments`; this fork dropped that group, and
the arguments landed in whatever function happened to be open. Restoring it also puts the
call back where miles has it, right after `add_algo_arguments`, so the fifteen groups both
repos share now appear in the same order and `--help` lists them the same way.

Same group name, unrelated contents: miles implements LoRA itself and has 21 flags for it;
this repo drives PEFT and has 6. Only `--lora-rank` and `--lora-alpha` are common, and
nothing here tries to align the members. (Noting for later: miles spells the target list
`--target-modules`, this repo `--lora-target-modules`.)

`add_debug_arguments` drops from 23 arguments to 17.

## Why the rename

Proposed standard for the `diffusion-` prefix, applied here for the first time:

1. **Domain** — the flag names the diffusion process itself and would be too broad without
   it: `--diffusion-num-steps`, `--diffusion-height`, `--diffusion-guidance-scale`.
2. **Side** — the same quantity exists on both sides and the prefix separates them:
   `--diffusion-flow-shift` configures the rollout engine, `--fsdp-flow-shift` the
   trainer's sigma grid.
3. **Otherwise, no prefix** — especially when a subsystem prefix (`lora-`, `nft-`, `ema-`,
   `pickscore-`) already places the flag.

`init_lora_weights` is not a diffusion concept and `lora-` already places it, so the prefix
was pure inheritance. The plural matches PEFT's own `LoraConfig.init_lora_weights`.

Six recipes pass this flag and are updated with it.

## How this was checked

An AST pass compares every `add_argument` block before and after: 174 arguments before, 174
after; the five moved blocks are byte-identical once whitespace is normalized, and the only
name change is the intended one. The renamed flag's `dest` was checked against its consumer
in `actor.py` — a `sed` that silently skipped that file would leave the parser producing
`lora_init_weights` while the code read `lora_init_weight`, which `py_compile` cannot catch.
Group call order was diffed against miles and matches for all fifteen shared groups.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the move is verified structurally and the rename has no behaviour change
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds (`py_compile`; `bash -n` on all six updated recipes)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so `--help` was not exercised end to end and the renamed
flag was not run through a real LoRA init.
