### PR TITLE
refactor(args)(5/10): extract add_ema_arguments and name the decay schedule

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -215,13 +215,13 @@ class FSDPTrainRayActor(TrainRayActor):
         checkpoint_payload = checkpoint.load(self)
 
         self.ema_shadow = None
-        if self.args.ema_shadow:
+        if self.args.use_ema:
             self.ema_shadow = EmaShadow(
                 (p for m in self.models.values() for p in m.parameters()),
-                decay=self.args.ema_decay,
-                uprate=self.args.ema_uprate,
-                uphold=self.args.ema_uphold,
-                flat_steps=self.args.ema_flat_steps,
+                decay=self.args.ema_decay_init,
+                uprate=self.args.ema_decay_ramp,
+                uphold=self.args.ema_decay_max,
+                flat_steps=self.args.ema_decay_flat_steps,
             )
 
         # sglang-d now supports /update_weights_from_tensor (PR #20464).

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1013,6 +1013,56 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
+        def add_ema_arguments(parser):
+            parser.add_argument(
+                "--use-ema",
+                action="store_true",
+                default=False,
+                help=(
+                    "Maintain an exponential moving average of the trainable weights as pi_old "
+                    "(LoRA or full finetune). Consumed by --ref-mode ema; combine with "
+                    "--ema-rollout-policy ema to sample under pi_old."
+                ),
+            )
+            parser.add_argument(
+                "--ema-rollout-policy",
+                type=str,
+                choices=["live", "ema"],
+                default="live",
+                help=(
+                    "Which trainable weights to push to rollout after each rollout_end when "
+                    "--use-ema is set: live weights, or the EMA copy (pi_old)."
+                ),
+            )
+            parser.add_argument(
+                "--ema-decay-init",
+                type=float,
+                default=0.001,
+                help="EMA decay during the flat period, before the ramp starts.",
+            )
+            parser.add_argument(
+                "--ema-decay-ramp",
+                type=float,
+                default=0.001,
+                help=(
+                    "Per-step increase of the EMA decay once the flat period ends. The ramp "
+                    "restarts from zero rather than continuing from --ema-decay-init."
+                ),
+            )
+            parser.add_argument(
+                "--ema-decay-max",
+                type=float,
+                default=0.5,
+                help="Ceiling the ramping EMA decay stops at.",
+            )
+            parser.add_argument(
+                "--ema-decay-flat-steps",
+                type=int,
+                default=0,
+                help="Steps the decay holds at --ema-decay-init before the ramp begins.",
+            )
+            return parser
+
         # debug
         def add_debug_arguments(parser):
             parser.add_argument(
@@ -1070,52 +1120,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "never drift. Useful for measuring pure forward-path divergence "
                     "from the rollout engine."
                 ),
-            )
-
-            # EMA
-            parser.add_argument(
-                "--ema-shadow",
-                action="store_true",
-                default=False,
-                help=(
-                    "Maintain an EMA shadow of trainable weights (pi_old; LoRA or full finetune). "
-                    "Consumed when --ref-mode ema; combine with --ema-rollout-policy ema to "
-                    "sample under pi_old."
-                ),
-            )
-            parser.add_argument(
-                "--ema-rollout-policy",
-                type=str,
-                choices=["live", "ema"],
-                default="live",
-                help=(
-                    "Which trainable weights to push to rollout after each rollout_end when "
-                    "--ema-shadow is set: live weights, or EMA shadow (pi_old)."
-                ),
-            )
-            parser.add_argument(
-                "--ema-decay",
-                type=float,
-                default=0.001,
-                help="EMA decay while step <= flat_steps.",
-            )
-            parser.add_argument(
-                "--ema-uprate",
-                type=float,
-                default=0.001,
-                help="EMA warmup rate after flat_steps.",
-            )
-            parser.add_argument(
-                "--ema-uphold",
-                type=float,
-                default=0.5,
-                help="EMA warmup cap.",
-            )
-            parser.add_argument(
-                "--ema-flat-steps",
-                type=int,
-                default=0,
-                help="EMA flat steps before warmup begins.",
             )
 
             parser.add_argument(
@@ -1305,6 +1309,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_eval_arguments(parser)
         parser = add_algo_arguments(parser)
         parser = add_lora_arguments(parser)
+        parser = add_ema_arguments(parser)
         parser = add_wandb_arguments(parser)
         parser = add_router_arguments(parser)
         parser = add_debug_arguments(parser)
@@ -1493,16 +1498,18 @@ def miles_validate_args(args):
                 "set --diffusion-model (for per-model defaults) or --lora-target-modules."
             )
 
-    if not 0.0 <= args.ema_decay <= 1.0:
-        raise ValueError(f"--ema-decay must be in [0, 1], got {args.ema_decay}")
-    if args.ema_uprate < 0.0:
-        raise ValueError(f"--ema-uprate must be non-negative, got {args.ema_uprate}")
-    if not 0.0 <= args.ema_uphold <= 1.0:
-        raise ValueError(f"--ema-uphold must be in [0, 1], got {args.ema_uphold}")
-    if args.ema_flat_steps < 0:
-        raise ValueError(f"--ema-flat-steps must be non-negative, got {args.ema_flat_steps}")
-    if args.ema_rollout_policy == "ema" and not args.ema_shadow:
-        raise ValueError("--ema-rollout-policy ema requires --ema-shadow")
+    if not 0.0 <= args.ema_decay_init <= 1.0:
+        raise ValueError(f"--ema-decay-init must be in [0, 1], got {args.ema_decay_init}")
+    if args.ema_decay_ramp < 0.0:
+        raise ValueError(f"--ema-decay-ramp must be non-negative, got {args.ema_decay_ramp}")
+    if not 0.0 <= args.ema_decay_max <= 1.0:
+        raise ValueError(f"--ema-decay-max must be in [0, 1], got {args.ema_decay_max}")
+    if args.ema_decay_flat_steps < 0:
+        raise ValueError(f"--ema-decay-flat-steps must be non-negative, got {args.ema_decay_flat_steps}")
+    if args.use_ema and args.ref_mode != "ema" and args.ema_rollout_policy != "ema":
+        raise ValueError("--use-ema has no consumer; set --ref-mode ema or --ema-rollout-policy ema")
+    if args.ema_rollout_policy == "ema" and not args.use_ema:
+        raise ValueError("--ema-rollout-policy ema requires --use-ema")
 
     if args.loss_type == "sft_loss":
         if not args.train_only:
@@ -1545,8 +1552,8 @@ def miles_validate_args(args):
             raise ValueError("--loss-type sft_loss does not support --diffusion-recompute-old-log-prob")
         if args.ref_mode != "none":
             raise ValueError("--loss-type sft_loss does not use a reference model; drop --ref-mode")
-        if args.ema_shadow:
-            raise ValueError("--loss-type sft_loss does not support --ema-shadow (EMA updates run in weight sync)")
+        if args.use_ema:
+            raise ValueError("--loss-type sft_loss does not support --use-ema (EMA updates run in weight sync)")
 
     is_nft = args.loss_type == "nft"
     if is_nft:
@@ -1567,8 +1574,8 @@ def miles_validate_args(args):
 
     if is_nft and args.ref_mode == "none":
         raise ValueError("--loss-type nft requires a reference model; set --ref-mode ema or lora_base")
-    if args.ref_mode == "ema" and not args.ema_shadow:
-        raise ValueError("--ref-mode ema requires --ema-shadow")
+    if args.ref_mode == "ema" and not args.use_ema:
+        raise ValueError("--ref-mode ema requires --use-ema")
     if args.ref_mode == "lora_base" and not args.use_lora:
         raise ValueError("--ref-mode lora_base requires --use-lora")
     if args.diffusion_kl_beta > 0 and args.ref_mode == "none":

--- a/scripts/run-diffusion-nft-sd3-pickscore.sh
+++ b/scripts/run-diffusion-nft-sd3-pickscore.sh
@@ -116,12 +116,12 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --diffusion-nft-adv-clip-max 5.0 \
   --diffusion-nft-timestep-fraction 0.99 \
   --ref-mode ema \
-  --ema-shadow \
+  --use-ema \
   --ema-rollout-policy ema \
-  --ema-decay 0.001 \
-  --ema-uprate 0.001 \
-  --ema-uphold 0.5 \
-  --ema-flat-steps 0 \
+  --ema-decay-init 0.001 \
+  --ema-decay-ramp 0.001 \
+  --ema-decay-max 0.5 \
+  --ema-decay-flat-steps 0 \
   --advantage-estimator grpo \
   --globalize-reward-std \
   --diffusion-model "${SD3_MODEL}" \


### PR DESCRIPTION
This PR is stacked on #117.

## What

A new `add_ema_arguments` group, six arguments moved into it, five renamed, and one
validation added. 3 files.

| Before | After |
|---|---|
| `--ema-shadow` | `--use-ema` |
| `--ema-decay` | `--ema-decay-init` |
| `--ema-uprate` | `--ema-decay-ramp` |
| `--ema-uphold` | `--ema-decay-max` |
| `--ema-flat-steps` | `--ema-decay-flat-steps` |
| `--ema-rollout-policy` | unchanged |

## Why the group

`add_debug_arguments` said nothing about what these do. The EMA copy is the `pi_old` a
reference forward or an off-policy rollout samples under — a training mode, not a
debugging aid. Unlike #117 there is no group to restore: miles has no EMA arguments at
all, so this group is new to the fork.

`add_debug_arguments` drops from 17 arguments to 11.

## Why the renames

Per the prefix and naming standard from #117, and because the old names described the
implementation rather than the job.

`--ema-shadow` named the in-memory copy, not the reason to keep one. `--use-ema` follows
the switch convention the repo already uses for `--use-lora`, `--use-wandb` and four
others, and stands to `--ema-decay-*` exactly as `--use-lora` stands to `--lora-rank`.

The remaining four are aspects of one curve — the decay holds at a starting value, then
ramps to a ceiling:

```
decay
 max ┤          ┌────────
     │         ╱
init ┤────────╱
     └────┬──────────────► step
      flat-steps
```

Only `--ema-decay` was named for the curve. `uprate` and `uphold` are not words a reader
can decode, and `uphold` reads as a verb. `--ema-decay` was actively misleading: it
applies only during the flat period, which is empty by default, so the flag named "the
decay" was the one with no effect on a default run.

No `schedule` infix: `init`, `ramp`, `max` and `flat-steps` only make sense for a curve,
so the word is implied, and there is no competing scalar `--ema-decay` left to
disambiguate against.

## The new validation

`--ref-mode ema` and `--ema-rollout-policy ema` each already required `--use-ema`. The
reverse went unchecked, so `--use-ema` on its own would update the copy every optimizer
step with nothing reading it. The two consumers are `actor.py:319` (weights pushed to the
engine) and `actor.py:556` (the reference forward); the flags are not redundant, since
using the EMA as a reference while still sampling under live weights is a real
configuration.

## Noted, not fixed

The ramp restarts from zero rather than continuing from `--ema-decay-init`, so raising
the flat value makes the decay drop at the transition — `--ema-decay-init 0.5` with the
default ramp falls to `0.001` on the step after the flat period. The defaults hide it
because `init` and `ramp` are both `0.001`. Documented in the help here; the fix belongs
in its own PR since it changes behaviour.

## How this was checked

An AST pass compares every `add_argument` block before and after: 174 arguments before,
174 after, no content changes beyond the intended renames. Each renamed flag's `dest` was
checked against its consumers — a rename that misses a consumer leaves the parser
producing one name while the code reads another, which `py_compile` cannot catch.
`EmaShadow`'s own `decay`/`uprate`/`uphold` parameter names are untouched; only the call
site changes.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; no behaviour change except the new validation, which rejects a configuration that previously did nothing
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds (`py_compile`; `bash -n` on the updated recipe)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so `--help` was not exercised end to end and no EMA run
was made.
