### PR TITLE
refactor(args)(6/10): give the dashboard its own group and scope the media flags to wandb

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -210,7 +210,7 @@ class RolloutManager:
         data = result.data
         self._save_debug_rollout_data(data, rollout_id=rollout_id, evaluation=True)
         metrics = _log_eval_rollout_data(rollout_id, self.args, data, result.metrics)
-        max_images = self.args.diffusion_log_images
+        max_images = self.args.wandb_log_num_images
         if max_images > 0:
             self._log_images(
                 {
@@ -401,8 +401,8 @@ class RolloutManager:
         reward_stats["rollout/step"] = compute_rollout_step(self.args, self.rollout_id)
         tracking_utils.log(self.args, reward_stats, step_key="rollout/step")
 
-        max_images = self.args.diffusion_log_images
-        interval = self.args.diffusion_log_image_interval
+        max_images = self.args.wandb_log_num_images
+        interval = self.args.wandb_log_image_interval
         if max_images > 0 and self.rollout_id % interval == 0:
             self._log_images(
                 {"rollout_media/sample_images": samples},
@@ -427,7 +427,7 @@ class RolloutManager:
     ) -> None:
         """Log per-key sample image grids under their own media namespace.
 
-        Caller decides whether to invoke (gating like ``--diffusion-log-images``
+        Caller decides whether to invoke (gating like ``--wandb-log-num-images``
         > 0 or rollout-side interval lives at the call site, not here). wandb
         media panels do not honor ``step_metric`` (they slide on the internal
         commit step), so panels pile up over a run — keeping them in their

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -385,7 +385,7 @@ def release_eval_sample_media(args: Namespace, sample: Sample) -> None:
     """Drop a scored eval sample's media, which only image logging and debug dumps still read."""
     if args.save_debug_rollout_data is not None:
         return
-    if sample.index < args.diffusion_log_images:
+    if sample.index < args.wandb_log_num_images:
         return
     sample.generated_output = None
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -410,18 +410,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Set rollout_debug_mode=true on POST /rollout/generate.",
             )
             parser.add_argument(
-                "--diffusion-log-images",
-                type=int,
-                default=0,
-                help="Number of diffusion images to log to W&B per rollout (0 disables).",
-            )
-            parser.add_argument(
-                "--diffusion-log-image-interval",
-                type=int,
-                default=1,
-                help="Log diffusion images every N rollouts. Only used when diffusion-log-images > 0.",
-            )
-            parser.add_argument(
                 "--update-weight-target-module",
                 type=str,
                 default="transformer",
@@ -976,6 +964,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument("--wandb-run-id", type=str, default=None)
+            parser.add_argument(
+                "--wandb-log-num-images",
+                type=int,
+                default=0,
+                help="Images or videos sent to W&B per rollout (0 disables).",
+            )
+            parser.add_argument(
+                "--wandb-log-image-interval",
+                type=int,
+                default=1,
+                help="Send media every N rollouts. Only used when --wandb-log-num-images > 0.",
+            )
             return parser
 
         def add_lora_arguments(parser):
@@ -1063,6 +1063,21 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
+        def add_dashboard_arguments(parser):
+            parser.add_argument(
+                "--use-miles-dashboard",
+                action="store_true",
+                default=False,
+                help="Collect phase and trajectory telemetry asynchronously.",
+            )
+            parser.add_argument(
+                "--miles-dashboard-workspace",
+                type=str,
+                default="./miles_dashboard",
+                help="Base directory for miles dashboard telemetry; each launch writes to its own run_<ts> subdir.",
+            )
+            return parser
+
         # debug
         def add_debug_arguments(parser):
             parser.add_argument(
@@ -1136,18 +1151,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default=None,
                 help=("Dump all details of training for post-hoc analysis and visualization."),
-            )
-            parser.add_argument(
-                "--use-miles-dashboard",
-                action="store_true",
-                default=False,
-                help="Collect phase and trajectory telemetry asynchronously.",
-            )
-            parser.add_argument(
-                "--miles-dashboard-workspace",
-                type=str,
-                default="./miles_dashboard",
-                help="Base directory for miles dashboard telemetry; each launch writes to its own run_<ts> subdir.",
             )
             return parser
 
@@ -1311,6 +1314,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
         parser = add_lora_arguments(parser)
         parser = add_ema_arguments(parser)
         parser = add_wandb_arguments(parser)
+        parser = add_dashboard_arguments(parser)
         parser = add_router_arguments(parser)
         parser = add_debug_arguments(parser)
         parser = add_sglang_diffusion_arguments(parser)
@@ -1450,8 +1454,8 @@ def miles_validate_args(args):
     if len(set(args.update_weight_target_modules)) != len(args.update_weight_target_modules):
         raise ValueError(f"--update-weight-target-module has duplicates: {args.update_weight_target_module!r}")
 
-    if args.diffusion_log_image_interval < 1:
-        raise ValueError(f"diffusion_log_image_interval must be >= 1, got {args.diffusion_log_image_interval}")
+    if args.wandb_log_image_interval < 1:
+        raise ValueError(f"wandb_log_image_interval must be >= 1, got {args.wandb_log_image_interval}")
 
     args.rollout_patch_groups = [name for name in (args.rollout_patch_group or "").split(",") if name]
 

--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -15,8 +15,8 @@ if [[ -n "${WANDB_API_KEY:-}" ]]; then
     --wandb-project miles-diffusion-grpo
     --wandb-group "${RUN_NAME}"
     --wandb-key "${WANDB_API_KEY}"
-    --diffusion-log-images 4
-    --diffusion-log-image-interval 10
+    --wandb-log-num-images 4
+    --wandb-log-image-interval 10
     --disable-wandb-random-suffix
   )
 fi

--- a/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
@@ -34,8 +34,8 @@ if [[ -n "${WANDB_API_KEY:-}" ]]; then
     --wandb-project miles-diffusion-grpo
     --wandb-group "${RUN_NAME}"
     --wandb-key "${WANDB_API_KEY}"
-    --diffusion-log-images 8
-    --diffusion-log-image-interval 10
+    --wandb-log-num-images 8
+    --wandb-log-image-interval 10
     --disable-wandb-random-suffix
   )
 fi

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -50,8 +50,8 @@ if [[ -n "${WANDB_API_KEY:-}" ]]; then
     --wandb-project miles-diffusion-grpo
     --wandb-group "${RUN_NAME}"
     --wandb-key "${WANDB_API_KEY}"
-    --diffusion-log-images 8
-    --diffusion-log-image-interval 10
+    --wandb-log-num-images 8
+    --wandb-log-image-interval 10
     --disable-wandb-random-suffix
   )
 fi

--- a/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
+++ b/scripts/run-diffusion-grpo-wan22-pickscore-5gpu.sh
@@ -41,8 +41,8 @@ if [[ -n "${WANDB_API_KEY:-}" ]]; then
     --wandb-project miles-diffusion-grpo
     --wandb-group "${RUN_NAME}"
     --wandb-key "${WANDB_API_KEY}"
-    --diffusion-log-images 8
-    --diffusion-log-image-interval 10
+    --wandb-log-num-images 8
+    --wandb-log-image-interval 10
     --disable-wandb-random-suffix
   )
 fi

--- a/scripts/run-diffusion-nft-sd3-pickscore.sh
+++ b/scripts/run-diffusion-nft-sd3-pickscore.sh
@@ -30,8 +30,8 @@ if [[ -n "${WANDB_API_KEY:-}" ]]; then
     --wandb-project miles-diffusion-nft
     --wandb-group "${RUN_NAME}"
     --wandb-key "${WANDB_API_KEY}"
-    --diffusion-log-images 8
-    --diffusion-log-image-interval 10
+    --wandb-log-num-images 8
+    --wandb-log-image-interval 10
     --disable-wandb-random-suffix
   )
 fi

--- a/tests/fast/rollout/test_release_eval_sample_media.py
+++ b/tests/fast/rollout/test_release_eval_sample_media.py
@@ -17,7 +17,7 @@ def make_sample(index: int) -> Sample:
 def test_media_released_when_not_logged():
     sample = make_sample(index=3)
 
-    release_eval_sample_media(Namespace(save_debug_rollout_data=None, diffusion_log_images=2), sample)
+    release_eval_sample_media(Namespace(save_debug_rollout_data=None, wandb_log_num_images=2), sample)
 
     assert sample.generated_output is None
 
@@ -25,7 +25,7 @@ def test_media_released_when_not_logged():
 def test_media_kept_for_logged_samples():
     sample = make_sample(index=1)
 
-    release_eval_sample_media(Namespace(save_debug_rollout_data=None, diffusion_log_images=2), sample)
+    release_eval_sample_media(Namespace(save_debug_rollout_data=None, wandb_log_num_images=2), sample)
 
     assert sample.generated_output is not None
 
@@ -33,6 +33,6 @@ def test_media_kept_for_logged_samples():
 def test_media_kept_when_debug_dump_enabled():
     sample = make_sample(index=3)
 
-    release_eval_sample_media(Namespace(save_debug_rollout_data="/tmp/dump", diffusion_log_images=0), sample)
+    release_eval_sample_media(Namespace(save_debug_rollout_data="/tmp/dump", wandb_log_num_images=0), sample)
 
     assert sample.generated_output is not None


### PR DESCRIPTION
This PR is stacked on #118.

## What

A new `add_dashboard_arguments` group, and the two media flags moved into the wandb group
and renamed to match. 9 files.

| Flag | Change |
|---|---|
| `--use-miles-dashboard` | debug → dashboard |
| `--miles-dashboard-workspace` | debug → dashboard |
| `--diffusion-log-images` | rollout → wandb, renamed `--wandb-log-num-images` |
| `--diffusion-log-image-interval` | rollout → wandb, renamed `--wandb-log-image-interval` |

## Why a dashboard group rather than one logging group

miles keeps one group per observability backend — `add_wandb_arguments`,
`add_mlflow_arguments`, `add_tensorboard_arguments`, `add_prometheus_arguments` — not one
group called "logging". The miles dashboard is a backend of the same kind, so it gets its
own group instead of being folded into a wandb group it has nothing to do with.

## Why the media flags are wandb's

They are wandb configuration in fact, not just by association:

- `_log_images` constructs `wandb.Image` and `wandb.Video` directly, and its docstring
  works around a wandb media-panel quirk (`step_metric` is ignored for media).
- `tracking_utils` is a wandb wrapper with a generic name: it gates on `args.use_wandb`
  and calls `wandb.log`. The only other sink is a JSONL tee for e2e tests.

Adding a second backend would mean building a media abstraction first — different
backends have unrelated media types — so it is not an import swap. Naming these after
wandb costs nothing today and stops them reading as backend-neutral.

`--diffusion-log-images` also read as a switch while being an `int` cap on how many media
items go out per rollout, hence `--wandb-log-num-images`. `num` sits before the noun to
match the seventeen existing `<scope>-num-<noun>` flags (`--diffusion-num-steps`,
`--pickscore-num-workers`, `--diffusion-output-num-frames`); no flag in the repo puts a
count at the end.

## What stays put

`--custom-rollout-log-function-path` and `--custom-eval-rollout-log-function-path` stay in
the rollout group. miles puts them there, and a user-supplied log function is not wandb
configuration — it can write anywhere.

Group sizes: rollout 42 → 40, wandb 10 → 12, dashboard 2 (new), debug 11 → 9.

## How this was checked

An AST pass compares every `add_argument` block before and after: 174 arguments before,
174 after, with the only name changes being the two intended ones. Each renamed flag's
`dest` was checked against its consumers, including
`tests/fast/rollout/test_release_eval_sample_media.py`, which builds a `Namespace` by hand
— a missed rename there would not fail, it would silently stop exercising the flag.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; one existing test updated for the rename, no behaviour change
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds (`bash -n` on the five updated recipes)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so `--help` was not exercised end to end and no
media was actually logged.
