### PR TITLE
refactor(args)(7/10): move the loss knobs from the train group into algo

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -109,48 +109,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="The backend for training.",
             )
             parser.add_argument(
-                "--diffusion-clip-range",
-                type=float,
-                default=1e-4,
-                help="Clip range for diffusion GRPO ratio.",
-            )
-            parser.add_argument(
-                "--diffusion-adv-clip-max",
-                type=float,
-                default=5.0,
-                help="Max absolute value for advantage clipping in diffusion training.",
-            )
-            parser.add_argument(
-                "--diffusion-recompute-old-log-prob",
-                action="store_true",
-                help=(
-                    "Recompute old log-probs with the trainer forward (pre-update weights) "
-                    "instead of using rollout-stored values, making the PPO ratio "
-                    "implementation-consistent. The first optimizer window skips the extra "
-                    "pass and reuses its training forward's log-prob (ratio == 1)."
-                ),
-            )
-            parser.add_argument(
-                "--diffusion-kl-beta",
-                type=float,
-                default=0.0,
-                help=(
-                    "Reference KL coefficient for diffusion GRPO. When > 0, enables a "
-                    "reference DiT forward (see --ref-mode; default lora_base)."
-                ),
-            )
-            parser.add_argument(
-                "--ref-mode",
-                type=str,
-                choices=["none", "lora_base", "ema"],
-                default=None,
-                help=(
-                    "Which reference weights to use for the no-grad DiT forward. "
-                    "Auto: lora_base when --diffusion-kl-beta > 0 and ema for --loss-type nft. "
-                    "Explicit values skip auto inference."
-                ),
-            )
-            parser.add_argument(
                 "--fsdp-master-dtype",
                 type=str,
                 default="fp32",
@@ -900,6 +858,48 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help=(
                     "Use batch-wide std instead of per-group std for GRPO advantage. "
                     "flow_grpo's pickscore recipe sets global_std=True, so enable this for parity."
+                ),
+            )
+            parser.add_argument(
+                "--diffusion-clip-range",
+                type=float,
+                default=1e-4,
+                help="Clip range for diffusion GRPO ratio.",
+            )
+            parser.add_argument(
+                "--diffusion-adv-clip-max",
+                type=float,
+                default=5.0,
+                help="Max absolute value for advantage clipping in diffusion training.",
+            )
+            parser.add_argument(
+                "--diffusion-recompute-old-log-prob",
+                action="store_true",
+                help=(
+                    "Recompute old log-probs with the trainer forward (pre-update weights) "
+                    "instead of using rollout-stored values, making the PPO ratio "
+                    "implementation-consistent. The first optimizer window skips the extra "
+                    "pass and reuses its training forward's log-prob (ratio == 1)."
+                ),
+            )
+            parser.add_argument(
+                "--diffusion-kl-beta",
+                type=float,
+                default=0.0,
+                help=(
+                    "Reference KL coefficient for diffusion GRPO. When > 0, enables a "
+                    "reference DiT forward (see --ref-mode; default lora_base)."
+                ),
+            )
+            parser.add_argument(
+                "--ref-mode",
+                type=str,
+                choices=["none", "lora_base", "ema"],
+                default=None,
+                help=(
+                    "Which reference weights to use for the no-grad DiT forward. "
+                    "Auto: lora_base when --diffusion-kl-beta > 0 and ema for --loss-type nft. "
+                    "Explicit values skip auto inference."
                 ),
             )
             return parser


### PR DESCRIPTION
This PR is stacked on #119.

## What

Five arguments moved from `add_train_arguments` to `add_algo_arguments`. 1 file, pure move.

| Flag | What it does |
|---|---|
| `--diffusion-clip-range` | PPO ratio clip |
| `--diffusion-adv-clip-max` | advantage clip |
| `--diffusion-recompute-old-log-prob` | recompute old log-probs with the trainer forward |
| `--diffusion-kl-beta` | reference KL coefficient |
| `--ref-mode` | which weights serve as the reference |

## Why

The train group had picked up five arguments that shape the objective, which split
same-kind knobs across two groups: `--diffusion-adv-clip-max` sat in train while
`--diffusion-nft-adv-clip-max` — its NFT counterpart, same `5.0` default — sat in algo.

`--ref-mode` and `--diffusion-kl-beta` belong there for the same reason: every validation
that mentions them is written against `--loss-type`, `--use-ema` and `--use-lora`, all of
which live in algo.

What is left in the train group now only configures the training backend: which backend,
the three dtypes, CFG batching, the trainer-side flow shift, and env vars. Group sizes:
train 12 → 7, algo 23 → 28.

## Names left alone

Checked against the prefix standard from #117. `--diffusion-clip-range` and
`--diffusion-adv-clip-max` name RL concepts rather than the diffusion process, so rule 3
would drop the prefix — but `--clip-range` collides visually with the existing
`--clip-grad`, and a bare `--adv-clip-max` loses its symmetry with
`--diffusion-nft-adv-clip-max`. Keeping them costs less.

Putting the two advantage clips next to each other makes the case for merging them, which
the next PR in the stack does: they are mutually exclusive (`--loss-type` picks one path),
so only one is ever read. This PR stays move-only.

## How this was checked

An AST pass compares every `add_argument` block before and after: 174 arguments before,
174 after, no additions, no removals, every block byte-identical once whitespace is
normalized, and the only difference is the owning function for these five.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; no behaviour change, the move is verified structurally
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so `--help` was not exercised end to end.
