### PR TITLE
refactor(args)(8/10): merge the advantage clips and put two flags in their groups

### DIFF
--- a/miles/backends/fsdp_utils/loss_hub/nft.py
+++ b/miles/backends/fsdp_utils/loss_hub/nft.py
@@ -120,7 +120,7 @@ def nft_loss_formula(
 
     args = ctx.args
     beta = args.diffusion_nft_beta
-    adv_clip_max = args.diffusion_nft_adv_clip_max
+    adv_clip_max = args.diffusion_adv_clip_max
     use_adaptive = args.diffusion_nft_adaptive_weight
 
     x0 = prepared.extras["x0"]

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -236,12 +236,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Diffusion rollout microgroup size (sub-batch of samples per prompt). Defaults to 1.",
             )
             parser.add_argument(
-                "--diffusion-eval-num-steps",
-                type=int,
-                default=None,
-                help="Number of diffusion inference steps for eval rollout. Defaults to diffusion-num-steps.",
-            )
-            parser.add_argument(
                 "--diffusion-fps",
                 type=float,
                 default=None,
@@ -360,12 +354,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                     "(diffusers op parity, small rollout perf hit) or 'ltx' "
                     "(see sglang_diffusion_utils/monkey_patches)."
                 ),
-            )
-            parser.add_argument(
-                "--diffusion-debug-mode",
-                action="store_true",
-                default=False,
-                help="Set rollout_debug_mode=true on POST /rollout/generate.",
             )
             parser.add_argument(
                 "--update-weight-target-module",
@@ -726,6 +714,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="number of responses for each prompt in generation",
             )
 
+            parser.add_argument(
+                "--diffusion-eval-num-steps",
+                type=int,
+                default=None,
+                help="Number of diffusion inference steps for eval rollout. Defaults to diffusion-num-steps.",
+            )
             return parser
 
         def add_algo_arguments(parser):
@@ -802,12 +796,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="DiffusionNFT dual-prediction blend coefficient (UniRL beta).",
             )
             parser.add_argument(
-                "--diffusion-nft-adv-clip-max",
-                type=float,
-                default=5.0,
-                help="DiffusionNFT advantage clip before remap to r in [0, 1].",
-            )
-            parser.add_argument(
                 "--no-diffusion-nft-adaptive-weight",
                 action="store_false",
                 dest="diffusion_nft_adaptive_weight",
@@ -870,7 +858,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "--diffusion-adv-clip-max",
                 type=float,
                 default=5.0,
-                help="Max absolute value for advantage clipping in diffusion training.",
+                help=(
+                    "Advantage clip. Under --loss-type policy_loss this only bounds outliers. "
+                    "Under nft it also sets the advantage-to-r slope, so raising it flattens the "
+                    "positive/negative contrast."
+                ),
             )
             parser.add_argument(
                 "--diffusion-recompute-old-log-prob",
@@ -1151,6 +1143,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default=None,
                 help=("Dump all details of training for post-hoc analysis and visualization."),
+            )
+            parser.add_argument(
+                "--diffusion-debug-mode",
+                action="store_true",
+                default=False,
+                help="Set rollout_debug_mode=true on POST /rollout/generate.",
             )
             return parser
 
@@ -1565,8 +1563,8 @@ def miles_validate_args(args):
             raise ValueError("--loss-type nft with --diffusion-noise-level 0 requires --diffusion-sde-type ode")
         if args.diffusion_nft_beta <= 0:
             raise ValueError(f"--diffusion-nft-beta must be > 0, got {args.diffusion_nft_beta}")
-        if args.diffusion_nft_adv_clip_max <= 0:
-            raise ValueError(f"--diffusion-nft-adv-clip-max must be > 0, got {args.diffusion_nft_adv_clip_max}")
+        if args.diffusion_adv_clip_max <= 0:
+            raise ValueError(f"--diffusion-adv-clip-max must be > 0, got {args.diffusion_adv_clip_max}")
         if not 0.0 < args.diffusion_nft_timestep_fraction <= 1.0:
             raise ValueError(
                 f"--diffusion-nft-timestep-fraction must be in (0, 1], got {args.diffusion_nft_timestep_fraction}"

--- a/scripts/run-diffusion-nft-sd3-pickscore.sh
+++ b/scripts/run-diffusion-nft-sd3-pickscore.sh
@@ -113,7 +113,6 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --clip-grad 1.0 \
   --loss-type nft \
   --diffusion-nft-beta 1.0 \
-  --diffusion-nft-adv-clip-max 5.0 \
   --diffusion-nft-timestep-fraction 0.99 \
   --ref-mode ema \
   --use-ema \


### PR DESCRIPTION
This PR is stacked on #120. Last of the regrouping half.

## What

Three files, one argument fewer.

| Flag | Change | In miles |
|---|---|---|
| `--diffusion-nft-adv-clip-max` | removed, merged into `--diffusion-adv-clip-max` | not present |
| `--diffusion-adv-clip-max` | survives the merge, help rewritten | not present |
| `--diffusion-eval-num-steps` | rollout → eval | not present |
| `--diffusion-debug-mode` | rollout → debug | not present |

## Why merge the clips

Both were `torch.clamp(adv, -x, x)` with the same `5.0` default, and `--loss-type` picks
exactly one loss path, so only one was ever read. Whichever the user did not set for their
loss type sat there having no effect. #120 moved them into the same group, which is what
made the duplication visible.

The value does not mean quite the same thing on both paths, and the help now says so:

> Advantage clip. Under `--loss-type policy_loss` this only bounds outliers. Under `nft`
> it also sets the advantage-to-`r` slope, so raising it flattens the positive/negative
> contrast.

Under `policy_loss` the clip only bounds outliers. Under `nft` it is also the denominator
in `r = clamp(adv, -c, c) / c / 2 + 0.5`, the weight blending the positive and negative
branches, so it sets the slope of the advantage-to-`r` map:

| adv | −2 | −1 | 0 | 1 | 2 |
|---|---|---|---|---|---|
| `c = 2` | 0.00 | 0.25 | 0.50 | 0.75 | 1.00 |
| `c = 5` | 0.30 | 0.40 | 0.50 | 0.60 | 0.70 |
| `c = 10` | 0.40 | 0.45 | 0.50 | 0.55 | 0.60 |

Raising it pulls every `r` toward `0.5` and flattens the contrast between good and bad
samples, rather than just sparing outliers. Worth knowing when switching loss types, since
the same `5.0` carries a different meaning on each.

## Why the two moves

Both were declared in the rollout group because that is where the request fields they map
to are built, not because they configure the rollout. `--diffusion-eval-num-steps`
overrides the step count for eval and inherits `--diffusion-num-steps` when unset;
`--diffusion-debug-mode` asks the engine for extra per-step tensors while debugging.

## How this was checked

An AST pass compares every `add_argument` block before and after: 174 arguments before,
173 after, one intended removal, no additions, and the only content change is the rewritten
help on the surviving clip. `--diffusion-adv-clip-max`'s `dest` was checked against both
consumers, `flow_grpo.py` and `nft.py`.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the merge removes a flag whose value was unreachable on the other loss path
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and the parser still builds (`bash -n` on the updated recipe)
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang or ray locally, so no NFT run was made to confirm the merged clip
behaves identically.
