### PR TITLE
feat(scripts)(9/10): port command_utils and convert the flow_grpo-aligned recipe

### DIFF
--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -1,0 +1,204 @@
+"""
+This file is not for miles framework itself, but as an optional utility to easily launch miles jobs and tests.
+"""
+
+import datetime
+import json
+import os
+import random
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from miles.utils.misc import exec_command
+from miles.utils.typer_utils import dataclass_cli
+
+_ = exec_command, dataclass_cli
+
+repo_base_dir = Path(os.path.abspath(__file__)).resolve().parents[3]
+
+
+def hf_download_dataset(full_name: str, include: str | None = None, data_dir: str = "/root/datasets") -> str:
+    """Download a dataset (or one subdirectory of it) and return the local path."""
+    _, partial_name = full_name.split("/")
+    local_dir = f"{data_dir}/{partial_name}"
+    include_arg = f"--include {shlex.quote(include)} " if include else ""
+    exec_command(f"hf download --repo-type dataset {full_name} {include_arg}--local-dir {shlex.quote(local_dir)}")
+    return local_dir
+
+
+# This class can be extended by concrete scripts
+@dataclass
+class ExecuteTrainConfig:
+    cuda_core_dump: bool = False
+    num_nodes: int = int(os.environ.get("SLURM_JOB_NUM_NODES", "1"))
+    cuda_visible_devices: str = ""
+    extra_env_vars: str = ""
+    output_dir: str = str(repo_base_dir / "logs")
+
+
+def execute_train(
+    train_args: str,
+    num_gpus_per_node: int,
+    config: ExecuteTrainConfig | None = None,
+    train_script: str = "train_diffusion.py",
+    before_ray_job_submit=None,
+    extra_env_vars: dict[str, str] | None = None,
+) -> None:
+    """Start a Ray cluster if we own one, then submit the trainer into it.
+
+    Set MILES_SCRIPT_EXTERNAL_RAY=1 when a scheduler already built the cluster: the
+    teardown and `ray start` are skipped and the job is submitted to the running one.
+    Submitting rather than running `python` directly is what makes the driver live in
+    the cluster, so it sees every node's GPUs and every worker gets the same runtime env.
+    """
+    if config is None:
+        config = ExecuteTrainConfig()
+    if not os.path.isabs(train_script):
+        train_script = f"{repo_base_dir}/{train_script}"
+    external_ray = get_bool_env_var("MILES_SCRIPT_EXTERNAL_RAY")
+    master_addr = os.environ.get("MASTER_ADDR", "127.0.0.1")
+
+    exec_command(
+        "pkill -9 sglang; "
+        "sleep 3; "
+        f"{'' if external_ray else 'ray stop --force; '}"
+        f"{'' if external_ray else 'pkill -9 ray; '}"
+        "pkill -9 miles; "
+        "sleep 3; "
+        "pkill -9 redis; "
+        "true; "
+    )
+
+    if not external_ray:
+        exec_command(
+            # keeps ray from buffering stdout/stderr
+            "export PYTHONBUFFERED=16 && "
+            f"ray start --head --node-ip-address {master_addr} "
+            f"--num-gpus {num_gpus_per_node} --disable-usage-stats"
+        )
+
+    if (f := before_ray_job_submit) is not None:
+        f()
+
+    runtime_env_vars = {
+        "NCCL_NVLS_ENABLE": os.environ.get("NCCL_NVLS_ENABLE", str(int(check_has_nvlink()))),
+        **{
+            k: os.environ[k]
+            for k in ("NCCL_SOCKET_IFNAME", "GLOO_SOCKET_IFNAME", "NCCL_DEBUG", "NCCL_DEBUG_FILE")
+            if k in os.environ
+        },
+        "no_proxy": f"127.0.0.1,{master_addr}",
+        # torch distributed needs this on every node, not just the submitting shell.
+        "MASTER_ADDR": master_addr,
+        **({"CUDA_VISIBLE_DEVICES": config.cuda_visible_devices} if config.cuda_visible_devices else {}),
+        **(
+            {
+                "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "1",
+                "CUDA_COREDUMP_SHOW_PROGRESS": "1",
+                "CUDA_COREDUMP_GENERATION_FLAGS": "skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory",
+                "CUDA_COREDUMP_FILE": f"{config.output_dir}/cuda_coredump_%h.%p.%t",
+            }
+            if config.cuda_core_dump
+            else {}
+        ),
+        **(extra_env_vars or {}),
+        **_parse_extra_env_vars(config.extra_env_vars),
+    }
+    runtime_env_vars["PYTHONPATH"] = _pythonpath_with_sources(runtime_env_vars.get("PYTHONPATH"))
+    runtime_env_json = json.dumps({"env_vars": runtime_env_vars})
+
+    if not get_bool_env_var("MILES_SCRIPT_ENABLE_RAY_SUBMIT", "1"):
+        return
+
+    exec_command(
+        "export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
+        f"""ray job submit {'' if 'RAY_ADDRESS' in os.environ else '--address="http://127.0.0.1:8265" '}"""
+        f"--runtime-env-json={shlex.quote(runtime_env_json)} "
+        f"-- python3 {shlex.quote(train_script)} {train_args}"
+    )
+
+
+def _pythonpath_with_sources(*additional_pythonpaths: str | None) -> str:
+    entries = [str(repo_base_dir)]
+    for pythonpath in (*additional_pythonpaths, os.environ.get("PYTHONPATH")):
+        if pythonpath:
+            entries.extend(pythonpath.split(os.pathsep))
+    return os.pathsep.join(dict.fromkeys(entries))
+
+
+def _parse_extra_env_vars(text: str):
+    try:
+        return json.loads(text)
+    except ValueError:
+        return {kv[0]: kv[1] for item in text.split(" ") if item.strip() != "" if (kv := item.split("=")) or True}
+
+
+def check_has_nvlink():
+    output = exec_command("nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l", capture_output=True)
+    return int(output) > 0
+
+
+def get_default_wandb_args(
+    test_file: str,
+    run_name_prefix: str | None = None,
+    run_id: str | None = None,
+    project: str | None = None,
+    **extra_flags: object,
+) -> str:
+    """miles' wandb args, plus a `project` override.
+
+    miles derives one project per script from the caller's filename. The diffusion
+    recipes deliberately share three projects (grpo, nft, sft) so runs across models stay
+    comparable in one panel, which a filename cannot express.
+    """
+    if not os.environ.get("WANDB_API_KEY"):
+        print("Skip wandb configuration since WANDB_API_KEY is not found")
+        return ""
+
+    test_file = Path(test_file)
+    test_name = test_file.stem
+    if len(test_name) < 6:
+        test_name = f"{test_file.parent.name}_{test_name}"
+
+    wandb_run_name = run_id or create_run_id()
+    if (x := os.environ.get("GITHUB_COMMIT_NAME")) is not None:
+        wandb_run_name += f"_{x}"
+    if (x := run_name_prefix) is not None:
+        wandb_run_name = f"{x}_{wandb_run_name}"
+
+    # Use the actual key value from environment to avoid shell expansion issues
+    wandb_key = os.environ.get("WANDB_API_KEY")
+    args = (
+        "--use-wandb "
+        f"--wandb-project {project or f'miles-{test_name}'} "
+        f"--wandb-group {wandb_run_name} "
+        f"--wandb-key '{wandb_key}' "
+        "--disable-wandb-random-suffix "
+    )
+    for name, value in extra_flags.items():
+        args += f"--{name.replace('_', '-')} {value} "
+    return args
+
+
+def create_run_id() -> str:
+    return datetime.datetime.utcnow().strftime("%y%m%d-%H%M%S") + f"-{random.Random().randint(0, 999):03d}"
+
+
+_warned_bool_env_var_keys = set()
+
+
+# copied from SGLang
+def get_bool_env_var(name: str, default: str = "false") -> bool:
+    value = os.getenv(name, default)
+    value = value.lower()
+
+    truthy_values = ("true", "1")
+    falsy_values = ("false", "0")
+
+    if (value not in truthy_values) and (value not in falsy_values):
+        if value not in _warned_bool_env_var_keys:
+            print(f"get_bool_env_var({name}) see non-understandable value={value} and treat as false")
+        _warned_bool_env_var_keys.add(value)
+
+    return value in truthy_values

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -1,9 +1,31 @@
 import importlib
+import subprocess
 from contextlib import contextmanager
 
 import ray
 
 from miles.utils.http_utils import is_port_available
+
+
+def exec_command(cmd: str, capture_output: bool = False) -> str | None:
+    print(f"EXEC: {cmd}", flush=True)
+
+    try:
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            shell=False,
+            check=True,
+            capture_output=capture_output,
+            **(dict(text=True) if capture_output else {}),
+        )
+    except subprocess.CalledProcessError as e:
+        if capture_output:
+            print(f"{e.stdout=} {e.stderr=}")
+        raise
+
+    if capture_output:
+        print(f"Captured stdout={result.stdout} stderr={result.stderr}")
+        return result.stdout
 
 
 # Mainly used for test purpose where `load_function` needs to load many in-flight generated functions

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -1,0 +1,142 @@
+"""Qwen-Image PickScore GRPO, aligned with flow_grpo `pickscore_qwenimage`.
+
+resolution=512, num_steps=10, eval_steps=50, guidance=4, noise_level=1.2,
+sde_window_size=2. sde_window_range=3,5 gives effective SDE indices [3,4]: flow_grpo
+hard-codes (0, num_steps//2) but only trains steps 3-4, and we mirror that.
+beta=0 (no KL), global_std=True, per-prompt mean.
+
+Per rollout: 32 prompts x 16 samples = 512 samples. num_steps_per_rollout=2 gives 256
+samples per optimizer step, matching flow_grpo's 32-GPU run (batch 4 x 32 GPU x 2 accum).
+
+Layout: the first four GPUs in CUDA_VISIBLE_DEVICES are train+sgld colocate, the fifth is
+a dedicated pickscore reward worker.
+
+Usage:
+    python3 scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+"""
+
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "Qwen/Qwen-Image"
+DATASET = "rockdu/miles-diffusion-datasets"
+DATASET_SUBSET = "flowgrpo_pickscore"
+WANDB_PROJECT = "miles-diffusion-grpo"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "4,5,6,7,1"
+    num_rollout: int = 400
+    data_dir: str = "/root/datasets"
+    extra_args: str = ""
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{DATASET_SUBSET}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{DATASET_SUBSET}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_grpo_pickscore_5gpu_flowgrpo_aligned_{U.create_run_id()}"
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        "--rollout-batch-size 32 "
+        "--n-samples-per-prompt 16 "
+        f"--num-rollout {args.num_rollout} "
+        "--num-steps-per-rollout 2 "
+        "--diffusion-microgroup-size 8 "
+        "--micro-batch-size-sample 8 "
+        "--micro-batch-size-tstep 1 "
+        "--diffusion-train-iter-order sample_major "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--diffusion-num-steps 10 "
+        "--diffusion-guidance-scale 4.0 "
+        "--diffusion-true-cfg-scale 4.0 "
+        "--diffusion-noise-level 1.2 "
+        "--diffusion-height 512 "
+        "--diffusion-width 512 "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.sde_window "
+        "--diffusion-num-sde-steps 2 "
+        "--diffusion-sde-window-range 3,5 "
+        "--rollout-patch-group sgld "
+    )
+
+    eval_args = (
+        f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl "
+        "--eval-interval 30 "
+        "--diffusion-eval-num-steps 50 "
+        "--skip-eval-before-train "
+    )
+
+    grpo_args = "--advantage-estimator grpo --globalize-reward-std --diffusion-clip-range 1e-4 "
+
+    optimizer_args = "--lr 3e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = "--use-lora --lora-ipc-weight-sync --lora-rank 64 --lora-alpha 128 --lora-init-weights gaussian "
+
+    reward_args = (
+        "--rm-type pickscore "
+        "--pickscore-num-workers 1 "
+        "--pickscore-num-gpus-per-worker 1.0 "
+        "--pickscore-batch-size 8 "
+        "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+        "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 4 "
+        "--sglang-attention-backend torch_sdpa "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = (
+        "--train-backend fsdp --fsdp-master-dtype fp32 --fsdp-reduce-dtype fp32 --diffusion-forward-dtype bf16 "
+    )
+
+    perf_args = "--gradient-checkpointing --deterministic-mode "
+
+    misc_args = (
+        "--actor-num-gpus-per-node 4 "
+        "--rollout-num-gpus 4 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--num-gpus-per-node 5 "
+        "--colocate "
+    )
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} "
+            f"{misc_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=5,
+        config=args,
+        extra_env_vars={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"},
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This PR is stacked on #121. First of the two script PRs.

## What

| File | Role |
|---|---|
| `miles/utils/misc.py` | `exec_command`, same implementation and same file as miles |
| `miles/utils/external_utils/command_utils.py` | `ExecuteTrainConfig`, `execute_train`, `hf_download_dataset`, `get_default_wandb_args`, `create_run_id`, `check_has_nvlink`, `get_bool_env_var` |
| `scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` | first consumer |

The utility layer ships with one recipe converted rather than on its own, so nothing
lands without a caller.

## What came over from miles, and what did not

| Function | Status |
|---|---|
| `get_bool_env_var` | verbatim |
| `check_has_nvlink` | verbatim |
| `_parse_extra_env_vars` | verbatim |
| `create_run_id` | verbatim |
| `hf_download_dataset` | takes an `include` glob |
| `get_default_wandb_args` | miles' signature plus an optional `project` |
| `_pythonpath_with_sources` | Megatron path dropped |
| `execute_train` | Megatron sourcing, `MODEL_ARGS` and the backend assertion dropped |
| `convert_checkpoint`, `fp8_cast_bf16`, `rsync_simple`, `save_to_temp_file`, mooncake helpers | not ported |

The two that are not simply Megatron removals:

- **`include`** — miles keeps one dataset per repo (`zhuzilin/dapo-math-17k`). The
  diffusion datasets are subdirectories of a single repo, so a recipe wanting
  `flowgrpo_pickscore` would otherwise pull every subset.
- **`project`** — miles derives one project per script from the caller's filename
  (`miles-{stem}`). The six diffusion recipes deliberately share three projects
  (`miles-diffusion-grpo` covers four of them) so runs across models stay comparable in
  one panel, which a filename cannot express. Everything else about miles' version is
  kept: `run_name_prefix`, `run_id`, and the `GITHUB_COMMIT_NAME` suffix.

`before_ray_job_submit`, `MILES_SCRIPT_ENABLE_RAY_SUBMIT` and `cuda_core_dump` are kept
even though no diffusion recipe uses them yet — they are generic, and miles' scripts use
the first two in eight places between them.

## Why a Python recipe at all

Recipes are bash arrays today: every one repeats the same wandb block and the same
`hf download`, then lists a wall of flags with no structure, so a reader cannot tell
which knobs set the batch shape and which set the objective. miles solved this with
`scripts/run_*.py` — a `ScriptArgs` dataclass over `ExecuteTrainConfig`, a
`prepare`/`execute` split, and named argument groups assembled into one command. The
converted recipe follows that shape.

## Why `ray job submit` rather than `python -u`

This is the part worth reviewing. The bash recipes run `python -u train_diffusion.py`
directly, which makes that process the Ray driver **in the submitting shell**. A driver
there only sees the local node's GPUs. That is fine for the single-node recipes we have
and useless for the multi-node ones coming.

`ray job submit` puts the driver **inside the cluster**, so it sees every node, and
`--runtime-env-json` hands every worker the same `PYTHONPATH`, `MASTER_ADDR` and NCCL
settings instead of whatever each node's shell happened to export.

`MILES_SCRIPT_EXTERNAL_RAY=1` skips both the teardown and `ray start` for the case where
a scheduler already built the cluster — the expected path at larger scale. Without it the
script would `ray stop --force` a cluster it does not own.

Not ported: `convert_checkpoint`, `fp8_cast_bf16` and the mooncake helpers, all Megatron
or LLM-side.

## CI is untouched, deliberately

`tests/e2e/short/` points at the bash recipes, which this PR does not modify. Switching
the suites to the Python scripts is a separate change and needs its own verification: they
compare metrics bit for bit under `--deterministic-mode`, and a submitted job replaces the
inherited environment with an explicit one, so any numerically relevant variable not
carried into `--runtime-env-json` would move the metrics.

## How this was checked

`exec_command` was stubbed and the generated commands captured. The training arguments
after `-- python3 train_diffusion.py` were compared flag by flag **and value by value**
against the bash recipe: nothing missing, nothing extra, no value differences. The
`hf download` line matches too, and the emitted `--runtime-env-json` was decoded and
inspected.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the new script is verified by command-equivalence against the recipe it mirrors
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags unchanged; the new script emits the same ones
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang, ray or GPUs locally, so the submitted job was never actually run.
The Python recipe should complete once on a real host before the bash one is retired.
