### PR TITLE
feat(scripts)(10/10): convert the remaining five recipes to Python

### DIFF
--- a/scripts/run_diffusion_grpo_ltx23_sglang.py
+++ b/scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -1,0 +1,148 @@
+"""LTX-2.3 video PickScore GRPO: 4-GPU FSDP train + sglang rollout colocate, 1 reward GPU.
+
+57-frame 512x768 video at 24 fps, 24 denoising steps, CPS-SDE with 3 trainable steps drawn
+per epoch from candidate steps 0-9. Everything runs bf16 end to end — master, reduce,
+forward and the sgl-d engine — on the sdpa_math attention backend.
+
+--hf-checkpoint points at gpt2 on purpose: LTX-2.3 needs no HF tokenizer here, and the flag
+still wants a resolvable repo id.
+
+Video rollouts take minutes per request, so the health checker gets a far longer interval
+and failure budget than the image recipes.
+
+Usage:
+    python3 scripts/run_diffusion_grpo_ltx23_sglang.py
+"""
+
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "Lightricks/LTX-2.3"
+DATASET = "rockdu/miles-diffusion-datasets"
+DATASET_SUBSET = "flowgrpo_pickscore"
+WANDB_PROJECT = "miles-diffusion-grpo"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "0,1,2,3,4"
+    num_rollout: int = 200
+    data_dir: str = "/root/datasets"
+    extra_args: str = ""
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{DATASET_SUBSET}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{DATASET_SUBSET}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_grpo_ltx23_pickscore_{U.create_run_id()}"
+
+    ckpt_args = f"--hf-checkpoint gpt2 --save {args.output_dir}/{run_name}/ckpt --save-interval 50 "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 8 "
+        f"--num-rollout {args.num_rollout} "
+        "--num-steps-per-rollout 2 "
+        "--diffusion-microgroup-size 1 "
+        "--micro-batch-size-sample 1 "
+        "--micro-batch-size-tstep 1 "
+        "--diffusion-train-iter-order sample_major "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--rollout-patch-group ltx "
+        "--diffusion-num-steps 24 "
+        "--diffusion-output-num-frames 57 "
+        "--diffusion-fps 24 "
+        "--diffusion-guidance-scale 1.0 "
+        "--diffusion-noise-level 0.8 "
+        "--diffusion-height 512 "
+        "--diffusion-width 768 "
+        "--diffusion-sde-type cps "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.epoch_global_random_choice "
+        "--diffusion-num-sde-steps 3 "
+        "--diffusion-sde-candidate-steps 0,1,2,3,4,5,6,7,8,9 "
+    )
+
+    grpo_args = (
+        "--advantage-estimator grpo --globalize-reward-std --diffusion-clip-range 1e-5 --diffusion-kl-beta 0.0 "
+    )
+
+    optimizer_args = "--lr 2e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = "--use-lora --lora-rank 64 --lora-alpha 128 --lora-init-weights gaussian "
+
+    reward_args = (
+        "--rm-type pickscore "
+        "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+        "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+        "--pickscore-num-frames 3 "
+        "--pickscore-num-gpus-per-worker 1.0 "
+        "--pickscore-num-workers 1 "
+        "--pickscore-batch-size 8 "
+        "--rollout-parser-num-workers 8 "
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=4, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 4 "
+        "--sglang-attention-backend torch_sdpa "
+        "--sglang-dit-precision bf16 "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = (
+        "--train-backend fsdp "
+        "--fsdp-master-dtype bf16 "
+        "--fsdp-reduce-dtype bf16 "
+        "--diffusion-forward-dtype bf16 "
+        "--fsdp-attention-backend sdpa_math "
+    )
+
+    perf_args = "--gradient-checkpointing --deterministic-mode "
+
+    misc_args = (
+        "--actor-num-nodes 1 "
+        "--actor-num-gpus-per-node 4 "
+        "--rollout-num-gpus 4 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--num-gpus-per-node 4 "
+        "--colocate "
+        "--rollout-health-check-interval 120 "
+        "--miles-router-health-check-failure-threshold 30 "
+    )
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {grpo_args} {optimizer_args} {lora_args} "
+            f"{reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} {misc_args} "
+            f"{args.extra_args}"
+        ),
+        num_gpus_per_node=5,
+        config=args,
+        extra_env_vars={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"},
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -1,0 +1,136 @@
+"""SD3.5-medium OCR GRPO through the sglang-diffusion /rollout/generate path.
+
+2-GPU colocate: FSDP DP=2 plus 2 rollout engines time-multiplexed on the same GPUs.
+
+SD3.5 is gated, so HF_TOKEN must be set even when the weights are cached — sglang still
+fetches model_index.json from the hub at startup.
+
+Usage:
+    python3 scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+    MILES_SCRIPT_DEBUG_ALIGNMENT=1 python3 scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+"""
+
+import os
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "stabilityai/stable-diffusion-3.5-medium"
+DATASET = "rockdu/miles-diffusion-datasets"
+DATASET_SUBSET = "flowgrpo_ocr"
+WANDB_PROJECT = "miles-diffusion-grpo"
+
+# master_sglang carries native SD3 /rollout/generate support; prepending it to PYTHONPATH
+# shadows the editable install at /sgl-workspace/sglang.
+MASTER_SGLANG_PYTHON = "/sgl-workspace/master_sglang/sglang/python"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "6,7"
+    num_rollout: int = 600
+    data_dir: str = "/root/datasets"
+    debug_alignment: bool = False
+    extra_args: str = ""
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{DATASET_SUBSET}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{DATASET_SUBSET}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_grpo_sd3_ocr_sglang_{U.create_run_id()}"
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        "--rollout-batch-size 8 "
+        "--n-samples-per-prompt 16 "
+        f"--num-rollout {args.num_rollout} "
+        "--global-batch-size 64 "
+        "--diffusion-microgroup-size 8 "
+        "--micro-batch-size-sample 16 "
+        "--micro-batch-size-tstep 5 "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--diffusion-num-steps 10 "
+        "--diffusion-guidance-scale 4.5 "
+        "--diffusion-noise-level 0.7 "
+        "--diffusion-height 512 "
+        "--diffusion-width 512 "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.sde_window "
+        "--diffusion-num-sde-steps 10 "
+        "--diffusion-sde-window-range 0,10 "
+    )
+
+    eval_args = "--diffusion-eval-num-steps 40 "
+
+    grpo_args = (
+        "--advantage-estimator grpo --globalize-reward-std --diffusion-clip-range 1e-4 --diffusion-kl-beta 0.04 "
+    )
+
+    optimizer_args = "--lr 3e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = "--use-lora --lora-ipc-weight-sync --lora-rank 32 --lora-alpha 64 --lora-init-weights gaussian "
+
+    reward_args = "--rm-type ocr "
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 8 "
+        "--sglang-dit-precision fp16 "
+        "--sglang-vae-slicing "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = "--train-backend fsdp --diffusion-forward-dtype fp16 "
+
+    perf_args = "--gradient-checkpointing --deterministic-mode "
+
+    misc_args = (
+        "--actor-num-gpus-per-node 2 "
+        "--rollout-num-gpus 2 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--num-gpus-per-node 2 "
+        "--colocate "
+    )
+
+    debug_args = "--diffusion-debug-mode --debug-skip-optimizer-step " if args.debug_alignment else ""
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} "
+            f"{misc_args} {debug_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=2,
+        config=args,
+        extra_env_vars={
+            "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+            "PYTHONPATH": MASTER_SGLANG_PYTHON,
+            "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
+            **({"MILES_VERIFY_WEIGHT_SYNC": "1"} if args.debug_alignment else {}),
+        },
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -1,0 +1,161 @@
+"""Wan2.2-T2V-A14B dual-expert 5-frame video GRPO with PickScore, 4 train GPUs + 1 reward GPU.
+
+resolution=480, num_frames=5, num_steps=10, eval_steps=28, flow_shift=3.0 overriding the
+sgl-d serving default of 12.0, guidance 4.0 high-noise / 3.0 low-noise, Flow-SDE
+noise_level=0.9, beta=0, per-prompt mean and std.
+
+SDE schedule: epoch_global_random_choice draws ONE step per rollout, shared across the
+batch, from candidate steps 1,2,3. At flow_shift=3.0 the dual-expert boundary is t=875, so
+steps 1,2 train `transformer` (high-noise) and step 3 trains `transformer_2` (low-noise);
+both experts get gradient stochastically and --update-weight-target-module syncs both.
+
+Per rollout: 48 prompts x 16 samples = 768 samples; num_steps_per_rollout=2 gives 384 per
+optimizer step over 4 train GPUs. micro-batch-size 2 keeps every micro-batch phase-pure
+(one DiT, one CFG scale); 4 OOMs on H200.
+
+Gradient checkpointing stays off: Wan2.2 under FSDP2 mixed precision hits a
+torch.utils.checkpoint CheckpointError on the fp32 RoPE freq buffers. If you OOM, lower
+--rollout-batch-size, --n-samples-per-prompt or --diffusion-microgroup-size.
+
+Usage:
+    python3 scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
+"""
+
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+DATASET = "rockdu/miles-diffusion-datasets"
+DATASET_SUBSET = "flowgrpo_pickscore"
+WANDB_PROJECT = "miles-diffusion-grpo"
+
+# Wan2.2 DiT LoRA targets: self-attn (attn1), cross-attn (attn2), and FFN.
+LORA_TARGET_MODULES = (
+    "attn1.to_q attn1.to_k attn1.to_v attn1.to_out.0 "
+    "attn2.to_q attn2.to_k attn2.to_v attn2.to_out.0 "
+    "ffn.net.0.proj ffn.net.2"
+)
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "0,1,2,3,4"
+    num_rollout: int = 10000
+    data_dir: str = "/root/datasets"
+    extra_args: str = ""
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{DATASET_SUBSET}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{DATASET_SUBSET}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_grpo_wan22_pickscore_5gpu_{U.create_run_id()}"
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        "--rollout-batch-size 48 "
+        "--n-samples-per-prompt 16 "
+        f"--num-rollout {args.num_rollout} "
+        "--num-steps-per-rollout 2 "
+        "--diffusion-microgroup-size 8 "
+        "--micro-batch-size 2 "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--diffusion-num-steps 10 "
+        "--diffusion-output-num-frames 5 "
+        "--diffusion-guidance-scale 4.0 "
+        "--diffusion-guidance-scale-2 3.0 "
+        "--diffusion-noise-level 0.9 "
+        "--diffusion-height 480 "
+        "--diffusion-width 480 "
+        "--diffusion-flow-shift 3.0 "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.epoch_global_random_choice "
+        "--diffusion-num-sde-steps 1 "
+        "--diffusion-sde-candidate-steps 1,2,3 "
+    )
+
+    eval_args = (
+        f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl "
+        "--eval-interval 30 "
+        "--diffusion-eval-num-steps 28 "
+        "--skip-eval-before-train "
+    )
+
+    grpo_args = "--advantage-estimator grpo --diffusion-clip-range 1e-4 "
+
+    optimizer_args = "--lr 1e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = (
+        "--use-lora "
+        "--lora-ipc-weight-sync "
+        "--lora-rank 64 "
+        "--lora-alpha 128 "
+        f"--lora-target-modules {LORA_TARGET_MODULES} "
+        "--lora-init-weights gaussian "
+    )
+
+    reward_args = (
+        "--rm-type pickscore "
+        "--pickscore-num-workers 1 "
+        "--pickscore-num-gpus-per-worker 1.0 "
+        "--pickscore-batch-size 8 "
+        "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+        "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 8 "
+        "--update-weight-buffer-size 2147483648 "
+        "--update-weight-target-module transformer,transformer_2 "
+    )
+
+    train_backend_args = (
+        "--train-backend fsdp --fsdp-master-dtype fp32 --fsdp-reduce-dtype fp32 --diffusion-forward-dtype bf16 "
+    )
+
+    misc_args = (
+        "--actor-num-gpus-per-node 4 "
+        "--rollout-num-gpus 4 "
+        "--rollout-num-gpus-per-engine 1 "
+        "--num-gpus-per-node 5 "
+        "--colocate "
+    )
+
+    debug_args = "--diffusion-debug-mode "
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {misc_args} "
+            f"{debug_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=5,
+        config=args,
+        extra_env_vars={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:False"},
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -1,0 +1,161 @@
+"""SD3.5-medium DiffusionNFT training with PickScore.
+
+Batch shape follows the UniRL 100-rollout override: 8 prompts x 8 samples, micro=4, on 2
+train GPUs plus a dedicated reward GPU.
+
+NFT needs a reference model, supplied here by the EMA copy (--ref-mode ema), and samples
+under pi_old via --ema-rollout-policy ema. noise_level=0 with sde_type=ode makes the
+rollout deterministic, which NFT requires.
+
+Smoke mode swaps in the small OCR dataset and a tiny batch, for checking the pipeline end
+to end without a real run.
+
+Usage:
+    python3 scripts/run_diffusion_nft_sd3_pickscore.py
+    MILES_SCRIPT_SMOKE=1 python3 scripts/run_diffusion_nft_sd3_pickscore.py
+"""
+
+import os
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "stabilityai/stable-diffusion-3.5-medium"
+DATASET = "rockdu/miles-diffusion-datasets"
+WANDB_PROJECT = "miles-diffusion-nft"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "4,5,2"
+    num_rollout: int = 0  # 0 picks the smoke/full default
+    data_dir: str = "/root/datasets"
+    smoke: bool = False
+    extra_args: str = ""
+
+
+def _subset(args: ScriptArgs) -> str:
+    return "flowgrpo_ocr" if args.smoke else "flowgrpo_pickscore"
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{_subset(args)}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{_subset(args)}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_nft_sd3_pickscore_{U.create_run_id()}"
+    num_rollout = args.num_rollout or (1 if args.smoke else 100)
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        f"--num-rollout {num_rollout} "
+        "--num-steps-per-rollout 1 "
+    ) + (
+        "--rollout-batch-size 2 --n-samples-per-prompt 2 --micro-batch-size 2 --diffusion-microgroup-size 2 "
+        if args.smoke
+        else "--rollout-batch-size 8 --n-samples-per-prompt 8 --micro-batch-size 4 --diffusion-microgroup-size 8 "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--diffusion-num-steps 10 "
+        "--diffusion-guidance-scale 1.0 "
+        "--diffusion-noise-level 0.0 "
+        "--diffusion-sde-type ode "
+        "--diffusion-height 512 "
+        "--diffusion-width 512 "
+    )
+
+    eval_args = "--diffusion-eval-num-steps 50 --skip-eval-before-train " + (
+        "" if args.smoke else f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl --eval-interval 30 "
+    )
+
+    nft_args = (
+        "--loss-type nft "
+        "--diffusion-nft-beta 1.0 "
+        "--diffusion-nft-timestep-fraction 0.99 "
+        "--advantage-estimator grpo "
+        "--globalize-reward-std "
+    )
+
+    ema_args = (
+        "--ref-mode ema "
+        "--use-ema "
+        "--ema-rollout-policy ema "
+        "--ema-decay-init 0.001 "
+        "--ema-decay-ramp 0.001 "
+        "--ema-decay-max 0.5 "
+        "--ema-decay-flat-steps 0 "
+    )
+
+    optimizer_args = "--lr 3e-4 --adam-beta2 0.999 --weight-decay 1e-4 --clip-grad 1.0 "
+
+    lora_args = "--use-lora --lora-ipc-weight-sync --lora-rank 32 --lora-alpha 64 --lora-init-weights gaussian "
+
+    reward_args = (
+        "--rm-type ocr "
+        if args.smoke
+        else (
+            "--rm-type pickscore "
+            "--pickscore-num-workers 1 "
+            "--pickscore-num-gpus-per-worker 1.0 "
+            "--pickscore-batch-size 8 "
+            "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+            "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+        )
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 8 "
+        "--sglang-dit-precision fp16 "
+        "--sglang-vae-slicing "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = "--train-backend fsdp --diffusion-forward-dtype fp16 "
+
+    perf_args = "--gradient-checkpointing "
+
+    misc_args = (
+        "--actor-num-gpus-per-node 2 "
+        "--rollout-num-gpus 2 "
+        "--rollout-num-gpus-per-engine 1 "
+        f"--num-gpus-per-node {2 if args.smoke else 3} "
+        "--colocate "
+    )
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {nft_args} {ema_args} "
+            f"{optimizer_args} {lora_args} {reward_args} {wandb_args} {sglang_args} "
+            f"{train_backend_args} {perf_args} {misc_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=2 if args.smoke else 3,
+        config=args,
+        extra_env_vars={
+            "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+            "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
+        },
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_diffusion_sft_wan22.py
+++ b/scripts/run_diffusion_sft_wan22.py
@@ -1,0 +1,120 @@
+"""4-GPU Wan2.2-T2V-A14B dual-expert LoRA SFT on a (video, prompt) jsonl dataset.
+
+No sglang engines: the sft_rollout plugin lazily encodes each round's cache misses through
+a colocated encoder actor pool, writing one content-addressed file per sample into
+.sft_cache/ next to the jsonl. Epoch 2 onward is all cache hits.
+
+Dataset rows: {"prompt": "...", "metadata": {"video": "/abs/path.mp4"}}
+
+Per rollout step: 64 samples, num_steps_per_rollout=4, so 16 samples per optimizer step
+over 4 dp ranks is 4 samples per rank at mbs=1.
+
+Usage:
+    MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_wan22.py
+"""
+
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+WANDB_PROJECT = "miles-diffusion-sft"
+
+# Wan2.2 DiT LoRA targets: self-attn (attn1), cross-attn (attn2), and FFN.
+LORA_TARGET_MODULES = (
+    "attn1.to_q attn1.to_k attn1.to_v attn1.to_out.0 "
+    "attn2.to_q attn2.to_k attn2.to_v attn2.to_out.0 "
+    "ffn.net.0.proj ffn.net.2"
+)
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    cuda_visible_devices: str = "0,1,2,3"
+    data_jsonl: str = ""
+    resume_ckpt: str = ""
+    start_rollout: int = -1
+    extra_args: str = ""
+
+
+def execute(args: ScriptArgs) -> None:
+    if not args.data_jsonl:
+        raise SystemExit("set --data-jsonl (or MILES_SCRIPT_DATA_JSONL) to a jsonl with prompt + metadata.video")
+    run_name = f"diffusion_sft_wan22_{U.create_run_id()}"
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    if args.resume_ckpt:
+        ckpt_args += f"--load {args.resume_ckpt} "
+        if args.start_rollout >= 0:
+            ckpt_args += f"--start-rollout-id {args.start_rollout} "
+
+    sft_args = (
+        "--loss-type sft_loss "
+        "--train-only "
+        "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
+        "--custom-convert-samples-to-train-data-path miles.rollout.sft_rollout.convert_samples_to_train_data "
+        "--custom-rollout-log-function-path miles.rollout.sft_rollout.log_rollout_data "
+        "--custom-prepare-train-batch-path miles.backends.fsdp_utils.loss_hub.sft.prepare_sft_batch "
+        "--custom-loss-function-path miles.backends.fsdp_utils.loss_hub.sft.sft_loss_formula "
+        f"--sft-encoder-checkpoint {MODEL} "
+        "--sft-frame-stride 2 "
+    )
+
+    rollout_args = (
+        f"--prompt-data {args.data_jsonl} "
+        "--input-key prompt "
+        "--rollout-batch-size 64 "
+        "--num-epoch 3 "
+        "--num-steps-per-rollout 4 "
+        "--micro-batch-size 1 "
+    )
+
+    diffusion_args = (
+        f"--diffusion-model {MODEL} "
+        "--diffusion-height 480 "
+        "--diffusion-width 832 "
+        "--diffusion-output-num-frames 81 "
+    )
+
+    optimizer_args = "--lr 1e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = (
+        "--use-lora "
+        "--lora-rank 64 "
+        "--lora-alpha 128 "
+        f"--lora-target-modules {LORA_TARGET_MODULES} "
+        "--lora-init-weights gaussian "
+    )
+
+    wandb_args = U.get_default_wandb_args(__file__, run_id=run_name, project=WANDB_PROJECT)
+
+    train_backend_args = (
+        "--train-backend fsdp "
+        "--fsdp-master-dtype fp32 "
+        "--fsdp-reduce-dtype fp32 "
+        "--diffusion-forward-dtype bf16 "
+        "--fsdp-flow-shift 3.0 "
+        "--update-weight-target-module transformer,transformer_2 "
+    )
+
+    misc_args = "--actor-num-gpus-per-node 4 --num-gpus-per-node 4 "
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {sft_args} {rollout_args} {diffusion_args} {optimizer_args} {lora_args} "
+            f"{wandb_args} {train_backend_args} {misc_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=4,
+        config=args,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This PR is stacked on #123. Last of the stack.

## What

The remaining five recipes as Python, same shape as the one in #123. 5 files, additions
only.

| Recipe | Python |
|---|---|
| `run-diffusion-grpo-ltx23-sglang.sh` | `run_diffusion_grpo_ltx23_sglang.py` |
| `run-diffusion-grpo-wan22-pickscore-5gpu.sh` | `run_diffusion_grpo_wan22_pickscore_5gpu.py` |
| `run-diffusion-grpo-sd3-ocr-sglang.sh` | `run_diffusion_grpo_sd3_ocr_sglang.py` |
| `run-diffusion-nft-sd3-pickscore.sh` | `run_diffusion_nft_sd3_pickscore.py` |
| `run-diffusion-sft-wan22.sh` | `run_diffusion_sft_wan22.py` |

## Why

The named argument groups are the point. A recipe as one flat wall of flags gives a
reader no way to tell which knobs set the batch shape and which set the objective;
`rollout_args`, `diffusion_args`, `grpo_args`, `lora_args`, `reward_args` and
`train_backend_args` do.

Worth knowing when reading these: the script-level groups are **not** the parser's
groups, and miles is the same. `--load` and `--save` live in the algo group in
`arguments.py` but read as `ckpt_args` in a recipe.

Branching that bash did with arrays becomes ordinary Python — the NFT recipe's smoke
mode, the SD3 OCR alignment-debug flags, and the SFT recipe's resume arguments are
conditionals now, not expanded array variables.

## How this was checked

For each pair, the bash recipe was run with `hf`, `mkdir`, `tee` and `nvidia-smi` stubbed
and the trainer call replaced by `echo`, so **bash itself expanded** `${SD3_MODEL}`,
`${WAN_LORA_TARGET_MODULES[@]}` and the rest. The Python script was run with
`exec_command` stubbed. The two argument lists were then compared flag by flag and value
by value:

```
run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned   bash 61 / py 61
run_diffusion_grpo_ltx23_sglang                      bash 66 / py 66
run_diffusion_grpo_wan22_pickscore_5gpu              bash 59 / py 59
run_diffusion_grpo_sd3_ocr_sglang                    bash 49 / py 49
run_diffusion_nft_sd3_pickscore                      bash 63 / py 63
run_diffusion_sft_wan22                              bash 38 / py 38
```

No missing flags, no extra flags, no value differences. Run-specific values (`--save`,
`--wandb-group`, dataset paths) are excluded, since they carry a timestamp or a local
path. The harness asserts all six pairs were actually compared — an earlier version
reported success while silently skipping every one of them, because the stubbed bash
produced no output and the "all ok" flag started out true.

## What is not done

The bash recipes stay and `tests/e2e/short/` still points at them. Switching the suites
over is a separate change: they compare metrics bit for bit under `--deterministic-mode`,
and a submitted Ray job replaces the inherited environment with an explicit one, so any
numerically relevant variable missing from `--runtime-env-json` would move the metrics.
Retiring the bash recipes should wait until each Python one has completed a real run.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; each script is verified by command equivalence against the recipe it mirrors
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags unchanged; the new scripts emit the same ones
- [ ] Public flags in the CLI reference — **n/a**, this repo has no CLI reference yet

Draft: no torch, sglang, ray or GPUs locally, so none of these were actually run.
