### PR TITLE
refactor(fsdp): upgrade needs_timestep_scaling to process_timestep_as_input in TrainPipelineConfig

### DIFF
--- a/miles/backends/fsdp_utils/configs/qwen_image.py
+++ b/miles/backends/fsdp_utils/configs/qwen_image.py
@@ -58,6 +58,9 @@ def _rebuild_pos_embed_freqs_on_cuda(model) -> None:
 class QwenImageTrainPipelineConfig(TrainPipelineConfig):
     hf_ckpt_name_patterns = ("qwen-image",)
 
+    def process_timestep_as_input(self, timesteps):
+        return timesteps / 1000.0
+
     lora_target_modules = [
         "to_q",
         "to_k",

--- a/miles/backends/fsdp_utils/configs/sd3.py
+++ b/miles/backends/fsdp_utils/configs/sd3.py
@@ -25,7 +25,6 @@ class SD3TrainPipelineConfig(TrainPipelineConfig):
         "attn.add_v_proj",
         "attn.to_add_out",
     ]
-    needs_timestep_scaling = False
 
     def prepare_cond_kwargs(self, cond: CondKwargs | None, device: torch.device) -> dict:
         if cond is None:

--- a/miles/backends/fsdp_utils/configs/train_pipeline_config.py
+++ b/miles/backends/fsdp_utils/configs/train_pipeline_config.py
@@ -78,7 +78,6 @@ class TrainPipelineConfig(abc.ABC):
 
     model_family: str | None = None
     lora_target_modules: list[str] = ["to_q", "to_k", "to_v", "to_out.0"]
-    needs_timestep_scaling: bool = True
     optimizer_state_allowed_missing: list[str] = []
     # Case-insensitive substrings matched against the checkpoint name (--diffusion-model).
     hf_ckpt_name_patterns: tuple[str, ...] = ()
@@ -98,6 +97,11 @@ class TrainPipelineConfig(abc.ABC):
 
     def configure(self, args) -> None:  # noqa: B027  optional no-op hook, not abstract
         """Bind the request constants a family needs at train time; default binds none."""
+
+    def process_timestep_as_input(self, timesteps: torch.Tensor) -> torch.Tensor:
+        """The trajectory timestep as this family's DiT takes it, rescaled the way its own
+        sglang-d DiT rescales it -- the arithmetic has to match, not just the value."""
+        return timesteps
 
     def compute_noise_pred(
         self,

--- a/miles/backends/fsdp_utils/configs/wan2_2.py
+++ b/miles/backends/fsdp_utils/configs/wan2_2.py
@@ -15,7 +15,6 @@ class Wan2_2TrainPipelineConfig(TrainPipelineConfig):
     # ("transformer_2") the rest.
     boundary_ratio = 0.875
     # Wan DiT expects raw scheduler timesteps (0..num_train_timesteps), no /1000 scaling.
-    needs_timestep_scaling = False
 
     def component_for_timestep(self, timestep: float, num_train_timesteps: int) -> str:
         if timestep >= self.boundary_ratio * num_train_timesteps:

--- a/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
+++ b/miles/backends/fsdp_utils/loss_hub/flow_grpo.py
@@ -62,10 +62,7 @@ def prepare_flow_grpo_batch(
             args.diffusion_guidance_scale_2,
         )
 
-    if config.needs_timestep_scaling:
-        timesteps_for_model = timesteps / float(num_train_timesteps)
-    else:
-        timesteps_for_model = timesteps
+    timesteps_for_model = config.process_timestep_as_input(timesteps)
 
     pos_list = [config.prepare_cond_kwargs(batch[i]["denoising_env"].pos_cond_kwargs, device) for i in range(bsz)]
     neg_list = (

--- a/miles/backends/fsdp_utils/loss_hub/nft.py
+++ b/miles/backends/fsdp_utils/loss_hub/nft.py
@@ -40,16 +40,12 @@ def prepare_nft_batch(
     pos_cond = config.collate_cond_for_sample_batch(pos_list, device, pad_to_len=pad_to_len)
 
     num_train_timesteps = ctx.scheduler.config.num_train_timesteps
-    if config.needs_timestep_scaling:
-        timesteps_for_model = t.to(dtype=torch.float32)
-    else:
-        timesteps_for_model = t * float(num_train_timesteps)
 
     xt = corrupt(x0, t, sample_noise(x0))
     return PreparedBatch(
         latents=xt,
         timesteps=t,
-        timesteps_for_model=timesteps_for_model,
+        timesteps_for_model=config.process_timestep_as_input(t * float(num_train_timesteps)),
         model=model,
         component_name=component_name,
         guidance_scale=0.0,

--- a/miles/backends/fsdp_utils/loss_hub/sft.py
+++ b/miles/backends/fsdp_utils/loss_hub/sft.py
@@ -82,19 +82,13 @@ def prepare_sft_batch(
     sigma_exp = sigmas.view(bsz, *([1] * (x0.ndim - 1)))
     latents = (1.0 - sigma_exp) * x0 + sigma_exp * noise
 
-    num_train_timesteps = int(ctx.scheduler.config.num_train_timesteps)
-    if config.needs_timestep_scaling:
-        timesteps_for_model = timesteps / float(num_train_timesteps)
-    else:
-        timesteps_for_model = timesteps
-
     cond_list = [{key: value.to(device) for key, value in pair["cond_kwargs"].items()} for pair in batch]
     pos_cond = config.collate_cond_for_sample_batch(cond_list, device, pad_to_len=pad_to_len)
 
     return PreparedBatch(
         latents=latents,
         timesteps=timesteps,
-        timesteps_for_model=timesteps_for_model,
+        timesteps_for_model=config.process_timestep_as_input(timesteps),
         model=model,
         component_name=component_name,
         guidance_scale=0.0,

--- a/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
+++ b/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
@@ -5,7 +5,10 @@ register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
 import pytest
 import torch
 
+from miles.backends.fsdp_utils.configs.qwen_image import QwenImageTrainPipelineConfig
+from miles.backends.fsdp_utils.configs.sd3 import SD3TrainPipelineConfig
 from miles.backends.fsdp_utils.configs.train_pipeline_config import TrainPipelineConfig, resolve_diffusion_model_family
+from miles.backends.fsdp_utils.configs.wan2_2 import Wan2_2TrainPipelineConfig
 
 
 class TestFamilyResolution:
@@ -85,3 +88,22 @@ class TestComputeNoisePred:
     def test_joint_batch_matches_two_pass(self):
         joint = {"bias": torch.cat([self.pos["bias"], self.neg["bias"]], dim=0)}
         torch.testing.assert_close(self._call(cfg_batching=True, joint_cond=joint), self._call())
+
+
+class TestProcessTimestepAsInput:
+    # What a family hands its DiT as the timestep, given the trajectory's t and the
+    # scheduler range N. Each family must reproduce the arithmetic its sglang-d DiT runs.
+    #
+    #   sd3, wan2_2   t         the DiT takes the trajectory timestep unchanged
+    #   qwen_image    t / 1000  the model's own normalizer, which Timesteps(scale=1000) undoes
+    TIMESTEPS = torch.tensor([978.2581787109375, 500.0])
+
+    @pytest.mark.parametrize("config_cls", [SD3TrainPipelineConfig, Wan2_2TrainPipelineConfig])
+    def test_raw_trajectory_timestep(self, config_cls):
+        out = config_cls.process_timestep_as_input(config_cls, self.TIMESTEPS)
+        assert torch.equal(out, self.TIMESTEPS)
+
+    def test_qwen_image_divides_by_the_model_normalizer(self):
+        out = QwenImageTrainPipelineConfig.process_timestep_as_input(QwenImageTrainPipelineConfig, self.TIMESTEPS)
+        # One division, like the rollout: any rewrite of the expression drifts ULPs.
+        assert torch.equal(out, self.TIMESTEPS / 1000.0)

--- a/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
+++ b/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
@@ -17,7 +17,8 @@ NUM_GRID = 8
 
 
 class _Config:
-    needs_timestep_scaling = False
+    # The SD3 default: the DiT takes the trajectory timestep unchanged.
+    process_timestep_as_input = staticmethod(lambda timesteps: timesteps)
 
     def collate_cond_for_sample_batch(self, per_sample_cond_kwargs, device, pad_to_len=None):
         return {"encoder_hidden_states": torch.cat([kw["encoder_hidden_states"] for kw in per_sample_cond_kwargs])}
@@ -82,14 +83,8 @@ class TestPrepareSftBatch:
         assert torch.allclose(prepared.latents, x0 + sigma * prepared.extras["target"], atol=1e-5)
         assert not prepared.use_cfg
         assert prepared.pos_cond["encoder_hidden_states"].shape == (4, 6, 8)
+        # SD3's DiT takes the raw trajectory timestep, so the hook is the identity here.
         assert torch.equal(prepared.timesteps_for_model, prepared.timesteps)
-
-    def test_timestep_scaling(self):
-        torch.manual_seed(0)
-        ctx = _ctx({"transformer": nn.Identity()})
-        ctx.train_pipeline_config.needs_timestep_scaling = True
-        prepared = prepare_sft_batch(ctx, _batch())
-        assert torch.allclose(prepared.timesteps_for_model, prepared.timesteps / NUM_TRAIN_TIMESTEPS)
 
     def test_single_model_indices_cover_grid_uniformly(self):
         ctx = _ctx({"transformer": nn.Identity()}, config=_SingleConfig())


### PR DESCRIPTION
## What

- Replace the `needs_timestep_scaling` boolean on `TrainPipelineConfig` with a `process_timestep_as_input(timesteps, *, num_train_timesteps)` hook that returns the timestep tensor the family's DiT actually consumes.
- Families declare their own arithmetic: sd3, wan2_2 and ltx inherit the identity; qwen_image implements `timesteps / float(num_train_timesteps)`.
- The three prepare hooks (flow-GRPO, NFT, SFT) call the hook instead of branching on the boolean.

## Why

The boolean could only express "divide by the scheduler range, or don't". That was enough while every family either took the raw trajectory timestep or `t / N`, but it cannot express a family whose DiT consumes a different quantity altogether — which is what LTX needs next: its DiT takes sigma, and reconstructing sigma from `t / divisor` drifts 1-2 float32 ULPs away from the sigma the rollout actually fed its own DiT. A hook lets that family return the rollout's value directly while every other family keeps its current arithmetic.

Two smaller wins: the qwen_image rescale now sits next to the qwen model rather than behind a flag read in three prepare functions, and SFT stops recomputing `num_train_timesteps` for a branch it no longer needs.

## Behaviour

None. Each family produces exactly the tensor it produced before:

| family | before | after |
|---|---|---|
| sd3, wan2_2, ltx | `needs_timestep_scaling = False` → raw `t` | inherits the identity hook |
| qwen_image | inherited default `True` → `t / num_train_timesteps` | same expression, in its own config |

The e2e standards are unchanged, so nothing needs re-recording.

## Files

- `configs/train_pipeline_config.py` — hook added, boolean removed
- `configs/qwen_image.py` — divides by the scheduler range
- `configs/sd3.py`, `configs/wan2_2.py` — drop the boolean, inherit the identity
- `loss_hub/flow_grpo.py`, `loss_hub/nft.py`, `loss_hub/sft.py` — call the hook
- `tests/.../configs/test_train_pipeline_config_registry.py` — `TestProcessTimestepAsInput`: identity for sd3/wan2_2, single division for qwen_image
- `tests/.../test_loss_hub_sft.py` — stub config declares the hook

## Follow-up

This is the first step of the LTX train/rollout alignment work. A later PR adds the rollout sigma as a second hook input and has LTX return it; the numbers and the e2e re-record land there, not here.

## Checklist

- [x] `pre-commit run --all-files` passes — ran on the touched files (black/ruff/isort/autoflake)
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green — 148 passed (`tests/fast/backends/fsdp_utils`, `tests/fast/utils`)
- [x] If launch flags changed, `python3 train.py --help` still parses — **no flag changes**
- [ ] If a public flag was added, it appears in the CLI reference docs — **no new flags**
- [ ] If an example was added, it has a real walkthrough — **no new examples**
