### PR TITLE
feat(diffusion): make the DP split of train pairs an explicit flag

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -179,10 +179,8 @@ class RolloutManager:
         log_perf_data_raw(rollout_id, self.args, is_primary_rank=True)
         logger.info("RolloutManager generate done: rollout_id=%s", rollout_id)
         dp_size = self.train_parallel_config["dp_size"]
-        # Legacy 2D compat: strided DP split + tile reorder reproduce the legacy
-        # tiles bit-for-bit; otherwise the native 1D contiguous split.
+        shards = self.train_data_dp_splitter.split_by_dp(data, dp_size, mode=self.args.train_dp_split_mode)
         if self.args.micro_batch_size_sample is not None:
-            shards = self.train_data_dp_splitter.split_by_dp(data, dp_size, mode="baseline_stride")
             shards = [
                 {
                     **shard,
@@ -196,8 +194,6 @@ class RolloutManager:
                 }
                 for shard in shards
             ]
-        else:
-            shards = self.train_data_dp_splitter.split_by_dp(data, dp_size)
         return [Box(ray.put(shard)) for shard in shards]
 
     def eval(self, rollout_id):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -784,6 +784,19 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--train-dp-split-mode",
+                type=str,
+                default="contiguous",
+                choices=["contiguous", "stride"],
+                help=(
+                    "How rollout train pairs are dealt to DP ranks. contiguous gives each rank an "
+                    "adjacent block, so a micro-batch can reproduce a rollout microgroup exactly. "
+                    "stride deals them round-robin, reproducing the miles-core dispatch that strides "
+                    "for sequence-length balance -- diffusion samples are equal-sized, so stride is "
+                    "only useful for the legacy parity check."
+                ),
+            )
+            parser.add_argument(
                 "--diffusion-train-iter-order",
                 type=str,
                 default="sample_major",

--- a/miles/utils/train_data_utils.py
+++ b/miles/utils/train_data_utils.py
@@ -77,9 +77,9 @@ class TrainDataDPSplitter:
     - ``contiguous`` (default): rank r gets one contiguous block of train pairs
       ``[r*pairs_per_rank : (r+1)*pairs_per_rank]``. Since pairs are sample-major,
       this gives rank r a contiguous block of samples.
-    - ``baseline_stride``: reproduces the legacy TrainRayActor dispatch, which
-      partitioned *samples* by stride ``range(r, num_samples, dp_size)`` and then
-      tiled them. Used by the ``verify/baseline-batch-parity`` check to confirm the
+    - ``stride``: reproduces the legacy TrainRayActor dispatch, which partitioned
+      *samples* by stride ``range(r, num_samples, dp_size)`` and then tiled them.
+      Used by the ``verify/baseline-batch-parity`` check to confirm the
       refactored rollout-side dispatch can feed each DP rank the exact same
       sample set (in the same order) as the old code path, so any residual
       train-curve difference is attributable to grouping policy, not a bug.
@@ -94,7 +94,7 @@ class TrainDataDPSplitter:
         """Split train data across DP ranks into equal-sized shards."""
         if dp_size <= 0:
             raise ValueError(f"dp_size must be positive, got {dp_size}")
-        if mode not in ("contiguous", "baseline_stride"):
+        if mode not in ("contiguous", "stride"):
             raise ValueError(f"unknown dp split mode {mode!r}")
         train_data = data["train_data"]
         scheduler_timesteps = data.get("scheduler_timesteps")
@@ -106,7 +106,7 @@ class TrainDataDPSplitter:
                 "would drop all pairs when enforcing equal DP shards"
             )
 
-        if mode == "baseline_stride":
+        if mode == "stride":
             rank_pairs = self._stride_partition_by_sample(train_data, dp_size)
         else:
             dropped_pairs = num_pairs % dp_size
@@ -153,12 +153,12 @@ class TrainDataDPSplitter:
         per_sample_counts = {len(g) for g in sample_groups}
         if len(per_sample_counts) != 1:
             raise ValueError(
-                f"baseline_stride split requires every sample to contribute the same number of "
+                f"stride split requires every sample to contribute the same number of "
                 f"train pairs, got counts {sorted(per_sample_counts)}"
             )
         if len(sample_groups) % dp_size != 0:
             raise ValueError(
-                f"baseline_stride split requires num_samples ({len(sample_groups)}) divisible by "
+                f"stride split requires num_samples ({len(sample_groups)}) divisible by "
                 f"dp_size ({dp_size}) for equal shards"
             )
 

--- a/scripts/run-diffusion-grpo-ltx23-sglang.sh
+++ b/scripts/run-diffusion-grpo-ltx23-sglang.sh
@@ -43,6 +43,7 @@ fi
   --n-samples-per-prompt 8 \
   --num-steps-per-rollout 2 \
   --num-rollout "${NUM_ROLLOUT:-200}" \
+  --train-dp-split-mode stride \
   --micro-batch-size-sample 1 \
   --micro-batch-size-tstep 1 \
   --diffusion-train-iter-order sample_major \

--- a/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
+++ b/scripts/run-diffusion-grpo-pickscore-5gpu-flowgrpo-aligned.sh
@@ -58,6 +58,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
   --num-rollout 400 \
   --deterministic-mode \
   --diffusion-microgroup-size 8 \
+  --train-dp-split-mode stride \
   --micro-batch-size-sample 8 \
   --micro-batch-size-tstep 1 \
   --diffusion-train-iter-order sample_major \

--- a/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
+++ b/scripts/run-diffusion-grpo-sd3-ocr-sglang.sh
@@ -73,6 +73,7 @@ python -u "${ROOT_DIR}/train_diffusion.py" \
   --n-samples-per-prompt 16 \
   --num-rollout "${NUM_ROLLOUT}" \
   --deterministic-mode \
+  --train-dp-split-mode stride \
   --micro-batch-size-sample 16 \
   --micro-batch-size-tstep 5 \
   --diffusion-microgroup-size 8 \

--- a/tests/fast/utils/test_grouping_parity.py
+++ b/tests/fast/utils/test_grouping_parity.py
@@ -8,12 +8,13 @@ non-determinism that makes end-to-end training comparison unreliable
 (see determinism/BACKWARD_NONDETERMINISM.md).
 
 Contract under test: with the parity flags
-``--diffusion-train-dp-split baseline_stride`` + ``--diffusion-train-cond-pad-window``,
+``--train-dp-split-mode stride`` + ``--diffusion-train-cond-pad-window``,
 the refactored pipeline feeds each DP rank / each micro-batch the **same tensors in
 the same order** as the legacy grid-based path.
 
 Layers:
-  L1  DP split            — baseline_stride == legacy range(rank, N, dp)
+  L1  DP split            — stride == legacy range(rank, N, dp), and only
+                            contiguous keeps a rollout microgroup whole on one rank
   L2  Converter           — flat train-pairs == direct sde-indexed trajectory data
   L3  Cond window padding — per-microbatch collate(pad_to_len=window_max)
                             == legacy window-collate-then-tile-slice
@@ -36,7 +37,7 @@ from miles.utils.train_data_utils import TrainDataDPSplitter, scheduler_meta_fro
 
 
 # --------------------------------------------------------------------------------------
-# L1 — DP split parity: baseline_stride reproduces legacy range(rank, N, dp_size)
+# L1 — DP split parity: stride reproduces legacy range(rank, N, dp_size)
 # --------------------------------------------------------------------------------------
 def _legacy_dp_partition(num_samples: int, dp_size: int):
     return [list(range(r, num_samples, dp_size)) for r in range(dp_size)]
@@ -56,11 +57,11 @@ def _rank_sample_order(shard):
     return seen
 
 
-def test_l1_dp_split_baseline_stride_matches_legacy():
+def test_l1_dp_split_stride_matches_legacy():
     splitter = TrainDataDPSplitter()
     for num_samples, ppp, dp in [(256, 2, 2), (256, 2, 4), (16, 1, 2), (12, 3, 3)]:
         data = _make_flat_pairs(num_samples, ppp)
-        shards = splitter.split_by_dp(data, dp, mode="baseline_stride")
+        shards = splitter.split_by_dp(data, dp, mode="stride")
         expected = _legacy_dp_partition(num_samples, dp)
         for r in range(dp):
             assert _rank_sample_order(shards[r]) == expected[r], (num_samples, dp, r)
@@ -74,8 +75,28 @@ def test_l1_contiguous_differs_from_stride():
     splitter = TrainDataDPSplitter()
     data = _make_flat_pairs(256, 2)
     cont = splitter.split_by_dp(data, 2, mode="contiguous")
-    strd = splitter.split_by_dp(data, 2, mode="baseline_stride")
+    strd = splitter.split_by_dp(data, 2, mode="stride")
     assert _rank_sample_order(cont[0]) != _rank_sample_order(strd[0])
+
+
+def test_l1_only_contiguous_keeps_rollout_microgroups_whole():
+    """A micro-batch can only reproduce a rollout forward if its samples reached one rank.
+
+    8 samples generated as 4 microgroups of 2, split over 2 DP ranks:
+
+        microgroups   [0 1] [2 3] [4 5] [6 7]
+        contiguous    rank0 = 0 1 2 3   -> microgroups {0,1} intact
+        stride        rank0 = 0 2 4 6   -> one sample from every microgroup
+    """
+    splitter = TrainDataDPSplitter()
+    data = _make_flat_pairs(num_samples=8, pairs_per_sample=1)
+    microgroups = [{0, 1}, {2, 3}, {4, 5}, {6, 7}]
+
+    contiguous = set(_rank_sample_order(splitter.split_by_dp(data, 2, mode="contiguous")[0]))
+    stride = set(_rank_sample_order(splitter.split_by_dp(data, 2, mode="stride")[0]))
+
+    assert sum(group <= contiguous for group in microgroups) == 2
+    assert sum(group <= stride for group in microgroups) == 0
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/fast/utils/test_legacy_tile_grouping_golden.py
+++ b/tests/fast/utils/test_legacy_tile_grouping_golden.py
@@ -1,8 +1,8 @@
-"""Golden CI: baseline_stride + 1D schedule reproduce the REAL legacy OCR tiles.
+"""Golden CI: stride + 1D schedule reproduce the REAL legacy OCR tiles.
 
 The distinctive axis here is the DP split: this replays the one real 2-GPU OCR config
 (legacy_ocr_tile_grouping.json, see gen_legacy_tile_fixture.py) through
-TrainDataDPSplitter("baseline_stride")  # == legacy range(rank, N, dp)
+TrainDataDPSplitter("stride")  # == legacy range(rank, N, dp)
     -> build_microbatch_schedule(...)    # contiguous micro-batches
 and asserts every legacy tile is reproduced cell-for-cell. The 2D tiling function is
 covered separately by test_tiled_microbatch_schedule.py (no DP split there).
@@ -39,7 +39,7 @@ def _refactored_grouping(cfg: dict):
     pairs = [
         {"sample_index": s, "sde_step": sde} for s in range(cfg["num_samples"]) for sde in cfg["sde_step_indices"]
     ]
-    shards = TrainDataDPSplitter().split_by_dp({"train_data": pairs}, cfg["dp_size"], mode="baseline_stride")
+    shards = TrainDataDPSplitter().split_by_dp({"train_data": pairs}, cfg["dp_size"], mode="stride")
 
     grouping: dict[tuple[int, int, int], list[list[int]]] = {}
     mb_counts: dict[tuple[int, int], int] = {}
@@ -88,10 +88,10 @@ def test_refactored_microbatch_count_matches_legacy_window():
         assert n == expected, f"rank={rank} optim_step={step}: {n} micro-batches, expected {expected}"
 
 
-def test_baseline_stride_is_what_makes_it_match():
+def test_stride_is_what_makes_it_match():
     """Sanity: with the *default* contiguous DP split (parity knob off) the very
-    first pinned tile no longer matches — proving the match is due to
-    baseline_stride, not a trivial identity."""
+    first pinned tile no longer matches — proving the match is due to stride,
+    not a trivial identity."""
     fx = _load_fixture()
     cfg = fx["meta"]["config"]
     tile = fx["tiles"][0]

--- a/tests/fixtures/gen_legacy_tile_fixture.py
+++ b/tests/fixtures/gen_legacy_tile_fixture.py
@@ -1,10 +1,10 @@
 """Golden fixture for the REAL 2-GPU OCR pipeline -> legacy_ocr_tile_grouping.json.
 
 Distinct from gen_legacy_tile_2d_fixture: this is the ONLY golden that exercises the DP
-split. It runs the full legacy dispatch end-to-end -- baseline_stride rank partition
+split. It runs the full legacy dispatch end-to-end -- stride rank partition
 (range(rank, N, dp)) + per-optim-step slice + tiling -- for the one real OCR config
 (512 samples, dp=2, window=2, sample_mb=4, tstep_mb=2), replayed by
-test_legacy_tile_grouping_golden.py via TrainDataDPSplitter("baseline_stride") +
+test_legacy_tile_grouping_golden.py via TrainDataDPSplitter("stride") +
 build_microbatch_schedule (the 1D path). The 2D fixture instead cross-checks the
 build_tiled_microbatch_schedule function across tiling shapes but never splits by rank.
 
@@ -172,7 +172,7 @@ def main() -> None:
                 "Real legacy TrainRayActor grid-tile group-batch membership, produced by "
                 "executing origin/main _run_optim_window verbatim with the 2-GPU OCR baseline "
                 "config. Each cell is [sample_index, sde_step]. The refactored compat pipeline "
-                "(baseline_stride DP split + build_microbatch_schedule, micro_batch_size="
+                "(stride DP split + build_microbatch_schedule, micro_batch_size="
                 f"{MICRO_BATCH_SIZE}) must reproduce every tile exactly."
             ),
             "legacy_provenance": {

--- a/tests/fixtures/legacy_ocr_tile_grouping.json
+++ b/tests/fixtures/legacy_ocr_tile_grouping.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "description": "Real legacy TrainRayActor grid-tile group-batch membership, produced by executing origin/main _run_optim_window verbatim with the 2-GPU OCR baseline config. Each cell is [sample_index, sde_step]. The refactored compat pipeline (baseline_stride DP split + build_microbatch_schedule, micro_batch_size=8) must reproduce every tile exactly.",
+    "description": "Real legacy TrainRayActor grid-tile group-batch membership, produced by executing origin/main _run_optim_window verbatim with the 2-GPU OCR baseline config. Each cell is [sample_index, sde_step]. The refactored compat pipeline (stride DP split + build_microbatch_schedule, micro_batch_size=8) must reproduce every tile exactly.",
     "legacy_provenance": {
       "ref": "radixark/miles_diffusion@a48476c (origin/main)",
       "dp_stride": "miles/ray/rollout.py:433",


### PR DESCRIPTION
## What

- Add `--train-dp-split-mode {contiguous,stride}` (default `contiguous`) and have `RolloutManager` read it, instead of deriving the split mode from whether `--micro-batch-size-sample` is set.
- Rename the splitter's `baseline_stride` mode to `stride`, so the flag value passes straight through to `TrainDataDPSplitter.split_by_dp(..., mode=...)` with no translation.
- Pin the three recipes that were reaching the strided split through the old coupling — `ltx23-sglang`, `sd3-ocr-sglang`, `pickscore-5gpu-flowgrpo-aligned` — to `--train-dp-split-mode stride`.
- Cover the split modes' effect on rollout microgroups in the L1 layer of the grouping-parity suite.

## Why

Bitwise train/rollout parity needs the train micro-batch to be the *same samples in the same batch* as the rollout's DiT forward — batch composition moves kernel dispatch and reduction order, so one sample in a different batch is a different forward and the ratio stops being 1. `--diffusion-microgroup-size N` pins that rollout batch at N samples, but a run cannot currently choose the DP split that keeps those N together: `--micro-batch-size-sample` silently forces the strided split, which deals samples `range(rank, N, dp_size)` and leaves each rank one sample out of every microgroup. The strided deal comes from miles-core, where it balances sequence lengths — diffusion samples are equal-sized, so it earns nothing here and becomes an opt-in flag with `contiguous` as the default.

## Naming

`--train-dp-split-mode` carries no `diffusion-` prefix, per the standard written down in #117: the prefix is for flags that name the diffusion process itself and would be too broad without it (rule 1), or where the same quantity exists on both sides and the prefix separates them (rule 2). This flag is neither — it names data dispatch, `train-dp-` already places it, so rule 3 applies. `-mode` over `-style` because the repo has three `-mode` flags and no `-style` one, and because it is literally the splitter's parameter name.

`baseline_stride` became `stride` in the same pass: "baseline" said *why we kept it around*, not what it does, and the flag value and the splitter mode should not need a mapping table between them. Pure rename, no behaviour attached.

## Behaviour

None, for every recipe in the tree. The three recipes that used to get the strided split (all of them set `--micro-batch-size-sample`) now ask for it explicitly, so the e2e standards are unchanged and nothing needs re-recording. The default flips only for a run that sets `--micro-batch-size-sample` without naming a split mode, which no recipe in the tree does.

## Files

- `miles/utils/arguments.py` — the flag, with `choices` doing the validation
- `miles/ray/rollout.py` — split mode read from the flag; the tile reorder keeps its own `micro_batch_size_sample` condition
- `miles/utils/train_data_utils.py` — `baseline_stride` → `stride`
- `scripts/run-diffusion-grpo-{ltx23-sglang,sd3-ocr-sglang,pickscore-5gpu-flowgrpo-aligned}.sh` — pinned to `stride`
- `tests/fast/utils/test_grouping_parity.py` — `test_l1_only_contiguous_keeps_rollout_microgroups_whole`, plus the L1 line in the header comment; mode rename
- `tests/fast/utils/test_legacy_tile_grouping_golden.py`, `tests/fixtures/gen_legacy_tile_fixture.py`, `tests/fixtures/legacy_ocr_tile_grouping.json` — mode rename in code and in the prose that names it (the fixture's recorded tiles are untouched)

## Follow-up

The LTX recipe stays on `stride` here. Flipping it to `contiguous` — which, with the dtype and kernel fixes, gets LTX to 2580/2580 bit-exact module outputs and `|ratio - 1| = 1.19e-7` at DP=2 — is a numerical change and lands with the alignment PR that re-records its standard.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green — 147 passed (`tests/fast/utils`, `tests/fast/backends/fsdp_utils`) before the rename; the rename itself is mechanical and CI re-runs the same suites
- [x] If launch flags changed, `python3 train_diffusion.py --help` still parses — covered by the three e2e stages, which launch real runs with the new flag set
- [ ] If a public flag was added, it appears in the CLI reference docs — **no CLI reference doc covers this group yet**
- [ ] If an example was added, it has a real walkthrough — **no new examples**
