### PR TITLE
refactor(args): write down the prefix rule and apply what it catches

### DIFF
--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -258,8 +258,8 @@ async def generate_and_rm_group(
     seed_base = (args.rollout_seed + group_index * n_per_prompt) % (2**31)
 
     tasks = []
-    for idx in range(0, len(group), args.diffusion_microgroup_size):
-        microgroup = group[idx : min(idx + args.diffusion_microgroup_size, len(group))]
+    for idx in range(0, len(group), args.rollout_microgroup_size):
+        microgroup = group[idx : min(idx + args.rollout_microgroup_size, len(group))]
         current_sampling_params = sampling_params.copy()
         current_sampling_params["seed"] = seed_base + idx
         tasks.append(

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1,3 +1,15 @@
+"""Command-line arguments for diffusion training.
+
+`diffusion-` marks the modality, so a CLI merged with miles LLM says what a flag is for:
+
+  - Prefix concepts from diffusion modelling — denoising, SDE, CFG, latents, frames.
+  - Not generic ML/RL — clipping, KL, EMA, LoRA, batching — nor what `lora-` etc. place.
+  - `fsdp-`/`rollout-` mark the side: `--fsdp-flow-shift` vs `--diffusion-flow-shift`.
+
+Shared concepts miles names differently (`--diffusion-clip-range` vs `--eps-clip`) keep
+the prefix until the CLIs merge; stripping it early leaves two names for one idea.
+"""
+
 import argparse
 import json
 import logging
@@ -230,10 +242,10 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
-                "--diffusion-microgroup-size",
+                "--rollout-microgroup-size",
                 type=int,
                 default=1,
-                help="Diffusion rollout microgroup size (sub-batch of samples per prompt). Defaults to 1.",
+                help="Samples per prompt sent in one rollout request (sub-batch of the group).",
             )
             parser.add_argument(
                 "--diffusion-fps",
@@ -633,23 +645,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=int,
                 default=None,
                 help=(
-                    "[DEPRECATED -- kept only for backward compatibility with legacy (pre-refactor) configs; planned for removal, prefer --micro-batch-size.] "
-                    "Diffusion FSDP legacy 2D grouping: samples per DiT-forward tile. When set "
-                    "(together with --micro-batch-size-tstep), the RolloutManager groups train pairs "
-                    "into sample x timestep tiles instead of contiguous --micro-batch-size chunks, "
-                    "reproducing the legacy TrainRayActor tiling (e.g. SD3.5 where tstep micro-batch "
-                    "!= SDE window)."
+                    "Samples per DiT-forward tile. When set together with --micro-batch-size-tstep, "
+                    "the RolloutManager groups train pairs into sample x timestep tiles rather than "
+                    "contiguous --micro-batch-size chunks. The two together are more expressive than "
+                    "--micro-batch-size, which can only cut the flat pair list: they control how many "
+                    "samples and how many timesteps share one forward."
                 ),
             )
             parser.add_argument(
                 "--micro-batch-size-tstep",
                 type=int,
                 default=None,
-                help=(
-                    "[DEPRECATED -- kept only for backward compatibility with legacy (pre-refactor) configs; planned for removal, prefer --micro-batch-size.] "
-                    "Diffusion FSDP legacy 2D grouping: SDE timesteps per DiT-forward tile "
-                    "(pairs with --micro-batch-size-sample)."
-                ),
+                help=("SDE timesteps per DiT-forward tile; pairs with --micro-batch-size-sample."),
             )
             parser.add_argument(
                 "--train-dp-split-mode",
@@ -669,11 +676,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 type=str,
                 default="sample_major",
                 choices=["sample_major", "timestep_major"],
-                help=(
-                    "[DEPRECATED -- kept only for backward compatibility with legacy (pre-refactor) configs; planned for removal, prefer --micro-batch-size.] "
-                    "Diffusion FSDP legacy 2D grouping: tile iteration order "
-                    "(only meaningful with --micro-batch-size-sample/-tstep)."
-                ),
+                help=("Tile iteration order; only meaningful with --micro-batch-size-sample/-tstep."),
             )
             return parser
 

--- a/scripts/run_diffusion_grpo_ltx23_sglang.py
+++ b/scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -52,7 +52,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--n-samples-per-prompt 8 "
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
-        "--diffusion-microgroup-size 1 "
+        "--rollout-microgroup-size 1 "
         "--micro-batch-size-sample 1 "
         "--micro-batch-size-tstep 1 "
         "--train-dp-split-mode stride "

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -53,7 +53,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--n-samples-per-prompt 16 "
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
-        "--diffusion-microgroup-size 8 "
+        "--rollout-microgroup-size 8 "
         "--micro-batch-size-sample 8 "
         "--micro-batch-size-tstep 1 "
         "--train-dp-split-mode stride "

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -54,7 +54,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--n-samples-per-prompt 16 "
         f"--num-rollout {args.num_rollout} "
         "--global-batch-size 64 "
-        "--diffusion-microgroup-size 8 "
+        "--rollout-microgroup-size 8 "
         "--micro-batch-size-sample 16 "
         "--micro-batch-size-tstep 5 "
         "--train-dp-split-mode stride "

--- a/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -15,7 +15,7 @@ optimizer step over 4 train GPUs. micro-batch-size 2 keeps every micro-batch pha
 
 Gradient checkpointing stays off: Wan2.2 under FSDP2 mixed precision hits a
 torch.utils.checkpoint CheckpointError on the fp32 RoPE freq buffers. If you OOM, lower
---rollout-batch-size, --n-samples-per-prompt or --diffusion-microgroup-size.
+--rollout-batch-size, --n-samples-per-prompt or --rollout-microgroup-size.
 
 Usage:
     python3 scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -66,7 +66,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--n-samples-per-prompt 16 "
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
-        "--diffusion-microgroup-size 8 "
+        "--rollout-microgroup-size 8 "
         "--micro-batch-size 2 "
     )
 

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -58,9 +58,9 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         f"--num-rollout {num_rollout} "
         "--num-steps-per-rollout 1 "
     ) + (
-        "--rollout-batch-size 2 --n-samples-per-prompt 2 --micro-batch-size 2 --diffusion-microgroup-size 2 "
+        "--rollout-batch-size 2 --n-samples-per-prompt 2 --micro-batch-size 2 --rollout-microgroup-size 2 "
         if args.smoke
-        else "--rollout-batch-size 8 --n-samples-per-prompt 8 --micro-batch-size 4 --diffusion-microgroup-size 8 "
+        else "--rollout-batch-size 8 --n-samples-per-prompt 8 --micro-batch-size 4 --rollout-microgroup-size 8 "
     )
 
     diffusion_args = (


### PR DESCRIPTION
Last argument change before the release. One rename, three deprecation notices removed, and
the naming rule written down where it can be found.

## What

| Change | Detail |
|---|---|
| `--diffusion-microgroup-size` → `--rollout-microgroup-size` | rename |
| `--micro-batch-size-sample`, `--micro-batch-size-tstep`, `--diffusion-train-iter-order` | deprecation notices removed |
| `arguments.py` module docstring | the `diffusion-` prefix rule |


## The rule

Agreed in #117 but it lived only in that PR's description, where nobody adding a flag will
find it. Condensed, with the clause added since — the prefix marks the **modality**, so a CLI
merged with miles LLM says which flags belong to which kind of run:

- **Prefix** when the concept comes from diffusion modelling itself — denoising schedule, SDE,
  CFG, latents, resolution, frames. After a merge these mean nothing for an LLM run.
- **No prefix** for generic ML/RL — clipping, KL, EMA, LoRA, optimizer, batching — even where
  miles has no such flag today. A subsystem prefix (`lora-`, `ema-`, `nft-`, `pickscore-`,
  `sglang-`) already places a flag; do not stack `diffusion-` on it.
- **`fsdp-` / `rollout-` mark the side, not the modality** — `--fsdp-flow-shift` against
  `--diffusion-flow-shift`.
- **Exception**: a shared concept miles names differently keeps the prefix until the CLIs merge
  and one name is chosen. Stripping `--diffusion-clip-range` now would leave `--clip-range`
  beside miles' `--eps-clip`, two names for one idea.

This replaces the earlier "names the diffusion process *and* would be too broad without it"
test, whose second clause never did any work and misfired once — it made `--guidance-scale`
look like it should lose the prefix.

## What the rule catches

One flag. `--diffusion-microgroup-size` names how many samples of a prompt go in one rollout
request: generic batching on the rollout side, not diffusion modelling. Its consumer is
`sglang_diffusion_rollout.py`, so `--rollout-microgroup-size` puts it with the side markers.
A bare `--microgroup-size` would lose the side.

Everything else already conforms: 29 prefixed flags, and the only apparent violations are the
three the exception covers.

## The deprecation notices

`--micro-batch-size-sample`, `--micro-batch-size-tstep` and `--diffusion-train-iter-order` were
marked "kept only for backward compatibility, planned for removal, prefer --micro-batch-size".
That premise was wrong: they are strictly **more** expressive. `--micro-batch-size` can only cut
the flat pair list, while these two control how many samples and how many timesteps share one
forward — a sample × timestep tile. True on-policy work needs that, so the help now says what
they do instead of announcing their removal.

## How this was checked

- Every prefixed flag re-checked against the written rule; the three flagged are exactly the
  ones the exception names.
- The renamed flag's `dest` checked against its consumer.
- The two e2e recipes now run from Python as of #128, so the renamed flag reaches CI directly;
  the rename is a pure substitution with no other edit in those files.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; a rename plus help text, verified structurally
- [x] `pytest tests/fast` identical to base: `1 failed / 22 passed / 27 errors`
- [x] Launch flags changed and every recipe updated
- [ ] CLI reference — **n/a**, this repo has none yet

Draft: no torch, sglang or ray locally, so nothing was run end to end.
