### PR TITLE
chore(utils)(2/12): remove unused helpers and fix contradicting doc strings

### DIFF
--- a/miles/utils/diffusion_data.py
+++ b/miles/utils/diffusion_data.py
@@ -25,12 +25,12 @@ def read_file(path):
             try:
                 yield json.loads(line)
             except json.JSONDecodeError as e:
-                print(f"JSON decode error at line {line_num}: {e}")
+                logger.warning(f"JSON decode error at line {line_num}: {e}")
                 continue
 
 
 class Dataset:
-    """T2I RL: same loading pattern as :class:`miles.utils.data.Dataset` — ``read_file`` yields row dicts; we build :class:`~miles.utils.types.Sample`."""
+    """Prompt-only dataset for T2I RL: one :class:`~miles.utils.types.Sample` per jsonl row."""
 
     def __init__(
         self,
@@ -46,8 +46,6 @@ class Dataset:
             if not isinstance(prompt, str) or not prompt.strip():
                 continue
             metadata = data.get(metadata_key) or {}
-            if not isinstance(metadata, dict):
-                metadata = {}
             origin_samples.append(Sample(prompt=prompt.strip(), metadata=metadata))
 
         self.origin_samples = origin_samples

--- a/miles/utils/distributed_utils.py
+++ b/miles/utils/distributed_utils.py
@@ -1,18 +1,4 @@
-from datetime import timedelta
-from typing import Any
-
-import torch
 import torch.distributed as dist
-from torch.distributed.distributed_c10d import (
-    Backend,
-    PrefixStore,
-    Store,
-    _new_process_group_helper,
-    _world,
-    default_pg_timeout,
-    rendezvous,
-)
-
 
 GLOO_GROUP = None
 
@@ -29,63 +15,5 @@ def get_gloo_group():
     """Get the Gloo group for distributed communication."""
     global GLOO_GROUP
     if GLOO_GROUP is None:
-        raise RuntimeError("Gloo group has not been initialized. Call _init_gloo_group() first.")
+        raise RuntimeError("Gloo group has not been initialized. Call init_gloo_group() first.")
     return GLOO_GROUP
-
-
-# Copy from pytorch to allow creating multiple main groups.
-# https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py
-def init_process_group(
-    backend: str | Backend = None,
-    init_method: str | None = None,
-    timeout: timedelta | None = None,
-    world_size: int = -1,
-    rank: int = -1,
-    store: Store | None = None,
-    group_name: str = None,
-    pg_options: Any | None = None,
-):
-    assert (store is None) or (init_method is None), "Cannot specify both init_method and store."
-
-    if store is not None:
-        assert world_size > 0, "world_size must be positive if using store"
-        assert rank >= 0, "rank must be non-negative if using store"
-    elif init_method is None:
-        init_method = "env://"
-
-    if backend:
-        backend = Backend(backend)
-    else:
-        backend = Backend("undefined")
-
-    if timeout is None:
-        timeout = default_pg_timeout
-
-    # backward compatible API
-    if store is None:
-        rendezvous_iterator = rendezvous(init_method, rank, world_size, timeout=timeout)
-        store, rank, world_size = next(rendezvous_iterator)
-        store.set_timeout(timeout)
-
-        # Use a PrefixStore to avoid accidental overrides of keys used by
-        # different systems (e.g. RPC) in case the store is multi-tenant.
-        store = PrefixStore(group_name, store)
-
-    # NOTE: The pg_options parameter was renamed into backend_options in PyTorch 2.6.0
-    # https://github.com/pytorch/pytorch/commit/a0c7029a75628cd5fa8df83c0de0ea98ee7fd844
-    # We need to determine the appropriate parameter name based on PyTorch version
-    pg_options_param_name = "backend_options" if str(torch.__version__) >= "2.6" else "pg_options"
-    pg, _ = _new_process_group_helper(
-        world_size,
-        rank,
-        [],
-        backend,
-        store,
-        group_name=group_name,
-        **{pg_options_param_name: pg_options},
-        timeout=timeout,
-    )
-
-    _world.pg_group_ranks[pg] = {i: i for i in range(world_size)}
-
-    return pg

--- a/miles/utils/iter_utils.py
+++ b/miles/utils/iter_utils.py
@@ -1,8 +1,4 @@
 from collections import defaultdict
-from collections.abc import Callable, Iterable
-from typing import Any
-
-import torch
 
 
 # details: https://stackoverflow.com/questions/773/how-do-i-use-itertools-groupby
@@ -12,31 +8,3 @@ def group_by(iterable, key=None):
     for item in iterable:
         ret[key(item) if key is not None else item].append(item)
     return dict(ret)
-
-
-# TODO fsdp can also use this
-def chunk_named_params_by_size(named_params: Iterable[tuple[str, torch.Tensor]], chunk_size: int):
-    return _chunk_by_size(
-        named_params,
-        compute_size=lambda named_weight: named_weight[1].nbytes,
-        chunk_size=chunk_size,
-    )
-
-
-def _chunk_by_size(objects: Iterable[Any], compute_size: Callable[[Any], int], chunk_size: int):
-    bucket: list[Any] = []
-    bucket_size = 0
-
-    for obj in objects:
-        obj_size = compute_size(obj)
-
-        if bucket and (bucket_size + obj_size) >= chunk_size:
-            yield bucket
-            bucket = []
-            bucket_size = 0
-
-        bucket.append(obj)
-        bucket_size += obj_size
-
-    if bucket:
-        yield bucket

--- a/miles/utils/metric_utils.py
+++ b/miles/utils/metric_utils.py
@@ -1,56 +1,10 @@
-import math
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
 
 def dict_add_prefix(d: dict[str, Any], prefix: str) -> dict[str, Any]:
     return {f"{prefix}{k}": v for k, v in d.items()}
-
-
-def compute_pass_rate(
-    flat_rewards: list[float],
-    group_size: int,
-    num_groups: int | None = None,
-):
-    if group_size == 1:
-        return {}
-
-    if num_groups is None:
-        num_groups = len(flat_rewards) // group_size
-
-    pass_rate_name_list = [2**i for i in range(int(math.log2(group_size)) + 1)]
-
-    assert len(flat_rewards) == num_groups * group_size, f"{len(flat_rewards)=} {num_groups=} {group_size=}"
-    rewards_of_group = np.array(flat_rewards).reshape(num_groups, group_size)
-
-    log_dict = {}
-    for k in pass_rate_name_list:
-        num_correct = np.sum(rewards_of_group == 1, axis=1)
-        num_samples = np.full(num_groups, group_size)
-
-        pass_k_estimates = _estimate_pass_at_k(num_samples, num_correct, k)
-
-        pass_k = np.mean(pass_k_estimates)
-        log_dict[f"pass@{k}"] = pass_k
-
-    return log_dict
-
-
-def _estimate_pass_at_k(num_samples, num_correct, k):
-    """
-    Estimates pass@k of each problem and returns them in an array.
-    """
-
-    def estimator(n, c, k):
-        """
-        Calculates 1 - comb(n - c, k) / comb(n, k).
-        """
-        if n - c < k:
-            return 1.0
-        return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
-
-    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples, num_correct, strict=False)])
 
 
 def compute_statistics(values: list[float]) -> dict[str, float]:
@@ -61,50 +15,6 @@ def compute_statistics(values: list[float]) -> dict[str, float]:
         "max": np.max(values).item(),
         "min": np.min(values).item(),
     }
-
-
-def compression_ratio(
-    data: str | bytes,
-    *,
-    encoding: str = "utf-8",
-    algorithm: Literal["zlib", "gzip", "bz2", "lzma"] = "zlib",
-    level: int = 9,
-) -> tuple[float, float]:
-    if isinstance(data, str):
-        raw = data.encode(encoding)
-    else:
-        raw = data
-
-    original = len(raw)
-    if original == 0:
-        return float("inf"), 0.0
-
-    if algorithm == "zlib":
-        import zlib
-
-        compressed = zlib.compress(raw, level)
-    elif algorithm == "gzip":
-        import gzip
-
-        compressed = gzip.compress(raw, compresslevel=level)
-    elif algorithm == "bz2":
-        import bz2
-
-        compressed = bz2.compress(raw, compresslevel=level)
-    elif algorithm == "lzma":
-        import lzma
-
-        compressed = lzma.compress(raw, preset=level)
-    else:
-        raise ValueError(f"Unsupported algorithm: {algorithm}")
-
-    comp_len = len(compressed)
-    if comp_len == 0:
-        return float("inf"), 100.0
-
-    ratio = original / comp_len
-    savings_pct = 100.0 * (1.0 - comp_len / original)
-    return ratio, savings_pct
 
 
 def compute_rollout_step(args, rollout_id):

--- a/miles/utils/misc.py
+++ b/miles/utils/misc.py
@@ -119,6 +119,7 @@ def should_run_periodic_action(
         rollout_id: The current rollout index (0-based).
         interval: Desired cadence; disables checks when None.
         num_rollout_per_epoch: Optional epoch boundary to treat as a trigger.
+        num_rollout: Total rollouts; the final one always triggers.
     """
     if interval is None:
         return False

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -82,7 +82,6 @@ class Sample:
     # Scalar from single RM (e.g. pickscore) or dict when combining multiple RMs
     # (--reward-key selects the scalar used for GRPO / logging).
     reward: float | dict[str, Any] | None = None
-    weight_versions: list[str] = field(default_factory=list)
 
     class Status(Enum):
         PENDING = "pending"


### PR DESCRIPTION
2/12 of the `miles/` cleanup stack. Deletions plus comment fixes; no behaviour change.

## What

Cross-checked against miles core (`radixark/miles` @ `d2e3ad9`), since "no caller
here" and "dead code" are different claims:

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `metric_utils.compute_pass_rate` / `_estimate_pass_at_k` | live — pass@k over text generations | only consumer was `training_utils/log_utils.py`, removed in #116 |
| `metric_utils.compression_ratio` | live — feeds `has_repetition` (compresses the last 10k chars to flag degenerate output) | image rollout has no text; `has_repetition` went away in 97f296a |
| `distributed_utils.init_process_group` | live — 2 callers | no distributed weight-update path in this repo |
| `Sample.weight_versions` | live — assigned by core's weight-version logging | never assigned here |
| `iter_utils.chunk_named_params_by_size` / `_chunk_by_size` | dead in core too | FSDP weight sync has its own bucketing loop |

Doc strings that describe something the code does not do:

| Where | Says | Actually |
| --- | --- | --- |
| `diffusion_data.Dataset` | "same loading pattern as `miles.utils.data.Dataset`" | that module was never ported here — dead link |
| `get_gloo_group` error | "Call `_init_gloo_group()` first" | the function is `init_gloo_group` |
| `should_run_periodic_action` | documents 3 of 4 params | omits `num_rollout`, which forces a trigger on the last rollout |

Plus one `print()` on a JSON-decode failure routed to the logger, and an
`isinstance(dict)` check one line after `or {}` already guaranteed a dict.

## Two that need a word

**`init_process_group` is not a redundant copy of torch's.** It is torch's body with
the make-this-the-process-default part removed (`_update_default_pg`,
`GroupMember.WORLD`), which is what lets a process that already has a default group
open a second world-level group with its own rendezvous — neither
`init_process_group` (one per process) nor `new_group` (subgroups of the existing
WORLD) can. Core needs it to NCCL-broadcast weights to separately-launched rollout
engines. This repo only ships the CUDA-IPC path and has no
`init_weights_update_group` anywhere, so it has no caller — and dropping it removes
a vendored torch internal that already needed a shim for the 2.6
`pg_options` → `backend_options` rename.

**`weight_versions` is not worth a placeholder.** Its two core metrics
(`mixed_version_ratio`, stats over `oldest_weight_version`) need a sample that can
span a weight update. This loop is synchronous, `--update-weights-interval` is gone,
generation is single-shot, and oversampling/abort are still TODO — so every sample in
a rollout shares one version, pinning the metrics to constants. Per-sample
attribution also needs the engine to return the version it used, which nothing parses
today. It comes back with async rollout, next to the existing `request_id` parsing.

## Not in this PR

`compute_rollout_step`, now `return rollout_id` because 97f296a removed the
`--wandb-always-use-train-step` branch it existed for — inlined in 3/12 with the rest
of the wandb step-metric plumbing.

## Checklist

- [x] `ruff check miles/ tests/ train_diffusion.py` passes
- [ ] `pre-commit run --all-files` — **not run**, no pre-commit env on this machine
- [ ] Tests — **none added**; deletes uncalled code and edits comments only.
      `tests/fast/utils/test_misc.py` already covers `should_run_periodic_action`,
      unchanged here.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at
      collection; needs CI or a GPU devbox
- [x] No launch flags changed, no public flag added, no example added
