### PR TITLE
chore(4/10): drop write-only monitor state and dead rollout-response code

### DIFF
--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -17,8 +17,6 @@ __all__ = [
     "RolloutImageResponseParserActor",
 ]
 
-# Prefer these keys for mapping dict ``rollout_log_probs`` → ``Sample.rollout_log_probs``.
-_ROLLOUT_LOG_PROB_PRIMARY_KEYS = ("log_prob", "log_probs", "total", "per_step")
 _IMAGE_CHANNEL_COUNTS = (1, 3, 4)
 
 
@@ -59,17 +57,6 @@ def _normalize_generated_output(tensor: torch.Tensor | None) -> torch.Tensor | N
         )
 
     return canonical.contiguous()
-
-
-def _deserialize_rollout_log_probs(
-    value: Any,
-    *,
-    deserialize_func: Callable[[Any], torch.Tensor | None],
-) -> torch.Tensor | None:
-    # Eval-mode rollout (rollout=False) sends no log_probs; train-mode always does.
-    if value is None:
-        return None
-    return deserialize_func(value)
 
 
 def _parse_tensor_or_list(
@@ -181,9 +168,8 @@ def apply_rollout_image_response(
         sample.seed = int(body["seed"])
 
     sample.generated_output = _normalize_generated_output(deserialize_func(body.get("generated_output")))
-    sample.rollout_log_probs = _deserialize_rollout_log_probs(
-        body.get("rollout_log_probs"), deserialize_func=deserialize_func
-    )
+    # Eval-mode rollout (rollout=False) sends no log_probs; train-mode always does.
+    sample.rollout_log_probs = deserialize_func(body.get("rollout_log_probs"))
     sample.rollout_debug_tensors = _parse_rollout_debug_tensors(
         body.get("rollout_debug_tensors"),
         deserialize_func=deserialize_func,

--- a/miles/utils/health_monitor.py
+++ b/miles/utils/health_monitor.py
@@ -31,7 +31,6 @@ class RolloutHealthMonitor:
         self._check_timeout = args.rollout_health_check_timeout
         self._check_first_wait = args.rollout_health_check_first_wait
         self._need_first_wait = True  # Need to wait after each resume
-        self._is_checking_enabled = False  # Track if health checking should be active
 
     def start(self) -> bool:
         """Start the health monitor thread. Called once during initialization.
@@ -73,14 +72,13 @@ class RolloutHealthMonitor:
         timeout = self._check_timeout + self._check_interval + 5
         self._thread.join(timeout=timeout)
         if self._thread.is_alive():
-            logging.warning("Rollout health monitor thread did not terminate within %.1fs", timeout)
+            logger.warning("Rollout health monitor thread did not terminate within %.1fs", timeout)
         else:
             logger.info("RolloutHealthMonitor stopped.")
 
         self._thread = None
         self._stop_event = None
         self._pause_event = None
-        self._is_checking_enabled = False
 
     def pause(self) -> None:
         """Pause health checking. Called when engines are offloaded."""
@@ -88,7 +86,6 @@ class RolloutHealthMonitor:
             return
         logger.info("Pausing health monitor...")
         self._pause_event.set()
-        self._is_checking_enabled = False
 
     def resume(self) -> None:
         """Resume health checking. Called when engines are onloaded."""
@@ -97,11 +94,6 @@ class RolloutHealthMonitor:
         logger.info("Resuming health monitor...")
         self._need_first_wait = True  # Need to wait after each resume
         self._pause_event.clear()
-        self._is_checking_enabled = True
-
-    def is_checking_enabled(self) -> bool:
-        """Return whether health checking is currently enabled (not paused)."""
-        return self._is_checking_enabled
 
     def _health_monitor_loop(self) -> None:
         assert self._stop_event is not None


### PR DESCRIPTION
4/12 of the `miles/` cleanup stack. **Stacked on #135** — the diff here is only this
PR's two commits. Deletions only, no behaviour change.

## What

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `health_monitor._is_checking_enabled` and the `is_checking_enabled()` that reads it | **dead there too** — no caller outside `health_monitor.py` on either side | written in four places, read only by that getter. It also mirrors `_pause_event`, the primitive the monitor loop actually waits on, so it can only drift |
| `_ROLLOUT_LOG_PROB_PRIMARY_KEYS` | **not present** — file is diffusion-only | nothing reads it; the assignment is its only occurrence |
| `_deserialize_rollout_log_probs` | **not present** — file is diffusion-only | wraps `_default_deserialize_func`, whose first two lines already do the same `None` check |

One fix: `logging.warning` → `logger.warning` in `health_monitor._kill_engine`. The
module-level call bypasses the module logger and lands on the root handler. Core has the
same typo — worth porting back separately.

## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**; removes a getter with no callers and a pass-through wrapper.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at collection.
- [x] No launch flags changed, no public flag added, no example added
