### PR TITLE
chore(args): remove three arguments nothing reads

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -742,7 +742,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             reset_arg(parser, "--load", type=str, default=None)
             reset_arg(parser, "--save", type=str, default=None)
             reset_arg(parser, "--save-interval", type=int, default=None)
-            reset_arg(parser, "--async-save", action="store_true")
             parser.add_argument(
                 "--ckpt-step",
                 type=int,
@@ -1293,16 +1292,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             parser.add_argument(
                 "--ci-metric-checker-threshold",
                 type=float,
-                default=None,
-            )
-            parser.add_argument(
-                "--ci-save-grad-norm",
-                type=str,
-                default=None,
-            )
-            parser.add_argument(
-                "--ci-load-grad-norm",
-                type=str,
                 default=None,
             )
             return parser


### PR DESCRIPTION
Tail of the argument cleanup. Three flags, 14 deletions, no additions.

## What

| Flag | In miles | Why it is dead here |
|---|---|---|
| `--async-save` | alive (4 sites) | Megatron's asynchronous checkpoint save; the FSDP checkpoint path has no equivalent |
| `--ci-save-grad-norm` | alive (1 site) | drives a grad-norm comparison in miles' CI utilities |
| `--ci-load-grad-norm` | alive (1 site) | same |

## Why they were missed

The sweep behind #112 and #114 keyed on `args.<name>` and `getattr(args, "<name>")`. These
three appear in neither form anywhere in the repo — no code has ever read them, so there was
nothing for a consumer grep to find. Re-deriving every `dest` from the parser and then
checking each one turned them up.

Same pattern as #114: alive upstream, and the flag came over with the fork while the wiring
did not. The diffusion e2e suites compare metric series through the standards registry
(`tests/ci/e2e_metrics_registry.py`) rather than through a grad-norm file, and reference
neither CI flag.

## How this was checked

Every `dest` the parser produces — 198 including the `FSDPArgs` fields — was checked against
`args.<name>` and `getattr` across `miles/`, `tests/`, `scripts/` and `train_diffusion.py`.
Ten others come back with no direct reader but are consumed after transformation inside
`arguments.py` itself (`offload` into `offload_train`/`offload_rollout`, `dump_details` into
the debug save paths, `eval_config` into `eval_datasets`, and so on); those stay.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests — **none added**; the change deletes flags no code path reads
- [x] `pytest tests/fast` identical to base: `1 failed / 23 passed / 27 errors`
- [x] Launch flags changed and the parser still builds; no recipe passed any of the three
- [ ] CLI reference — **n/a**, this repo has none yet

Draft: no torch, sglang or ray locally, so nothing was run end to end.
