### PR TITLE
chore(fsdp)(6/10): drop a duplicate override and a debug print from weight sync

### DIFF
--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -165,13 +165,6 @@ class DiffusionUpdateWeight(abc.ABC):
 
     def _update_component_weights(self, target_module: str, model: torch.nn.Module) -> None:
         state_dict = model.state_dict()
-        if self.weight_version <= 2 and dist.get_rank() == 0:
-            keys = list(state_dict.keys())
-            print(
-                f"[weight_sync v{self.weight_version} {target_module}] total={len(keys)} keys, "
-                f"first5={keys[:5]}, last3={keys[-3:]}",
-                flush=True,
-            )
         bucket = []
         bucket_size = 0
         for name, param in state_dict.items():
@@ -340,11 +333,6 @@ class DiffusionUpdateWeightFromTensorLoRA(DiffusionUpdateWeightFromTensor):
         if isinstance(t, DTensor):
             return t.redistribute(placements=[Replicate()] * t.device_mesh.ndim).to_local()
         return t
-
-    def update_weights(self):
-        self.weight_version += 1
-        for target_module, model in self.models.items():
-            self._update_component_weights(target_module, model)
 
     def _update_component_weights(self, target_module: str, model: torch.nn.Module) -> None:
         verify = os.environ.get("MILES_VERIFY_WEIGHT_SYNC", "").lower() in ("1", "true", "yes")


### PR DESCRIPTION
6/12 of the `miles/` cleanup stack. **Stacked on #139** — the diff here is only this
PR's own commit. One file, deletions only, no behaviour change.

`diffusion_update_weight_utils.py` has no counterpart in miles core, so nothing here is
constrained by keeping the two trees in sync.

## What

| Removed | Why |
| --- | --- |
| `DiffusionUpdateWeightFromTensorLoRA.update_weights` | byte-identical to the base method it overrides, down to the loop body, differing only in the missing `-> None` annotation. The class now inherits the same three lines. `DiffusionUpdateWeightFromTensorLoRAIPC` keeps its own override, which really does differ — it buckets by LoRA layer group |
| the `weight_version <= 2` debug `print` in `_update_component_weights` | dumped the `state_dict` key count plus the first five and last three keys through `print(..., flush=True)` on the first two syncs. The equivalent gate in the LoRA IPC path logs through `logger.info`, so this was an oversight, not a convention |

## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**. The removed override and the base method are the same three
      statements, so `DiffusionUpdateWeightFromTensorLoRA.update_weights` resolves to
      identical behaviour; nothing consumed the print.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at
      collection; needs CI or a GPU devbox
- [x] No launch flags changed, no public flag added, no example added
