### PR TITLE
refactor(args): group recipe flags by concern, not by name prefix

### DIFF
--- a/scripts/run_diffusion_grpo_ltx23_sglang.py
+++ b/scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -42,7 +42,9 @@ def prepare(args: ScriptArgs) -> str:
 def execute(args: ScriptArgs, data_dir: str) -> None:
     run_name = f"diffusion_grpo_ltx23_pickscore_{U.create_run_id()}"
 
-    ckpt_args = f"--hf-checkpoint gpt2 --save {args.output_dir}/{run_name}/ckpt --save-interval 50 "
+    ckpt_args = (
+        f"--hf-checkpoint gpt2 --diffusion-model {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 50 "
+    )
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
@@ -53,14 +55,8 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
         "--rollout-microgroup-size 1 "
-        "--micro-batch-size-sample 1 "
-        "--micro-batch-size-tstep 1 "
         "--train-dp-split-mode stride "
         "--diffusion-train-iter-order sample_major "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--rollout-patch-group ltx "
         "--diffusion-num-steps 24 "
         "--diffusion-output-num-frames 57 "
@@ -91,7 +87,6 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--pickscore-num-gpus-per-worker 1.0 "
         "--pickscore-num-workers 1 "
         "--pickscore-batch-size 8 "
-        "--rollout-parser-num-workers 8 "
     )
 
     wandb_args = U.get_default_wandb_args(
@@ -114,7 +109,12 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--fsdp-attention-backend sdpa_math "
     )
 
-    perf_args = "--gradient-checkpointing --deterministic-mode "
+    perf_args = (
+        "--gradient-checkpointing "
+        "--micro-batch-size-sample 1 "
+        "--micro-batch-size-tstep 1 "
+        "--rollout-parser-num-workers 8 "
+    )
 
     misc_args = (
         "--actor-num-nodes 1 "
@@ -123,13 +123,14 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--rollout-num-gpus-per-engine 1 "
         "--num-gpus-per-node 4 "
         "--colocate "
+        "--deterministic-mode "
         "--rollout-health-check-interval 120 "
         "--miles-router-health-check-failure-threshold 30 "
     )
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {rollout_args} {diffusion_args} {grpo_args} {optimizer_args} {lora_args} "
+            f"{ckpt_args} {rollout_args} {grpo_args} {optimizer_args} {lora_args} "
             f"{reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} {misc_args} "
             f"{args.extra_args}"
         ),

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -43,7 +43,10 @@ def prepare(args: ScriptArgs) -> str:
 def execute(args: ScriptArgs, data_dir: str) -> None:
     run_name = f"diffusion_grpo_pickscore_5gpu_flowgrpo_aligned_{U.create_run_id()}"
 
-    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+    ckpt_args = (
+        f"--hf-checkpoint {MODEL} --diffusion-model {MODEL} "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+    )
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
@@ -54,14 +57,8 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
         "--rollout-microgroup-size 8 "
-        "--micro-batch-size-sample 8 "
-        "--micro-batch-size-tstep 1 "
         "--train-dp-split-mode stride "
         "--diffusion-train-iter-order sample_major "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--diffusion-num-steps 10 "
         "--diffusion-guidance-scale 4.0 "
         "--diffusion-true-cfg-scale 4.0 "
@@ -111,7 +108,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--train-backend fsdp --fsdp-master-dtype fp32 --fsdp-reduce-dtype fp32 --diffusion-forward-dtype bf16 "
     )
 
-    perf_args = "--gradient-checkpointing --deterministic-mode "
+    perf_args = "--gradient-checkpointing --micro-batch-size-sample 8 --micro-batch-size-tstep 1 "
 
     misc_args = (
         "--actor-num-gpus-per-node 4 "
@@ -119,11 +116,12 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--rollout-num-gpus-per-engine 1 "
         "--num-gpus-per-node 5 "
         "--colocate "
+        "--deterministic-mode "
     )
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{ckpt_args} {rollout_args} {eval_args} {grpo_args} {optimizer_args} "
             f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} "
             f"{misc_args} {args.extra_args}"
         ),

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -44,7 +44,7 @@ def prepare(args: ScriptArgs) -> str:
 def execute(args: ScriptArgs, data_dir: str) -> None:
     run_name = f"diffusion_grpo_sd3_ocr_sglang_{U.create_run_id()}"
 
-    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt "
+    ckpt_args = f"--hf-checkpoint {MODEL} --diffusion-model {MODEL} --save {args.output_dir}/{run_name}/ckpt "
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
@@ -55,13 +55,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         f"--num-rollout {args.num_rollout} "
         "--global-batch-size 64 "
         "--rollout-microgroup-size 8 "
-        "--micro-batch-size-sample 16 "
-        "--micro-batch-size-tstep 5 "
         "--train-dp-split-mode stride "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--diffusion-num-steps 10 "
         "--diffusion-guidance-scale 4.5 "
         "--diffusion-noise-level 0.7 "
@@ -98,7 +92,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     train_backend_args = "--train-backend fsdp --diffusion-forward-dtype fp16 "
 
-    perf_args = "--gradient-checkpointing --deterministic-mode "
+    perf_args = "--gradient-checkpointing --micro-batch-size-sample 16 --micro-batch-size-tstep 5 "
 
     misc_args = (
         "--actor-num-gpus-per-node 2 "
@@ -106,15 +100,14 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--rollout-num-gpus-per-engine 1 "
         "--num-gpus-per-node 2 "
         "--colocate "
-    )
-
-    debug_args = "--diffusion-debug-mode --debug-skip-optimizer-step " if args.debug_alignment else ""
+        "--deterministic-mode "
+    ) + ("--diffusion-debug-mode --debug-skip-optimizer-step " if args.debug_alignment else "")
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{ckpt_args} {rollout_args} {eval_args} {grpo_args} {optimizer_args} "
             f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} "
-            f"{misc_args} {debug_args} {args.extra_args}"
+            f"{misc_args} {args.extra_args}"
         ),
         num_gpus_per_node=2,
         config=args,

--- a/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -56,7 +56,10 @@ def prepare(args: ScriptArgs) -> str:
 def execute(args: ScriptArgs, data_dir: str) -> None:
     run_name = f"diffusion_grpo_wan22_pickscore_5gpu_{U.create_run_id()}"
 
-    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+    ckpt_args = (
+        f"--hf-checkpoint {MODEL} --diffusion-model {MODEL} "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 10 "
+    )
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
@@ -67,11 +70,6 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         f"--num-rollout {args.num_rollout} "
         "--num-steps-per-rollout 2 "
         "--rollout-microgroup-size 8 "
-        "--micro-batch-size 2 "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--diffusion-num-steps 10 "
         "--diffusion-output-num-frames 5 "
         "--diffusion-guidance-scale 4.0 "
@@ -118,16 +116,14 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
     )
 
-    sglang_args = (
-        "--use-miles-router "
-        "--sglang-server-concurrency 8 "
-        "--update-weight-buffer-size 2147483648 "
-        "--update-weight-target-module transformer,transformer_2 "
-    )
+    sglang_args = "--use-miles-router --sglang-server-concurrency 8 --update-weight-buffer-size 2147483648 "
 
     train_backend_args = (
         "--train-backend fsdp --fsdp-master-dtype fp32 --fsdp-reduce-dtype fp32 --diffusion-forward-dtype bf16 "
+        "--update-weight-target-module transformer,transformer_2 "
     )
+
+    perf_args = "--micro-batch-size 2 "
 
     misc_args = (
         "--actor-num-gpus-per-node 4 "
@@ -135,15 +131,14 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--rollout-num-gpus-per-engine 1 "
         "--num-gpus-per-node 5 "
         "--colocate "
+        "--diffusion-debug-mode "
     )
-
-    debug_args = "--diffusion-debug-mode "
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} {optimizer_args} "
-            f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {misc_args} "
-            f"{debug_args} {args.extra_args}"
+            f"{ckpt_args} {rollout_args} {eval_args} {grpo_args} {optimizer_args} "
+            f"{lora_args} {reward_args} {wandb_args} {sglang_args} {train_backend_args} {perf_args} "
+            f"{misc_args} {args.extra_args}"
         ),
         num_gpus_per_node=5,
         config=args,

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -49,7 +49,10 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
     run_name = f"diffusion_nft_sd3_pickscore_{U.create_run_id()}"
     num_rollout = args.num_rollout or (1 if args.smoke else 100)
 
-    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    ckpt_args = (
+        f"--hf-checkpoint {MODEL} --diffusion-model {MODEL} "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    )
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
@@ -57,27 +60,23 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--input-key input "
         f"--num-rollout {num_rollout} "
         "--num-steps-per-rollout 1 "
-    ) + (
-        "--rollout-batch-size 2 --n-samples-per-prompt 2 --micro-batch-size 2 --rollout-microgroup-size 2 "
-        if args.smoke
-        else "--rollout-batch-size 8 --n-samples-per-prompt 8 --micro-batch-size 4 --rollout-microgroup-size 8 "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--diffusion-num-steps 10 "
         "--diffusion-guidance-scale 1.0 "
         "--diffusion-noise-level 0.0 "
         "--diffusion-sde-type ode "
         "--diffusion-height 512 "
         "--diffusion-width 512 "
+    ) + (
+        "--rollout-batch-size 2 --n-samples-per-prompt 2 --rollout-microgroup-size 2 "
+        if args.smoke
+        else "--rollout-batch-size 8 --n-samples-per-prompt 8 --rollout-microgroup-size 8 "
     )
 
     eval_args = "--diffusion-eval-num-steps 50 --skip-eval-before-train " + (
         "" if args.smoke else f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl --eval-interval 30 "
     )
 
-    nft_args = (
+    grpo_args = (
         "--loss-type nft "
         "--diffusion-nft-beta 1.0 "
         "--diffusion-nft-timestep-fraction 0.99 "
@@ -126,7 +125,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     train_backend_args = "--train-backend fsdp --diffusion-forward-dtype fp16 "
 
-    perf_args = "--gradient-checkpointing "
+    perf_args = "--gradient-checkpointing " + ("--micro-batch-size 2 " if args.smoke else "--micro-batch-size 4 ")
 
     misc_args = (
         "--actor-num-gpus-per-node 2 "
@@ -138,7 +137,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {nft_args} {ema_args} "
+            f"{ckpt_args} {rollout_args} {eval_args} {grpo_args} {ema_args} "
             f"{optimizer_args} {lora_args} {reward_args} {wandb_args} {sglang_args} "
             f"{train_backend_args} {perf_args} {misc_args} {args.extra_args}"
         ),

--- a/scripts/run_diffusion_sft_wan22.py
+++ b/scripts/run_diffusion_sft_wan22.py
@@ -44,38 +44,35 @@ def execute(args: ScriptArgs) -> None:
         raise SystemExit("set --data-jsonl (or MILES_SCRIPT_DATA_JSONL) to a jsonl with prompt + metadata.video")
     run_name = f"diffusion_sft_wan22_{U.create_run_id()}"
 
-    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    ckpt_args = (
+        f"--hf-checkpoint {MODEL} --diffusion-model {MODEL} --sft-encoder-checkpoint {MODEL} "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    )
     if args.resume_ckpt:
         ckpt_args += f"--load {args.resume_ckpt} "
         if args.start_rollout >= 0:
             ckpt_args += f"--start-rollout-id {args.start_rollout} "
 
-    sft_args = (
-        "--loss-type sft_loss "
-        "--train-only "
-        "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
-        "--custom-convert-samples-to-train-data-path miles.rollout.sft_rollout.convert_samples_to_train_data "
-        "--custom-rollout-log-function-path miles.rollout.sft_rollout.log_rollout_data "
-        "--custom-prepare-train-batch-path miles.backends.fsdp_utils.loss_hub.sft.prepare_sft_batch "
-        "--custom-loss-function-path miles.backends.fsdp_utils.loss_hub.sft.sft_loss_formula "
-        f"--sft-encoder-checkpoint {MODEL} "
-        "--sft-frame-stride 2 "
-    )
-
     rollout_args = (
+        "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
         f"--prompt-data {args.data_jsonl} "
         "--input-key prompt "
         "--rollout-batch-size 64 "
         "--num-epoch 3 "
         "--num-steps-per-rollout 4 "
-        "--micro-batch-size 1 "
-    )
-
-    diffusion_args = (
-        f"--diffusion-model {MODEL} "
         "--diffusion-height 480 "
         "--diffusion-width 832 "
         "--diffusion-output-num-frames 81 "
+    )
+
+    sft_args = (
+        "--loss-type sft_loss "
+        "--train-only "
+        "--custom-convert-samples-to-train-data-path miles.rollout.sft_rollout.convert_samples_to_train_data "
+        "--custom-rollout-log-function-path miles.rollout.sft_rollout.log_rollout_data "
+        "--custom-prepare-train-batch-path miles.backends.fsdp_utils.loss_hub.sft.prepare_sft_batch "
+        "--custom-loss-function-path miles.backends.fsdp_utils.loss_hub.sft.sft_loss_formula "
+        "--sft-frame-stride 2 "
     )
 
     optimizer_args = "--lr 1e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
@@ -99,12 +96,14 @@ def execute(args: ScriptArgs) -> None:
         "--update-weight-target-module transformer,transformer_2 "
     )
 
+    perf_args = "--micro-batch-size 1 "
+
     misc_args = "--actor-num-gpus-per-node 4 --num-gpus-per-node 4 "
 
     U.execute_train(
         train_args=(
-            f"{ckpt_args} {sft_args} {rollout_args} {diffusion_args} {optimizer_args} {lora_args} "
-            f"{wandb_args} {train_backend_args} {misc_args} {args.extra_args}"
+            f"{ckpt_args} {rollout_args} {sft_args} {optimizer_args} {lora_args} "
+            f"{wandb_args} {train_backend_args} {perf_args} {misc_args} {args.extra_args}"
         ),
         num_gpus_per_node=4,
         config=args,


### PR DESCRIPTION
## What

Regroup the flags in all six `scripts/run_diffusion_*.py` recipes so each block holds one
concern, using miles' own group vocabulary. Pure rearrangement — the generated command line
is unchanged.

All six now share one group sequence:

```
ckpt → rollout → eval → grpo → [ema] → optimizer → lora → reward
     → wandb → sglang → train_backend → perf → misc
```

(`run_diffusion_sft_wan22.py` is `ckpt → rollout → sft → optimizer → lora → wandb →
train_backend → perf → misc`: it has no eval and no engines, and `sft_args` takes the
algorithm group's slot.)

## Why

The recipes grouped flags by what their **names** started with, not by what they configure.
Every `--diffusion-*` flag landed in a `diffusion_args` block whether it set the sampler,
the loss, or a dtype. That split single concerns across blocks — the SDE step schedule sat
in `diffusion_args` while the batch shape feeding it sat in `rollout_args` — and it is not
how miles' launch scripts group. Each move below follows where miles itself puts the
analogous flag.

| Move | miles precedent |
| --- | --- |
| `diffusion_args` deleted; sampler knobs (`--diffusion-num-steps/-guidance-scale{,-2}/-true-cfg-scale/-noise-level/-sde-type/-num-sde-steps/-sde-window-range/-sde-candidate-steps/-step-strategy-path/-height/-width/-output-num-frames/-fps/-flow-shift`, `--rollout-patch-group`) → `rollout_args` | `rollout_args` is where miles keeps `--rollout-temperature` and `--rollout-max-response-len` |
| `--micro-batch-size{,-sample,-tstep}` → `perf_args`, `--global-batch-size` stays in `rollout_args` | four miles scripts put `--micro-batch-size` in `perf_args`; memory knob and data knob are different concerns |
| `nft_args` folded into `grpo_args` | `grpo_args` is miles' loss/algorithm group (`--advantage-estimator`, `--eps-clip`, `--kl-loss-*`) |
| `debug_args` folded into `misc_args`; `--deterministic-mode` moved there too | `run_deepseek_v4.py` puts `--deterministic-mode` in `misc_args`, next to `--colocate` / `--dump-details` |
| `--train-dp-split-mode`, `--diffusion-train-iter-order` → `rollout_args` | `--balance-data`, the closest analogue (how train pairs reach DP ranks), is in `rollout_args` in all 20 miles scripts that set it |
| `--update-weight-target-module` → `train_backend_args` in both recipes that set it | its consumer is `miles/backends/fsdp_utils/actor.py`, which uses it to pick the modules to **train** — which is why the engine-less SFT recipe needs it at all |
| `--diffusion-model` → `ckpt_args` | it names the model to load, like `--hf-checkpoint` / `--ref-load` / `--model-name` |
| `--rollout-parser-num-workers` → `perf_args` | its help is about keeping engines fed; miles' `perf_args` is throughput/memory |

`reward_args` and `ema_args` survive. miles has no reward-service group to borrow a name
from, so `reward_args` is modelled on `sglang_args`; and both blocks are toggled as a unit,
which miles does itself with `mtp_args`, `true_on_policy_args`, `r3_args` and `seq_args`.

`--loss-type` is the one flag that lands in different groups across recipes: it goes to each
recipe's algorithm group, so `grpo_args` for the RL recipes and `sft_args` for SFT. Calling
an SFT run's loss selector a "grpo" arg would be worse than the inconsistency.

## Validation

The rearrangement must not change what gets launched, so it was checked rather than
eyeballed. A harness installs a fake `command_utils` (real `get_default_wandb_args` output,
`create_run_id` pinned, `execute_train` capturing instead of launching), execs each recipe,
and records the `train_args` token multiset plus `num_gpus_per_node` and the `extra_env_vars`
passed to `execute_train`.

Seven variants were captured, covering every conditional branch in the six files:

| variant | tokens |
| --- | --- |
| `grpo_ltx23_sglang` | 140 |
| `grpo_pickscore_5gpu_flowgrpo_aligned` | 129 |
| `grpo_sd3_ocr_sglang` (`--debug-alignment`) | 106 |
| `grpo_wan22_pickscore_5gpu` | 134 |
| `nft_sd3_pickscore` | 130 |
| `nft_sd3_pickscore` (`--smoke`) | 115 |
| `sft_wan22` (`--resume-ckpt` + `--start-rollout`) | 95 |

All 7 compare identical before and after. The comparison asserts `n == 7` so a harness that
silently captures nothing fails instead of reporting green.

## Files

| File | Change |
| --- | --- |
| `scripts/run_diffusion_grpo_ltx23_sglang.py` | dissolve `diffusion_args`; mbs + parser workers → `perf_args`; `--deterministic-mode` → `misc_args` |
| `scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` | same |
| `scripts/run_diffusion_grpo_sd3_ocr_sglang.py` | same, plus `debug_args` → `misc_args` |
| `scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py` | same, plus `--update-weight-target-module` sglang → `train_backend` |
| `scripts/run_diffusion_nft_sd3_pickscore.py` | same, plus `nft_args` → `grpo_args`; per-branch `--micro-batch-size` → `perf_args` |
| `scripts/run_diffusion_sft_wan22.py` | same, plus `--rollout-function-path` → `rollout_args`, `--sft-encoder-checkpoint` → `ckpt_args` |

## Checklist

- [x] `pre-commit run --all-files` passes (ran `--files scripts/run_diffusion_*.py`; black reformatted two blocks, committed)
- [ ] Added/updated tests for new behaviour — **no tests added**: the equivalence harness stubs `command_utils`, which is launch-only glue with no test fixture in the repo; the invariant it checks (command line unchanged) is a property of this diff, not of shipped behaviour
- [ ] `pytest -x` is green — **not run**: no GPU/ray/httpx in this environment
- [x] If launch flags changed, `python3 train.py --help` still parses — no flag added, removed or renamed; only their grouping in the recipes moved
- [x] If a public flag was added, it appears in the CLI reference docs — n/a, no new flag
- [x] If an example was added, it has a real walkthrough — n/a

`tests/e2e/short/test_sd3_ocr_grpo_2xGPU.py` drives `run_diffusion_grpo_sd3_ocr_sglang.py`
through `ScriptArgs` field names, none of which changed, so the e2e interface is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
