### PR TITLE
chore(ray)(7/10): drop helpers with no callers and an env block whose effect is discarded

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -256,9 +256,6 @@ class FSDPTrainRayActor(TrainRayActor):
             )
             yield
 
-    def _get_parallel_config(self) -> dict:
-        return {"dp_size": getattr(self.parallel_state, "dp_size", 1)}
-
     @timer
     def sleep(self) -> None:
         if not self.args.offload_train:

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -56,7 +56,7 @@ class RayTrainGroup:
             **self.args.train_env_vars,
         }
 
-        if getattr(self.args, "deterministic_mode", False):
+        if self.args.deterministic_mode:
             # Must be in the process env at spawn: NCCL reads it at
             # init_process_group and cuBLAS at first matmul, both before the actor
             # runs. torch-runtime knobs are set in the actor instead.
@@ -66,19 +66,6 @@ class RayTrainGroup:
             env_vars.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
         # Let Ray set CUDA_VISIBLE_DEVICES per actor to avoid all ranks
         # sharing GPU0. (Old --diffusion-train branch removed.)
-
-        if self.args.offload_train and self.args.train_backend == "megatron":
-            import torch_memory_saver
-
-            dynlib_path = os.path.join(
-                os.path.dirname(os.path.dirname(torch_memory_saver.__file__)),
-                "torch_memory_saver_hook_mode_preload.abi3.so",
-            )
-            assert os.path.exists(dynlib_path), f"LD_PRELOAD so file {dynlib_path} does not exist."
-
-            env_vars["LD_PRELOAD"] = dynlib_path
-            env_vars["TMS_INIT_ENABLE"] = "1"
-            env_vars["TMS_INIT_ENABLE_CPU_BACKUP"] = "1"
 
         backend = self.args.train_backend
         if backend == "fsdp":

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -133,10 +133,6 @@ class TrainRayActor(RayActor):
     def update_weights(self):
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def _get_parallel_config(self):
-        raise NotImplementedError
-
     def set_rollout_manager(self, rollout_manager):
         self.rollout_manager = rollout_manager
         if self.args.rank == 0:

--- a/miles/ray/utils.py
+++ b/miles/ray/utils.py
@@ -1,6 +1,4 @@
 # Adapted from https://github.com/OpenRLHF/OpenRLHF/blob/10c733694ed9fbb78a0a2ff6a05efc7401584d46/openrlhf/trainer/ray/utils.py#L1
-import os
-
 import ray
 import torch
 from miles.ray.ray_actor import RayActor
@@ -23,10 +21,6 @@ NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
     "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
     "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
 ]
-
-
-def ray_noset_visible_devices(env_vars=os.environ):
-    return any(env_vars.get(env_var) for env_var in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST)
 
 
 def get_physical_gpu_id():


### PR DESCRIPTION
7/12 of the `miles/` cleanup stack. **Stacked on #140** — the diff here is only this
PR's own commit. Deletions only, no behaviour change.

## What

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `ray_noset_visible_devices` | **dead there too** — no caller | no caller. The `NOSET_VISIBLE_DEVICES_ENV_VARS_LIST` it reads stays; `ray/rollout.py` uses it |
| `_get_parallel_config`, both the abstract declaration in `TrainRayActor` and the override in `FSDPTrainRayActor` | **dead there too** — declared, never called | nothing calls either half. `RayActor` is a plain class, so `abstractmethod` was not enforcing anything |
| the megatron `torch_memory_saver` block in `_allocate_gpus_for_actor` | **live** — core runs the megatron backend | it fills `env_vars`, which is read 13 lines below the dispatch that raises for any backend but `"fsdp"`, so its effect is never observable |
| `getattr(self.args, "deterministic_mode", False)` | **core reads it directly** | `FSDPArgs` always defines it |


## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**; each removal is callerless, or unobservable because the
      dispatch raises before `env_vars` is read.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at collection.
- [x] No launch flags changed, no public flag added, no example added
