### PR TITLE
chore(http)(8/10): drop three helpers with no caller in this repo

### DIFF
--- a/miles/utils/http_utils.py
+++ b/miles/utils/http_utils.py
@@ -2,7 +2,6 @@ import asyncio
 import ipaddress
 import json
 import logging
-import multiprocessing
 import os
 import random
 import socket
@@ -113,36 +112,6 @@ def _wrap_ipv6(host):
         return f"[{host.strip('[]')}]"
     except ipaddress.AddressValueError:
         return host
-
-
-def run_router(args):
-    try:
-        from sglang_router.launch_router import launch_router
-
-        router = launch_router(args)
-        if router is None:
-            return 1
-        return 0
-    except Exception as e:
-        logger.info(e)
-        return 1
-
-
-def terminate_process(process: multiprocessing.Process, timeout: float = 1.0) -> None:
-    """Terminate a process gracefully, with forced kill as fallback.
-
-    Args:
-        process: The process to terminate
-        timeout: Seconds to wait for graceful termination before forcing kill
-    """
-    if not process.is_alive():
-        return
-
-    process.terminate()
-    process.join(timeout=timeout)
-    if process.is_alive():
-        process.kill()
-        process.join()
 
 
 _http_client: httpx.AsyncClient | None = None
@@ -290,10 +259,3 @@ async def post(url, payload, max_retries=60, raw=False):
             # fall through to local
 
     return await _post(_http_client, url, payload, max_retries, raw)
-
-
-async def get(url):
-    response = await _http_client.get(url)
-    response.raise_for_status()
-    output = _parse_response(response)
-    return output


### PR DESCRIPTION
8/12 of the `miles/` cleanup stack. **Stacked on #144** — the diff here is only this
PR's own commit. One file, deletions only, no behaviour change.

## What

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `run_router` | **live** — `ray/rollout/router_manager.py` picks between it and the miles router per `--use-miles-router` | this repo's `_start_router` raises for anything but the miles router, so nothing imports the sglang-router launcher |
| `terminate_process` | **dead there too** — no caller | no caller |
| `get` | — | the GET counterpart of `post`; only `post` is imported anywhere |

`import multiprocessing` went with them — it existed for `terminate_process`'s type hint.

`_wrap_ipv6` keeps its underscore: core names it the same way and imports it across
modules too, so renaming would only add a diff between the two trees.

## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**; all three removals are callerless.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at collection.
- [x] No launch flags changed, no public flag added, no example added
