### PR TITLE
chore(rollout)(9/10): drop dead accessors, a discarded statement and a nested factory

### DIFF
--- a/miles/rollout/data_source.py
+++ b/miles/rollout/data_source.py
@@ -171,17 +171,6 @@ class RolloutDataSourceWithBuffer(RolloutDataSource):
             group = samples[i]  # type: ignore
             self.buffer.append(group)
 
-    # TODO remove
-    def update_metadata(self, metadata: dict):
-        self.metadata.update(metadata)
-
-    # TODO remove
-    def get_metadata(self):
-        return self.metadata
-
-    def get_buffer_length(self):
-        return len(self.buffer)
-
 
 def pop_first(args, rollout_id, buffer: list[list[Sample]], num_samples: int) -> list[list[Sample]]:
     num_to_pop = min(len(buffer), num_samples)

--- a/miles/rollout/rm_hub/ocr.py
+++ b/miles/rollout/rm_hub/ocr.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import logging
 
@@ -17,15 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 def _init_paddleocr(use_gpu: bool) -> PaddleOCR:
-    def make_ocr() -> PaddleOCR:
-        return PaddleOCR(
-            use_angle_cls=False,
-            lang="en",
-            use_gpu=use_gpu,
-            show_log=False,
-        )
-
-    return make_ocr()
+    return PaddleOCR(
+        use_angle_cls=False,
+        lang="en",
+        use_gpu=use_gpu,
+        show_log=False,
+    )
 
 
 class OcrScorer:
@@ -75,7 +71,7 @@ class OcrScorer:
 
             except Exception as e:
                 # Error handling (e.g., OCR parsing failure)
-                print(f"OCR processing failed: {str(e)}")
+                logger.warning(f"OCR processing failed: {e}")
                 dist = len(prompt)  # Maximum penalty
             reward = 1 - dist / (len(prompt))
             rewards.append(reward)
@@ -147,15 +143,3 @@ async def ocr_rm(args, sample: Sample):
     image = _rgb_hwc_from_generated(sample)
     score = await pool.score(image, sample.prompt)
     return score
-
-
-if __name__ == "__main__":
-    args = argparse.Namespace(ocr_num_workers=4)
-    pil_image = Image.open("imgs/miles_logo.png").convert("RGB")
-    image_tensor = torch.from_numpy(np.array(pil_image)).permute(2, 0, 1).unsqueeze(1).float()
-    sample = Sample(
-        prompt='A logo of Miles saying "Miles"',
-        generated_output=image_tensor,
-    )
-    img = np.array(pil_image)
-    print(OcrScorer()([img], [sample.prompt])[0])

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -254,7 +254,7 @@ async def generate_and_rm_group(
     # N-spaced base so sgl-d's seed→[seed+0..seed+N-1] expansion stays disjoint
     # per (rollout, prompt-group); group_index is monotonic across the run.
     n_per_prompt = args.n_samples_per_prompt
-    group_index = int(getattr(group[0], "group_index", 0) or 0)
+    group_index = int(group[0].group_index or 0)
     seed_base = (args.rollout_seed + group_index * n_per_prompt) % (2**31)
 
     tasks = []
@@ -278,11 +278,6 @@ async def generate_and_rm_group(
             sample.reward = reward
 
     return group
-
-
-async def abort(args: Namespace, rollout_id: int) -> list[list[Sample]]:
-    # SGL-D TODO: support oversampling+filter & abort
-    raise NotImplementedError("SGLang-Diffusion doesn't support abort")
 
 
 async def generate_rollout_async(
@@ -320,7 +315,6 @@ async def generate_rollout_async(
     ), "Now we don't support over sampling, please set --over_sampling_batch_size equal to --rollout_batch_size"
 
     data = []
-    all_data = []
     do_print = True
     pbar = tqdm(total=target_data_size * args.n_samples_per_prompt, desc="Rollout generation")
     while len(data) < target_data_size:
@@ -342,7 +336,6 @@ async def generate_rollout_async(
                 do_print = False
 
             assert len(group) == args.n_samples_per_prompt
-            all_data.append(group)
             dynamic_filter_output = call_dynamic_filter(dynamic_filter, args, group)
             if not dynamic_filter_output.keep:
                 metric_gatherer.on_dynamic_filter_drop(reason=dynamic_filter_output.reason)
@@ -367,7 +360,6 @@ async def generate_rollout_async(
 
     assert len(data) == args.rollout_batch_size, f"Got {len(data)} samples, expected {args.rollout_batch_size}"
     data = sorted(data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
-    sorted(all_data, key=lambda group: group[0][0].index if isinstance(group[0], list) else group[0].index)
 
     # reset the global state to prevent effects on the next rollout or eval.
     state.reset()
@@ -437,7 +429,7 @@ async def eval_rollout_single_dataset(
             sample = copy.deepcopy(prompt_sample)
             sample.index = sample_index
             sample_index += 1
-            sample.metadata = dataset_config.inject_metadata(getattr(sample, "metadata", None))
+            sample.metadata = dataset_config.inject_metadata(sample.metadata)
             # Per-task dict so concurrent ``create_task`` calls never share one mutating mapping.
             # Train sets this inside ``generate_and_rm_group``; eval only needs ``rollout_microgroup_seed`` for images.
             sampling_params = base_sampling_params.copy()

--- a/miles/rollout/step_strategy_hub.py
+++ b/miles/rollout/step_strategy_hub.py
@@ -64,7 +64,7 @@ def epoch_global_random_choice(
 
 
 def _sde_candidate_steps(args: Namespace, num_steps: int) -> list[int]:
-    raw = getattr(args, "diffusion_sde_candidate_steps", None)
+    raw = args.diffusion_sde_candidate_steps
     if raw is None:
         raise ValueError(
             "epoch_global_random_choice requires --diffusion-sde-candidate-steps "


### PR DESCRIPTION
9/11 of the `miles/` cleanup stack. **Stacked on #145** — the diff here is only this
PR's own commit. Deletions only, no behaviour change.

## What

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `data_source.get_buffer_length` | **live** — 4 callers | no caller here |
| `data_source.update_metadata`, `data_source.get_metadata` | **dead there too** — the other `get_metadata` hits are `FlattenedTensorBucket`'s, an unrelated method of the same name | no caller. `self.metadata` itself stays — it goes into the saved `state_dict` |
| `sglang_diffusion_rollout`: `all_data` and the `sorted(all_data, …)` it fed | **not present** — file is diffusion-only | the `sorted` result was discarded and nothing read `all_data` afterwards |
| `sglang_diffusion_rollout.abort` | **not present** — file is diffusion-only | only raised `NotImplementedError`, no caller |
| two `getattr` calls on `Sample` fields, and one on `args.diffusion_sde_candidate_steps` | — | the dataclass and argparse always define them. `group_index` keeps its `or 0`, since that field defaults to `None` |
| `ocr._init_paddleocr`'s nested `make_ocr`, one `print` on an exception path, and the `__main__` demo block | **not present** — file is diffusion-only | the factory was called immediately; the demo opens a hardcoded image path |

The `isinstance(group[0], list)` guards stay: `--custom-generate-function-path` lets a
user-supplied generate return a nested structure, which is what they absorb.

## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**; every removal is callerless or a discarded expression.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at collection.
- [x] No launch flags changed, no public flag added, no example added
