### PR TITLE
chore(args)(10/10): drop the megatron config validator and a duplicate arg pre-parse

### DIFF
--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -44,7 +44,6 @@ class MilesRouter:
         self.worker_failure_counts: dict[str, int] = {}
         # Quarantined workers excluded from routing pool
         self.dead_workers: set[str] = set()
-        self.max_weight_version = None
 
         max_connections = args.miles_router_max_connections
         if max_connections is None:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1307,13 +1307,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
-        def add_sglang_tp_size():
-            temp_parser = argparse.ArgumentParser(add_help=False)
-            temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
-            temp_args, _ = temp_parser.parse_known_args()
-            sglang_tp_size = temp_args.rollout_num_gpus_per_engine
-            return sglang_tp_size
-
         # Add custom arguments in front to prevent overwritten some miles arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
@@ -1343,7 +1336,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             help="Path to the YAML config for custom function arguments.",
         )
 
-        parser.set_defaults(sglang_tensor_parallel_size=add_sglang_tp_size())
         return parser
 
     return add_miles_arguments
@@ -1356,7 +1348,9 @@ def parse_args(add_custom_arguments=None):
     # TODO: Diffusion FSDP
     add_miles_arguments = get_miles_extra_args_provider(add_custom_arguments)
 
-    parse_args_train_backend()
+    if os.environ.get("MILES_BACKEND") is not None:
+        raise Exception("`MILES_BACKEND` is deprecated, please use --train-backend directly.")
+
     from miles.backends.fsdp_utils.arguments import load_fsdp_args
 
     args = load_fsdp_args(extra_args_provider=add_miles_arguments)
@@ -1368,16 +1362,6 @@ def parse_args(add_custom_arguments=None):
     sglang_validate_args(args)
 
     return args
-
-
-def parse_args_train_backend():
-    if os.environ.get("MILES_BACKEND") is not None:
-        raise Exception("`MILES_BACKEND` is deprecated, please use --train-backend directly.")
-
-    parser = argparse.ArgumentParser()
-    get_miles_extra_args_provider()(parser)
-    args_partial, _ = parser.parse_known_args()
-    return args_partial.train_backend
 
 
 def _resolve_eval_datasets(args) -> list[EvalDatasetConfig]:
@@ -1742,33 +1726,3 @@ def miles_validate_args(args):
             if hasattr(args, k):
                 logger.info(f"Warning: Argument {k} is already set to {getattr(args, k)}, will override with {v}.")
             setattr(args, k, v)
-
-
-def hf_validate_args(args, hf_config):
-    def equal(x, y):
-        return x == y
-
-    errors = []
-
-    # multimodal models have different config structure
-    if hasattr(hf_config, "text_config"):
-        hf_config = hf_config.text_config
-
-    for hf_config_name, megatron_config_name, compare_fn in [
-        ("hidden_size", "hidden_size", equal),
-        ("num_attention_heads", "num_attention_heads", equal),
-        ("num_hidden_layers", "num_layers", equal),
-        ("intermediate_size", "ffn_hidden_size", equal),
-        ("tie_word_embeddings", "untie_embeddings_and_output_weights", lambda x, y: not x == y),
-        ("rms_norm_eps", "norm_epsilon", equal),
-        ("rope_theta", "rotary_base", equal),
-    ]:
-        if hasattr(hf_config, hf_config_name):
-            if not compare_fn(getattr(hf_config, hf_config_name), getattr(args, megatron_config_name)):
-                errors.append(
-                    f"{hf_config_name} in hf config {getattr(hf_config, hf_config_name)} is not equal to "
-                    f"{megatron_config_name} {getattr(args, megatron_config_name)}, please check the config."
-                )
-
-    if len(errors) > 0:
-        raise AssertionError("hf_validate_args failed: " + "; ".join(errors))


### PR DESCRIPTION
10/10 of the `miles/` cleanup stack, the last one. **Stacked on #147** — the diff here is
only this PR's own commit. Deletions only, no behaviour change.

## What

| Removed | In miles core | Dead here because |
| --- | --- | --- |
| `hf_validate_args` | **live** — called from core's `parse_args` | no caller, and all seven megatron args it compares against (`num_layers`, `ffn_hidden_size`, `rotary_base`, …) are undefined here, so it would raise `AttributeError` rather than validate |
| `parse_args_train_backend` | **live** — core really dispatches between backends | it re-registered every argument into a throwaway parser just to return a value the caller discarded; its `MILES_BACKEND` check moves inline |
| `router.max_weight_version` | **not present** | assigned in `__init__`, never read |

`router.py`'s broken `__main__`, `verbose`, duplicated `_use_url` branches and
tokenizer-mentioning doc strings are left alone — core's copies are byte-identical, so
fixing them here would only add divergence.

## Checklist

- [x] `pre-commit run --all-files` passes (all 9 hooks: check-yaml, check-case-conflict,
      detect-private-key, check-added-large-files, requirements-txt-fixer, ruff-check,
      autoflake, isort, black)
- [ ] Tests — **none added**; the `MILES_BACKEND` check is preserved verbatim at its only
      reachable call site, the rest is callerless.
- [ ] `pytest -x` — **not run**, no `torch` locally so `tests/fast` fails at collection.
- [x] No launch flags changed, no public flag added, no example added
