### PR TITLE
fix(args): stop a custom TrainPipelineConfig from clearing the model family

### DIFF
--- a/miles/rollout/encoder_hub/__init__.py
+++ b/miles/rollout/encoder_hub/__init__.py
@@ -14,4 +14,7 @@ def get_encoder(family: str | None):
         from miles.rollout.encoder_hub import wan2_2
 
         return wan2_2
-    raise ValueError(f"no encoder_hub entry for model family {family!r}")
+    raise ValueError(
+        f"no encoder_hub entry for model family {family!r}; set --diffusion-model-family to one "
+        "that has an entry, or add a module here for it"
+    )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1472,12 +1472,15 @@ def miles_validate_args(args):
 
     from miles.utils.misc import load_function
 
+    if args.diffusion_model_family is not None:
+        # Downstream lookups compare this exactly (encoder_hub.get_encoder), so normalize once
+        # here rather than at every reader.
+        args.diffusion_model_family = args.diffusion_model_family.strip().lower()
+
     if args.train_pipeline_config_path is not None:
-        if args.diffusion_model_family is not None:
-            raise ValueError("--train-pipeline-config-path and --diffusion-model-family both name a config; pass one.")
-        # Explicit config path IS the identity (custom classes never need registering).
+        # The path names the config class; the family stays whatever was passed, since it is a
+        # separate axis (encoder_hub) and may be unset for a model that customizes that too.
         cfg_cls = load_function(args.train_pipeline_config_path)
-        args.diffusion_model_family = None
     else:
         from miles.backends.fsdp_utils.configs.train_pipeline_config import (
             get_train_pipeline_config_cls,
@@ -1486,10 +1489,6 @@ def miles_validate_args(args):
 
         if args.diffusion_model_family is None:
             args.diffusion_model_family = resolve_diffusion_model_family(args.hf_checkpoint)
-        else:
-            # Downstream lookups compare this exactly (encoder_hub.get_encoder), so normalize
-            # here rather than at every reader.
-            args.diffusion_model_family = args.diffusion_model_family.strip().lower()
         cfg_cls = get_train_pipeline_config_cls(args.diffusion_model_family)
         args.train_pipeline_config_path = f"{cfg_cls.__module__}.{cfg_cls.__qualname__}"
     if args.model_backend_path is None:


### PR DESCRIPTION
## What

Drop two lines from the `--train-pipeline-config-path` branch of `miles_validate_args`:
the `--diffusion-model-family` conflict check, and the `args.diffusion_model_family = None`
that followed it. Normalization moves ahead of the branch so it applies on either path.

## Why

The model family is a separate axis from the config class. It selects the config class when
no path is given, and it independently selects the encoder module —
`encoder_hub.get_encoder(args.diffusion_model_family)`, read by the SFT validation block and
by `SftEncodeActor`.

The branch cleared it to `None` on the grounds that "explicit config path IS the identity".
That is the identity of the config *class*, not of the family, so a custom config could not
run SFT at all: `get_encoder` got `None` and raised. #142 then rejected the two flags
together, walling off the only combination that could have supplied the family.

## No new validation, on purpose

The obvious-looking alternative is to require `--diffusion-model-family` whenever a config
path is given, since the family is the key several per-model pieces are looked up by. That
was rejected: the encoder — and other per-family pieces — may become customizable in their
own right, and a check here would then forbid a legitimate run. The family stays optional;
whoever needs it fails at the lookup that needs it. `get_encoder`'s message now names the
flag to pass, so that failure is actionable instead of just reporting `None`.

For the same reason this does not stamp `cfg_cls.model_family`. `model_backend` guards the
FSDP parallel-plan lookup on that attribute, so an undecorated out-of-tree class does not get
a plan — but that is the class author's call to make (declare `model_family`, or use
`@register_train_pipeline_config`), not something the CLI should decide for them.

## Validation

Captured `train_args` from all six recipes plus the smoke and debug-alignment variants
(7 total): identical to main. None of them passes `--train-pipeline-config-path`, so nothing
in-tree changes behaviour. `pre-commit` and `py_compile` clean.

Not run: `pytest` and `train.py --help` — no torch/sglang/ray in this environment. No test
added: the branch sits in `miles_validate_args`, reachable only through `parse_args`, which
has no fixture in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
