### PR TITLE
fix(args): restore the sglang tensor-parallel default dropped in #148

### DIFF
--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1301,6 +1301,13 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
+        def add_sglang_tp_size():
+            temp_parser = argparse.ArgumentParser(add_help=False)
+            temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
+            temp_args, _ = temp_parser.parse_known_args()
+            sglang_tp_size = temp_args.rollout_num_gpus_per_engine
+            return sglang_tp_size
+
         # Add custom arguments in front to prevent overwritten some miles arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
@@ -1330,6 +1337,7 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             help="Path to the YAML config for custom function arguments.",
         )
 
+        parser.set_defaults(sglang_tensor_parallel_size=add_sglang_tp_size())
         return parser
 
     return add_miles_arguments


### PR DESCRIPTION
These two lines are what default each rollout engine tensor-parallel degree to the engine full GPU count. I removed them in #148 after a literal grep said nothing reads `sglang_tensor_parallel_size`, but `_compute_server_args` forwards every `ServerArgs` field by building the name at runtime, so the grep could not see it.

Affects runs with `--rollout-num-gpus-per-engine > 1`; single-GPU engines are tp=1 either way, which is why the e2e recipes stayed green.
