### PR TITLE
fix(wandb): restore the getattr guard on sglang_enable_metrics

### DIFF
--- a/miles/utils/wandb_utils.py
+++ b/miles/utils/wandb_utils.py
@@ -118,7 +118,7 @@ def init_wandb_secondary(args, router_addr=None):
             x_update_finish_state=False,
         )
 
-    if args.sglang_enable_metrics and router_addr is not None:
+    if getattr(args, "sglang_enable_metrics", False) and router_addr is not None:
         logger.info(f"Forward SGLang metrics at {router_addr} to WandB.")
         settings_kwargs |= dict(
             x_stats_open_metrics_endpoints={


### PR DESCRIPTION
sgl-d `ServerArgs` has no `enable_metrics` field, so the attribute can be absent — the direct read I introduced in #135 raises `AttributeError` on any `--use-wandb` run.
