### PR TITLE
DEBUG DO NOT MERGE: trace GPU pairing across placement group, engine pinning and weight sync

### DIFF
--- a/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
+++ b/miles/backends/fsdp_utils/diffusion_update_weight_utils.py
@@ -273,6 +273,13 @@ class DiffusionUpdateWeightFromTensor(DiffusionUpdateWeight):
         else:
             gathered_batches = None
 
+        # DEBUG(gpu-pairing): the engine side already names its own GPU when the lookup fails;
+        # this is the other half -- which rank contributed which UUID, and where it was sent.
+        logger.warning(
+            f"[gpu-pairing] rank={dist.get_rank()} uuid={get_physical_gpu_id()} "
+            f"gather_src={self._ipc_gather_src} group_size={dist.get_world_size(self._ipc_gather_group)}"
+        )
+
         dist.gather_object(
             obj=(get_physical_gpu_id(), serialized_tensors),
             object_gather_list=gathered_batches,

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -170,22 +170,28 @@ class SGLangDiffusionEngine(RayActor):
                 logger.warning("Skipping router add_worker: only miles_router is supported for now")
 
     def _pin_to_assigned_gpu(self):
-        if self.base_gpu_id is None:
-            return
+        # DEBUG(gpu-pairing): every branch reports, via print. This module's logger emits
+        # nothing in a ray actor -- `Launch HttpServerEngineAdapter` one frame up is absent from
+        # the job log too, while rollout.py's logger.info comes through -- so a logging call here
+        # proves nothing either way about which branch ran. No torch.cuda: touching it would
+        # initialise CUDA before sglang does.
         span = self.args.rollout_num_gpus_per_engine
         cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+        prefix = f"[gpu-pairing] engine rank={self.rank} base_gpu_id={self.base_gpu_id} inherited_cvd={cvd!r}"
+        if self.base_gpu_id is None:
+            print(f"{prefix} -> NO PIN (base_gpu_id is None); engine keeps the ambient device", flush=True)
+            return
         if not cvd:
             # No ambient device list (full-node multi-node ray start): pin to the physical GPUs.
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(self.base_gpu_id + i) for i in range(span))
+            pinned = ",".join(str(self.base_gpu_id + i) for i in range(span))
+            os.environ["CUDA_VISIBLE_DEVICES"] = pinned
+            print(f"{prefix} -> pinned={pinned!r} (empty-cvd path, base_gpu_id as a physical id)", flush=True)
             return
         visible = [x.strip() for x in cvd.split(",") if x.strip()]
         local_idx = _to_local_gpu_id(self.base_gpu_id)
         pinned = ",".join(visible[local_idx : local_idx + span])
         os.environ["CUDA_VISIBLE_DEVICES"] = pinned
-        logger.info(
-            f"Engine rank={self.rank}: pinned CUDA_VISIBLE_DEVICES={pinned} "
-            f"(base_gpu_id={self.base_gpu_id}, local_idx={local_idx})"
-        )
+        print(f"{prefix} -> pinned={pinned!r} (translated path, local_idx={local_idx})", flush=True)
 
     def _make_request(self, endpoint: str, payload: dict | None = None):
         """Make a POST request to the specified endpoint with the given payload.

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import socket
 
 import ray
@@ -73,6 +74,14 @@ def _create_placement_group(num_gpus):
         logger.info(
             f"  bundle {i:4}, actual_bundle_index: {actual_bundle_index:4}, "
             f"node: {gpu_ids[actual_bundle_index][0]}, gpu: {gpu_ids[actual_bundle_index][1]}"
+        )
+        # DEBUG(gpu-pairing): print, not logger -- this runs in the ray job driver, whose
+        # logger is not configured at INFO, so the map above never reaches the CI log.
+        print(
+            f"[gpu-pairing] logical={i} bundle={actual_bundle_index} "
+            f"node={gpu_ids[actual_bundle_index][0]} ray_gpu_id={gpu_ids[actual_bundle_index][1]!r} "
+            f"driver_cvd={os.environ.get('CUDA_VISIBLE_DEVICES')!r}",
+            flush=True,
         )
 
     return pg, pg_reordered_bundle_indices, pg_reordered_gpu_ids


### PR DESCRIPTION
> ## ⛔️ DEBUG ONLY — DO NOT MERGE
>
> Logging-only patch to locate an intermittent weight-sync failure. It changes no behaviour
> and is not meant to land. Delete the branch once the numbers are captured.

## What this is for

`stage-c-5-gpu-h200` failed once with a rollout engine and its paired train rank on different physical GPUs:

```
400 Bad Request .../update_weights_from_tensor
{"success":false,"message":"no payload was exported from this worker's GPU
 ed713ead-dabb-d9a5-5729-48d71fdae4c5, got ['06f16679-a603-0c39-3744-96c85033dfe1']"}
```

Seen once (run 31552549125). The same commit passed on rerun and an unrelated branch passed 14 minutes later, so it is intermittent and tied to no PR.

The pairing is a positional assumption with no check — `diffusion_update_weight_utils.py:222`, *"Here we assume the gpu id of rollout engines and train actors are the same."* The sglang-side UUID lookup is the only thing that noticed it broke.

## Why logging, and why print

Reasoning from the code produced three confident wrong answers:

1. *"Slack on the runner lets the two roles pick different GPUs"* — no: colocate hands both roles the same `(pg, reordered_bundle_indices, reordered_gpu_ids)`, and train rank `r` and engine `r` index the same entry (`actor_group.py:88`, `rollout.py:501`).
2. *"`_to_local_gpu_id` misreads a local index as a physical id"* — a real hazard, but only when `0 < min(visible) < len(visible)`, and whether it triggers depends on which id form Ray hands over, which is environment-dependent (`ray/_private/worker.py:1182-1185`: the ids are a subset of `CUDA_VISIBLE_DEVICES` when it was set at worker start, otherwise `0..N-1`).
3. *"The pin log line is absent from the job log, so the translating branch never ran"* — **wrong, and the reason is the point of this patch.**

A live run settles (3). In the engine actor process:

```
RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
CUDA_VISIBLE_DEVICES=0,1,2          <- non-empty
```

Non-empty `cvd` means the `if not cvd` branch cannot fire, so the translating branch *did* run and `_to_local_gpu_id` *was* called — yet its `logger.info` appears nowhere. The explanation is not control flow: **this module's logger emits nothing from a ray actor.** `Launch HttpServerEngineAdapter`, one frame up in the same file and unconditionally executed, is equally absent, while `rollout.py`'s `logger.info` comes through in the same log.

So a logging call in this file proves nothing either way, which is why every line here is `print(..., flush=True)`. That also means `_to_local_gpu_id` stays a live suspect: the 5gpu runner's `CUDA_VISIBLE_DEVICES=3,4,5,6,7` has `min=3 < len=5` and sits inside the ambiguous band, while the 3gpu runner's `0,1,2` does not — which matches the observation that only the 5gpu suite has ever failed this way.

## The patch

| site | what it now reports |
|---|---|
| `sglang_diffusion_engine.py::_pin_to_assigned_gpu` | every branch: rank, `base_gpu_id`, inherited `CUDA_VISIBLE_DEVICES`, what it pinned, which branch ran |
| `diffusion_update_weight_utils.py` gather | which rank contributed which UUID, and its gather target — the other half of the mismatch |
| `placement_group.py` bundle map | logical index → bundle → node → Ray gpu id, as `print` because the ray job driver's logger is not at INFO either |

No `torch.cuda` call inside the pin path: touching it there would initialise CUDA before sglang does.

## How to use it

Run any e2e on the 5gpu runner from this branch and grep `[gpu-pairing]`. Each engine's chosen device and each rank's UUID land in the same log, so the mismatch can be read off instead of inferred. The failure is intermittent — one in three observed runs — so this may need several attempts.

## Follow-ups this should feed

- **`sglang_diffusion_engine.py` logs nothing.** Every `logger.info` in that module is dead in a ray actor. That is worth fixing on its own; it is what made this failure opaque.
- The pairing assumption at `diffusion_update_weight_utils.py:222` deserves a startup assertion (engine `i`'s UUID == rank `i*k`'s UUID) rather than surfacing as a 400 on the first weight sync, reporting only one side.
- `_to_local_gpu_id` accepts both id forms and silently picks one where they overlap. The form is decidable where `reordered_gpu_ids` is produced, so it could be carried explicitly instead of guessed.
