### PR TITLE
fix(rollout): restore the prefer-TP default for multi-GPU engines

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -276,8 +276,9 @@ jobs:
             python-multipart pyzmq scipy sentencepiece setproctitle soundfile \
             tiktoken timm torchvision==0.26.0 uvicorn uvloop watchfiles xgrammar
           # sglang's memory_pool_host.py unconditionally imports sgl_kernel
-          # on non-NPU/XPU/MPS hardware. sgl_kernel is GPU-only — install a
-          # local stub so imports succeed at module load.
+          # on non-NPU/XPU/MPS hardware. sgl_kernel is GPU-only. multimodal_gen
+          # similarly hard-imports cache_dit at package load. Install local
+          # stubs so both imports succeed at module load.
           uv pip install tests/ci/cpu_stubs
 
       - name: Resolve suite plan

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1307,13 +1307,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             )
             return parser
 
-        def add_sglang_tp_size():
-            temp_parser = argparse.ArgumentParser(add_help=False)
-            temp_parser.add_argument("--rollout-num-gpus-per-engine", type=int, default=1)
-            temp_args, _ = temp_parser.parse_known_args()
-            sglang_tp_size = temp_args.rollout_num_gpus_per_engine
-            return sglang_tp_size
-
         # Add custom arguments in front to prevent overwritten some miles arguments.
         if add_custom_arguments is not None:
             parser = add_custom_arguments(parser)
@@ -1343,7 +1336,6 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             help="Path to the YAML config for custom function arguments.",
         )
 
-        parser.set_defaults(sglang_tensor_parallel_size=add_sglang_tp_size())
         return parser
 
     return add_miles_arguments
@@ -1421,6 +1413,11 @@ def _resolve_eval_datasets(args) -> list[EvalDatasetConfig]:
 
 
 def set_default_diffusion_args(args) -> None:
+    # Prefer TP for multi-GPU engines: SP/CFG-parallel change sampling numerics, so they stay
+    # opt-in. (The old default targeted a renamed dest and had silently stopped applying.)
+    if args.sglang_tp_size is None and args.sglang_sp_degree is None and not args.sglang_enable_cfg_parallel:
+        args.sglang_tp_size = args.rollout_num_gpus_per_engine
+
     is_nft = args.loss_type == "nft"
     if is_nft:
         if args.custom_expand_samples_to_train_pairs_path is None:

--- a/tests/ci/cpu_stubs/cache_dit/__init__.py
+++ b/tests/ci/cpu_stubs/cache_dit/__init__.py
@@ -1,0 +1,16 @@
+"""Stub cache_dit for CPU-only CI.
+
+sglang.multimodal_gen.__init__ eagerly imports DiffGenerator, which loads
+cache_dit_integration and does `import cache_dit` at module load. The real
+cache-dit package is not in the CPU runner's --no-deps install. Any attribute
+access on this stub returns a MagicMock so collection succeeds; tests that
+actually *call* cache-dit will fail loudly, which is correct.
+"""
+
+from unittest.mock import MagicMock
+
+
+def __getattr__(name: str):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return MagicMock(name=f"cache_dit.{name}")

--- a/tests/ci/cpu_stubs/cache_dit/caching/__init__.py
+++ b/tests/ci/cpu_stubs/cache_dit/caching/__init__.py
@@ -1,0 +1,9 @@
+"""Stub cache_dit.caching — see cache_dit/__init__.py for rationale."""
+
+from unittest.mock import MagicMock
+
+
+def __getattr__(name: str):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return MagicMock(name=f"cache_dit.caching.{name}")

--- a/tests/ci/cpu_stubs/cache_dit/caching/block_adapters.py
+++ b/tests/ci/cpu_stubs/cache_dit/caching/block_adapters.py
@@ -1,0 +1,9 @@
+"""Stub cache_dit.caching.block_adapters — see cache_dit/__init__.py for rationale."""
+
+from unittest.mock import MagicMock
+
+
+def __getattr__(name: str):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return MagicMock(name=f"cache_dit.caching.block_adapters.{name}")

--- a/tests/ci/cpu_stubs/cache_dit/caching/cache_contexts.py
+++ b/tests/ci/cpu_stubs/cache_dit/caching/cache_contexts.py
@@ -1,0 +1,9 @@
+"""Stub cache_dit.caching.cache_contexts — see cache_dit/__init__.py for rationale."""
+
+from unittest.mock import MagicMock
+
+
+def __getattr__(name: str):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return MagicMock(name=f"cache_dit.caching.cache_contexts.{name}")

--- a/tests/ci/cpu_stubs/cache_dit/parallelism/__init__.py
+++ b/tests/ci/cpu_stubs/cache_dit/parallelism/__init__.py
@@ -1,0 +1,9 @@
+"""Stub cache_dit.parallelism — see cache_dit/__init__.py for rationale."""
+
+from unittest.mock import MagicMock
+
+
+def __getattr__(name: str):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return MagicMock(name=f"cache_dit.parallelism.{name}")

--- a/tests/ci/cpu_stubs/pyproject.toml
+++ b/tests/ci/cpu_stubs/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sgl-kernel-stub"
 version = "0.0.0"
-description = "Stub sgl_kernel package for CPU-only CI (real sgl_kernel is GPU-only)"
+description = "Stub GPU-only packages (sgl_kernel, cache_dit) for CPU-only CI"
 
 [tool.setuptools.packages.find]
-include = ["sgl_kernel*"]
+include = ["sgl_kernel*", "cache_dit*"]

--- a/tests/fast/utils/test_sglang_parallel_defaults.py
+++ b/tests/fast/utils/test_sglang_parallel_defaults.py
@@ -1,0 +1,63 @@
+"""The engine-parallelism default: multi-GPU engines prefer TP unless SP/CFG is opted into.
+
+    user config                                  effective engine layout
+    (nothing set), 4 GPUs/engine        ->       tp_size=4          (this default)
+    --sglang-sp-degree 4                ->       untouched: SP is an explicit numerics opt-in
+    --sglang-enable-cfg-parallel        ->       untouched: same
+    --sglang-tp-size 2                  ->       untouched: explicit wins
+
+This default once lived on a renamed argparse dest and silently stopped applying, which
+flipped multi-GPU engines to SP+CFG and degraded sampling; these tests pin the semantics.
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+import pytest
+
+from miles.utils.arguments import set_default_diffusion_args
+
+
+def _args(**overrides):
+    base = dict(
+        sglang_tp_size=None,
+        sglang_sp_degree=None,
+        sglang_enable_cfg_parallel=False,
+        rollout_num_gpus_per_engine=4,
+        loss_type="grpo",
+        custom_expand_samples_to_train_pairs_path=None,
+        custom_prepare_train_batch_path=None,
+        custom_loss_function_path=None,
+        ref_mode="none",
+        diffusion_kl_beta=0.0,
+    )
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_multi_gpu_engine_defaults_to_full_tp():
+    args = _args()
+    set_default_diffusion_args(args)
+    assert args.sglang_tp_size == 4
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"sglang_sp_degree": 4},
+        {"sglang_enable_cfg_parallel": True},
+    ],
+)
+def test_explicit_sp_or_cfg_disables_the_tp_default(overrides):
+    args = _args(**overrides)
+    set_default_diffusion_args(args)
+    assert args.sglang_tp_size is None
+
+
+def test_explicit_tp_size_wins():
+    args = _args(sglang_tp_size=2, sglang_sp_degree=2)
+    set_default_diffusion_args(args)
+    assert args.sglang_tp_size == 2


### PR DESCRIPTION
## What

- Restore the prefer-TP default for multi-GPU rollout engines: when none of `--sglang-tp-size` / `--sglang-sp-degree` / `--sglang-enable-cfg-parallel` is set, default `sglang_tp_size = rollout_num_gpus_per_engine` in `set_default_diffusion_args`. Explicit SP/CFG opt-ins keep full control.
- Delete the dead `add_sglang_tp_size` closure and its `parser.set_defaults(sglang_tensor_parallel_size=...)` — the dest it targeted no longer exists.

## Why

The prefer-TP default was silently dead: it was written against the old dest `sglang_tensor_parallel_size`, while the engine forwards `args.sglang_tp_size` (since cdc8b42 switched from hardcoded `tp_size=1` to forwarding). `argparse.set_defaults` on a nonexistent dest does not error, so multi-GPU engines quietly fell through to SGL-D's internal fallback — SP + CFG-parallel — which changes sampling numerics and degraded training badly (the Wan2.2 reward-regression root cause).

The new default lives in the fill-defaults function next to its peers, states the intent (`SP/CFG-parallel change sampling numerics, so they stay opt-in`), and is pinned by tests so a future rename cannot silence it again.

## Files

- `miles/utils/arguments.py` — the fill + dead-code removal
- `tests/fast/utils/test_sglang_parallel_defaults.py` — 4 CPU tests (default applies; SP opt-out; CFG opt-out; explicit TP wins), stage-a-cpu

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green — the 4 new tests pass on a devbox (`4 passed`)
- [x] Remaining items — **no public flags added/changed; no docs/examples touched**
