### PR TITLE
docs: align PR 151 doc pages with the post-refactor CLI

### DIFF
--- a/docs/advanced/single-prompt-multi-gen.md
+++ b/docs/advanced/single-prompt-multi-gen.md
@@ -9,7 +9,7 @@ outputs as a batch. Engine-side expansion is opt-in per model family in sglang-d
 
 ## 1. Microgroups
 
-`--diffusion-microgroup-size M` splits each prompt group of `n_samples_per_prompt` samples into requests of at most M
+`--rollout-microgroup-size M` splits each prompt group of `n_samples_per_prompt` samples into requests of at most M
 (`generate_and_rm_group` in `miles/rollout/sglang_diffusion_rollout.py`). Each request carries
 `num_outputs_per_prompt = M`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Each model name links to its recipe page.
 | Flow-GRPO (`policy_loss`)                | ✅     | ✅          | ✅      | ✅       | ✅       |
 | DiffusionNFT (`nft`)                     | ✅     | 🟡         | 🟡     | 🟡      | 🟡      |
 | SFT (`sft_loss`, `--train-only`)         | 🟡    | 🟡         | ✅      | 🟡      | 🟡      |
-| LoRA + IPC weight sync                   | ✅     | ✅          | ✅      | ✅    | ✅       |
+| LoRA + IPC weight sync                   | ✅     | ✅          | ✅      | 🟡    | ✅       |
 | Single-prompt multi-gen (microgroup > 1) | ✅     | ✅          | ✅      | ❌       | ❌      |
 | USP sequence parallelism                 | ❌     | ❌          | ✅    | ❌       | ❌       |
 | Deterministic mode                       | ✅     | ✅          | ❌      | ✅       | ❌       |
@@ -74,7 +74,7 @@ Each model name links to its recipe page.
 
 1. **[Installation](/getting-started/installation)** — Docker image, pinned dependency versions, bare-metal setup.
 2. **[Quick Start](/getting-started/quick-start)** — a working Flow-GRPO run on SD3.5 with 2 GPUs.
-3. **[Core Concepts](/user-guide/concepts)** — the five objects in every miles-diffusion job and the loop that connects
+3. **[Core Concepts](/user-guide/concepts)** — the four objects in every miles-diffusion job and the loop that connects
    them.
 4. **[Training Script Walkthrough](/user-guide/training-script-walkthrough)** — every argument group in a launch script,
    annotated.

--- a/docs/models/cosmos/cosmos3.md
+++ b/docs/models/cosmos/cosmos3.md
@@ -18,7 +18,7 @@ everything below applies family-wide; the canonical recipes are validated on **C
   parameter-name fragments rather than dropped; LoRA targets are GEN attention only (`add_q_proj`, `add_k_proj`,
   `add_v_proj`, `to_add_out`).
 - **Packed single-sample forward.** The transformer consumes one packed text+vision sequence per forward — one request
-  cannot batch multiple outputs, so recipes run `--diffusion-microgroup-size 1` and CFG batching is disabled by
+  cannot batch multiple outputs, so recipes run `--rollout-microgroup-size 1` and CFG batching is disabled by
   construction.
 - **Karras flow-sigma grid.** Checkpoints ship a non-uniform sigma grid; SDE candidate steps must be derived from it.
 
@@ -55,12 +55,12 @@ From `miles/backends/fsdp_utils/configs/cosmos3.py`:
 
 ## 4. Launch
 
-Canonical recipe: `scripts/run-diffusion-grpo-cosmos3-pickscore-t2i-5gpu.sh` — 4 colocate + 1 reward GPU, T2I (832×480,
+Canonical recipe: `scripts/run_diffusion_grpo_cosmos3_pickscore_t2i_5gpu.py` — 4 colocate + 1 reward GPU, T2I (832×480,
 1 frame), PickScore reward.
 
 ```bash
 export SGLANG_DISABLE_COSMOS3_GUARDRAILS=1   # RL scores raw samples; skip serving-side guardrail models
-bash scripts/run-diffusion-grpo-cosmos3-pickscore-t2i-5gpu.sh
+python3 scripts/run_diffusion_grpo_cosmos3_pickscore_t2i_5gpu.py
 ```
 
 

--- a/docs/models/wan/wan2-2.md
+++ b/docs/models/wan/wan2-2.md
@@ -62,7 +62,7 @@ MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_wan22.
 ## 5. Pairs well with
 
 - [Single-Prompt Multi-Generation](/advanced/single-prompt-multi-gen) — the microgroup mechanics behind
-  `--diffusion-microgroup-size 8`.
+  `--rollout-microgroup-size 8`.
 - [LoRA Training and Weight Sync](/advanced/lora) — IPC merge used by the GRPO recipe.
 - [SDE Step Backend](/advanced/sde-backend) — how the trained SDE step is scored train-side.
 - [Rewards](/user-guide/rewards) — PickScore worker pool configuration.

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -53,8 +53,9 @@ Every flag in miles-diffusion configures one of these four phases.
 In miles-diffusion a sample is a whole denoising **trajectory**, and the fan-out continues below it: a step strategy
 picks the trained timesteps, and micro-batching counts **(x_t → x_{t+1}) pairs**. One equation per level.
 
-**Trajectory level** — the four-knob invariant, enforced in `miles/utils/arguments.py`. Set any three; the fourth is
-derived, and contradictions abort:
+**Trajectory level** — the four-knob invariant, enforced in `miles/utils/arguments.py`. `rollout_batch_size` is
+required and `n_samples_per_prompt` defaults to 1; of the right-hand pair, set one and the other is derived
+(passing both with contradicting values aborts):
 
 ```bash
 rollout_batch_size × n_samples_per_prompt
@@ -75,7 +76,7 @@ Two independent knobs control physical batching, one per side of the loop:
 
 | Knob                          | Side     | Governs                         |
 | ----------------------------- | -------- | ------------------------------- |
-| `--diffusion-microgroup-size` | rollout  | Samples per engine **request**  |
+| `--rollout-microgroup-size` | rollout  | Samples per engine **request**  |
 | `--micro-batch-size`          | training | Train pairs per DiT **forward** |
 
 And one knob controls the trajectory→pair fan-out itself: `--diffusion-step-strategy-path` picks the SDE step subset per


### PR DESCRIPTION
Catch the pages up with the args refactor that merged alongside them:

- --diffusion-microgroup-size was renamed --rollout-microgroup-size (#141 series); update all four references.
- The bash recipes were dropped for Python launchers (#128); point the Cosmos3 launch at the .py form.
- index.md said 'five objects' where concepts.md defines four.
- The four-knob invariant blurb claimed 'set any three, the fourth is derived'; only global_batch_size <-> num_steps_per_rollout derive from each other, rollout_batch_size is required and n_samples_per_prompt defaults to 1.
