### PR TITLE
ci: nightly full run of every suite on main

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,11 +12,16 @@ name: PR Test
 #   * `docker-paths` + `docker-build` build a `pr-<num>` image on docker PRs.
 #   * `ci_megatron_pr` workflow_dispatch input removed — miles-D source has
 #     zero `from megatron` imports.
-#   * No `schedule` trigger yet (miles main runs a nightly full CI).
+#   * Nightly full CI on main: every suite with `--match-all-labels`, like
+#     miles main's cron (catches drift in floating deps: sglang main tip,
+#     image `latest`, HF snapshots).
 
 on:
   pull_request:
     types: [synchronize, labeled, opened, reopened]
+  schedule:
+    # 16:30 UTC = 09:30 PDT / 08:30 PST (cron is UTC, no DST).
+    - cron: '30 16 * * *'
   workflow_dispatch:
     inputs:
       ci_sglang_pr:
@@ -39,7 +44,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # PR updates supersede their previous run; cron and manual runs on main
+  # must not cancel one another.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.schedule || github.run_id }}
   cancel-in-progress: true
 
 # PR labels are passed through to run_suite.py as raw `run-ci-<X>` strings via
@@ -112,7 +119,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       (needs.docker-build.result == 'success' || needs.docker-build.result == 'skipped') &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
     runs-on: ubuntu-latest
     outputs:
       container_image: ${{ steps.resolve.outputs.container_image }}
@@ -143,14 +150,15 @@ jobs:
 
   # Stage A: CPU-only fast tests (always runs on PR)
   stage-a-cpu:
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Stage B: CPU-only slower bucket (currently empty; reserved for future
@@ -158,14 +166,15 @@ jobs:
   # Empty result exits 0 in run_suite.py.
   stage-b-cpu:
     needs: [stage-a-cpu]
-    if: (github.event_name == 'workflow_dispatch') || (github.event.pull_request)
+    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request)
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-b-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Stage B GPU: fast-gpu bucket, runs once stage-a-cpu is green (fast-fail:
@@ -178,7 +187,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
       # Suite names match the runner split: 3gpu (GPUs 0-2) + 5gpu (GPUs 3-7).
@@ -187,7 +196,8 @@ jobs:
       execute_command: >-
         python tests/ci/run_suite.py --hw cuda --suite stage-b-3-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Stage B GPU: 4-GPU distributed tests on the 5gpu runner.
@@ -197,7 +207,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&
-      ((github.event_name == 'workflow_dispatch') || (github.event.pull_request))
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
     uses: ./.github/workflows/_run-ci.yml
     with:
       runs_on: '["h200", "5gpu"]'
@@ -205,7 +215,8 @@ jobs:
       execute_command: >-
         python tests/ci/run_suite.py --hw cuda --suite stage-b-5-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Fan-in so each stage-c needs one job instead of every stage-b.
@@ -227,7 +238,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-b.result == 'success' &&
-      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ||
         (github.event.pull_request &&
           !contains(github.event.pull_request.labels.*.name, 'skip-ci-stage-c')))
     uses: ./.github/workflows/_run-ci.yml
@@ -237,7 +248,8 @@ jobs:
       execute_command: >-
         python tests/ci/run_suite.py --hw cuda --suite stage-c-3-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Stage C GPU: e2e suite on the 5gpu runner.
@@ -247,7 +259,7 @@ jobs:
       always() && !cancelled() &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-b.result == 'success' &&
-      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ||
         (github.event.pull_request &&
           !contains(github.event.pull_request.labels.*.name, 'skip-ci-stage-c')))
     uses: ./.github/workflows/_run-ci.yml
@@ -257,5 +269,6 @@ jobs:
       execute_command: >-
         python tests/ci/run_suite.py --hw cuda --suite stage-c-5-gpu-h200
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit

--- a/tests/ci/run_suite.py
+++ b/tests/ci/run_suite.py
@@ -37,11 +37,6 @@ PER_COMMIT_SUITES = {
     ],
 }
 
-# Nightly test suites (placeholder for future use)
-NIGHTLY_SUITES = {
-    HWBackend.CUDA: [],
-}
-
 
 def strip_run_ci_prefix(raw_labels: Iterable[str]) -> set[str]:
     """Strip the `run-ci-` prefix from each PR-side label.
@@ -73,11 +68,14 @@ def filter_tests(
     ci_tests: list[CIRegistry],
     hw: HWBackend,
     suite: str,
-    nightly: bool = False,
+    admit_nightly_tests: bool = False,
     labels: set[str] | None = None,
     match_all_labels: bool = False,
 ) -> tuple[list[CIRegistry], list[CIRegistry]]:
     """Filter registered tests down to the set that should run.
+
+    Nightly tests live in the per-commit suites: excluded by default,
+    admitted (in addition) when `admit_nightly_tests` is set.
 
     The base predicate (hw / suite / nightly / disabled) is applied first.
     Label selection then narrows further, with two modes:
@@ -94,12 +92,10 @@ def filter_tests(
       set; a test with non-empty `labels` survives only when its labels
       intersect the PR-supplied set.
     """
-    ci_tests = [t for t in ci_tests if t.backend == hw and t.suite == suite and t.nightly == nightly]
+    ci_tests = [t for t in ci_tests if t.backend == hw and t.suite == suite and (not t.nightly or admit_nightly_tests)]
 
-    valid_suites = NIGHTLY_SUITES.get(hw, []) if nightly else PER_COMMIT_SUITES.get(hw, [])
-
-    if suite not in valid_suites:
-        print(f"Warning: Unknown suite {suite} for backend {hw.name}, nightly={nightly}")
+    if suite not in PER_COMMIT_SUITES.get(hw, []):
+        print(f"Warning: Unknown suite {suite} for backend {hw.name}")
 
     if not match_all_labels:
         label_set: set[str] = labels or set()
@@ -216,7 +212,7 @@ def run_a_suite(args):
         all_tests,
         hw,
         suite,
-        nightly,
+        admit_nightly_tests=nightly,
         labels=stripped_labels,
         match_all_labels=args.match_all_labels,
     )
@@ -267,7 +263,7 @@ def main():
     parser.add_argument(
         "--nightly",
         action="store_true",
-        help="Run nightly tests instead of per-commit tests.",
+        help="Also admit tests registered with nightly=True (excluded from PR runs).",
     )
     parser.add_argument(
         "--timeout-per-file",


### PR DESCRIPTION
## What
- `schedule` trigger on pr-test.yml: nightly at 16:30 UTC (09:30 PDT / 08:30 PST), running every suite (stage-a/b CPU, stage-b fast-gpu 3+5, stage-c e2e 3+5) with `--match-all-labels` — same shape as miles main's nightly cron.
- Concurrency group keys on `pull_request.number || event.schedule || run_id` so cron/manual runs on main never cancel each other (miles main's pattern).

## Why
- The repo's floating deps (sglang main tip, image `latest`, HF snapshots) can break e2e standards with zero PRs in flight; a nightly full run on main surfaces the drift the next morning instead of inside an unrelated PR.

## Notes
- Ports miles main's `admit_nightly_tests` semantics: `nightly=True` tests live in the per-commit suites, are excluded from PR/dispatch runs (even with `run-ci-all`), and are admitted only by the schedule's `--nightly`. `NIGHTLY_SUITES` placeholder removed. Verified: synthetic nightly test excluded on day paths, admitted on schedule; enumeration still covers 39/39 registered tests.
- `docker-paths`/`docker-build` stay PR-only; nightly runs on the image `resolve-ci-image` picks (default `latest`).
- Fast-fail is kept (stage-c still needs stage-b green) — deviation from miles main's nightly, which disables it; can follow up if we'd rather have full signal per night.
- First scheduled run only fires after this merges to main (schedule reads the default branch's workflow).

## Checklist
- [x] `pre-commit run --all-files` passes
- [x] YAML parses; no test-code changes
- [x] Launch flags / CLI docs / examples — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)


