### PR TITLE
fix: kill sgl-d workers in teardown, not just "sglang"

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -91,6 +91,7 @@ jobs:
           pkill -9 -f gcs_server 2>/dev/null || true
           pkill -9 -f 'ray-dashboard' 2>/dev/null || true
           pkill -9 sglang 2>/dev/null || true
+          pkill -9 sgl_diffusion 2>/dev/null || true
           ray stop --force 2>/dev/null || true
           sleep 3
 

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -61,6 +61,7 @@ def execute_train(
 
     exec_command(
         "pkill -9 sglang; "
+        "pkill -9 sgl_diffusion; "
         "sleep 3; "
         f"{'' if external_ray else 'ray stop --force; '}"
         f"{'' if external_ray else 'pkill -9 ray; '}"

--- a/tests/ci/e2e_metrics_registry.py
+++ b/tests/ci/e2e_metrics_registry.py
@@ -71,7 +71,8 @@ def _cleanup_gpu_state() -> None:
     """Kill ray/sglang leftovers from a previous test in this job and wait for
     GPU memory to drain (engines take minutes to die after their driver exits)."""
     subprocess.run(
-        "pkill -9 -f 'ray::'; pkill -9 -f raylet; pkill -9 -f gcs_server; pkill -9 -f sgl_diffusion; ray stop --force; true",
+        "pkill -9 -f 'ray::'; pkill -9 -f raylet; pkill -9 -f gcs_server; "
+        "pkill -9 sglang; pkill -9 sgl_diffusion; ray stop --force; true",
         shell=True,
         capture_output=True,
     )


### PR DESCRIPTION
## What

- `execute_train`'s teardown now also runs `pkill -9 sgl_diffusion`, so sgl-d's engine
  workers are actually killed alongside ray.
- The CI `Cleanup Ray processes` step gets the same line.
- `tests/ci/e2e_metrics_registry.py` drops the `-f` from its `sgl_diffusion` kill.

## Why

`pkill` matches on process name, and sgl-d renames its workers to `sgl_diffusion::*`
(e.g. `sgl_diffusion::scheduler_U0`). The string `sglang` is not a substring of
`sgl_diffusion`, so the teardown never matched them. Measured on an H200 devbox:

```
$ ps -eo pid,comm,args | grep sgl_diffusion
3636386 sgl_diffusion:: sgl_diffusion::scheduler_U0
$ pkill -9 sglang        # still alive
$ pkill -9 sgl_diffusion # killed
```

`ray stop --force` takes down the driver, but these workers are separate processes that
survive it — orphaned (PPID 1) and still holding tens of GB per GPU. The next run on the
same machine then starts against occupied cards. Containerized CI hides this (the job's
PID namespace dies with the container); shared devboxes do not, and this is where the
"someone left the GPUs full" reports come from.

The e2e registry already used the right process name, but with `-f`, which matches the
full command line — including the shell running that very `subprocess.run` string. The
shell killed itself mid-chain, so `ray stop --force` at the end of the chain never ran.
Verified:

```
$ bash -c "pkill -9 -f sgl_diffusion; echo REACHED_NEXT_COMMAND"
(no output — the shell is gone)
```

Matching on the process name instead is both correct here and free of that hazard.

## Files

| File | Role |
| --- | --- |
| `miles/utils/external_utils/command_utils.py` | launcher teardown before `ray start` |
| `.github/workflows/_run-ci.yml` | CI cleanup step between jobs |
| `tests/ci/e2e_metrics_registry.py` | per-test GPU cleanup in the e2e harness |

## Not in this PR

The teardown still kills by process name across the whole PID namespace, so on a shared
machine it takes out a neighbour's run as well as its own. Narrowing it to the current
job's process tree is a separate change.

## Checklist

- [x] `pre-commit run --all-files` passes — ran on the three touched files; all hooks pass
- [ ] Added/updated tests for new behaviour — **no tests added**: the change is a shell
      command in a teardown path; asserting on it would pin the exact string
- [ ] `pytest -x` is green — **not run** (no Python behaviour changed)
- [x] If launch flags changed, `python3 train.py --help` still parses — no flags changed
- [x] If a public flag was added, it appears in the CLI reference docs — no flags added
- [x] If an example was added, it has a real walkthrough — no examples added
