### PR TITLE
fix: set CUDA_VISIBLE_DEVICES at ray start, not per job

### DIFF
--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -140,7 +140,7 @@ register_e2e_ci(
     est_time=1200,
     suite="stage-c-3-gpu-h200",
     script="scripts/run_diffusion_grpo_sd3_ocr_sglang.py",
-    args=["--num-rollout", "2", "--cuda-visible-devices", "0,1"],
+    args=["--num-rollout", "2"],
     metrics=["rollout/reward/raw_mean", "train/grad_norm", ...],
 )
 ```

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -31,7 +31,6 @@ Every launcher follows the same layout:
 ```python
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):     # inherits output_dir, num_nodes, ...
-    cuda_visible_devices: str = "4,5,6,7,1"
     num_rollout: int = 400
     extra_args: str = ""                     # appended verbatim to the command line
 
@@ -61,7 +60,7 @@ Options shared by every launcher, from the `ExecuteTrainConfig` base class and r
 | Option | Default | Purpose |
 |---|---|---|
 | `--num-nodes` | `$SLURM_JOB_NUM_NODES` or `1` | Training nodes |
-| `--cuda-visible-devices` | recipe-set | Physical GPUs the job may use |
+| `--cuda-visible-devices` | inherited from the environment | Physical GPUs the job may use. Applied by exporting it for `ray start`, so the count must equal the recipe's GPU count. Leave it unset when something upstream (a CI runner, your shell) already pins the devices. |
 | `--output-dir` | `<repo>/logs` | Where checkpoints and dumps are written |
 | `--extra-env-vars` | empty | Extra env vars added to the Ray runtime env |
 | `--extra-args` | empty | Extra flags appended to the `train_diffusion.py` command line |

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -60,7 +60,7 @@ Options shared by every launcher, from the `ExecuteTrainConfig` base class and r
 | Option | Default | Purpose |
 |---|---|---|
 | `--num-nodes` | `$SLURM_JOB_NUM_NODES` or `1` | Training nodes |
-| `--cuda-visible-devices` | inherited from the environment | Physical GPUs the job may use. Applied by exporting it for `ray start`, so the count must equal the recipe's GPU count. Leave it unset when something upstream (a CI runner, your shell) already pins the devices. |
+| `--cuda-visible-devices` | inherited from the environment | Physical GPUs the job may use. Applied by exporting it for `ray start`. |
 | `--output-dir` | `<repo>/logs` | Where checkpoints and dumps are written |
 | `--extra-env-vars` | empty | Extra env vars added to the Ray runtime env |
 | `--extra-args` | empty | Extra flags appended to the `train_diffusion.py` command line |

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -37,6 +37,18 @@ class ExecuteTrainConfig:
     output_dir: str = str(repo_base_dir / "logs")
 
 
+def _cvd_export(config: ExecuteTrainConfig, num_gpus_per_node: int) -> str:
+    """Shell prefix pinning the raylet's GPUs; empty means inherit the caller's environment."""
+    if not config.cuda_visible_devices:
+        return ""
+    visible = [x.strip() for x in config.cuda_visible_devices.split(",") if x.strip()]
+    assert len(visible) == num_gpus_per_node, (
+        f"--cuda-visible-devices lists {len(visible)} GPU(s) ({config.cuda_visible_devices}) but this "
+        f"recipe runs on {num_gpus_per_node}; ray would hand out ids the visible list does not have."
+    )
+    return f"export CUDA_VISIBLE_DEVICES={','.join(visible)} && "
+
+
 def execute_train(
     train_args: str,
     num_gpus_per_node: int,
@@ -73,10 +85,20 @@ def execute_train(
 
     if not external_ray:
         exec_command(
+            # `ray start` is the only place a GPU restriction takes effect: Ray reads the
+            # device list once, when the raylet comes up, and schedules from it forever
+            # after. Set later (per job or per actor) it is just an env var the scheduler
+            # never sees, so the job can be placed on GPUs it was told not to touch.
+            f"{_cvd_export(config, num_gpus_per_node)}"
             # keeps ray from buffering stdout/stderr
             "export PYTHONBUFFERED=16 && "
             f"ray start --head --node-ip-address {master_addr} "
             f"--num-gpus {num_gpus_per_node} --disable-usage-stats"
+        )
+    else:
+        assert not config.cuda_visible_devices, (
+            "--cuda-visible-devices cannot be applied to an externally started cluster: "
+            "export CUDA_VISIBLE_DEVICES before `ray start` instead."
         )
 
     if (f := before_ray_job_submit) is not None:
@@ -92,7 +114,6 @@ def execute_train(
         "no_proxy": f"127.0.0.1,{master_addr}",
         # torch distributed needs this on every node, not just the submitting shell.
         "MASTER_ADDR": master_addr,
-        **({"CUDA_VISIBLE_DEVICES": config.cuda_visible_devices} if config.cuda_visible_devices else {}),
         **(
             {
                 "CUDA_ENABLE_COREDUMP_ON_EXCEPTION": "1",

--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -85,10 +85,8 @@ def execute_train(
 
     if not external_ray:
         exec_command(
-            # `ray start` is the only place a GPU restriction takes effect: Ray reads the
-            # device list once, when the raylet comes up, and schedules from it forever
-            # after. Set later (per job or per actor) it is just an env var the scheduler
-            # never sees, so the job can be placed on GPUs it was told not to touch.
+            # Ray reads the device list once, at raylet startup; set per job or per actor
+            # it never reaches the scheduler, which then places work on excluded GPUs.
             f"{_cvd_export(config, num_gpus_per_node)}"
             # keeps ray from buffering stdout/stderr
             "export PYTHONBUFFERED=16 && "

--- a/scripts/run_diffusion_grpo_ltx23_sglang.py
+++ b/scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -25,7 +25,6 @@ WANDB_PROJECT = "miles-diffusion-grpo"
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "0,1,2,3,4"
     num_rollout: int = 200
     data_dir: str = "/root/datasets"
     extra_args: str = ""

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -29,7 +29,6 @@ WANDB_PROJECT = "miles-diffusion-grpo"
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "4,5,6,7,1"
     num_rollout: int = 400
     data_dir: str = "/root/datasets"
     extra_args: str = ""

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -29,7 +29,6 @@ MASTER_SGLANG_PYTHON = "/sgl-workspace/master_sglang/sglang/python"
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "6,7"
     num_rollout: int = 600
     data_dir: str = "/root/datasets"
     debug_alignment: bool = False

--- a/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -42,7 +42,6 @@ LORA_TARGET_MODULES = (
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "0,1,2,3,4"
     num_rollout: int = 10000
     data_dir: str = "/root/datasets"
     extra_args: str = ""

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -29,7 +29,6 @@ WANDB_PROJECT = "miles-diffusion-nft"
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "4,5,2"
     num_rollout: int = 0  # 0 picks the smoke/full default
     data_dir: str = "/root/datasets"
     smoke: bool = False

--- a/scripts/run_diffusion_sft_wan22.py
+++ b/scripts/run_diffusion_sft_wan22.py
@@ -32,7 +32,6 @@ LORA_TARGET_MODULES = (
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    cuda_visible_devices: str = "0,1,2,3"
     data_jsonl: str = ""
     resume_ckpt: str = ""
     start_rollout: int = -1

--- a/tests/e2e/short/test_ltx23_pickscore_grpo_4xGPU.py
+++ b/tests/e2e/short/test_ltx23_pickscore_grpo_4xGPU.py
@@ -10,9 +10,7 @@ register_e2e_ci(
     est_time=1800,
     suite="stage-c-5-gpu-h200",
     script="scripts/run_diffusion_grpo_ltx23_sglang.py",
-    # Empty on purpose: the runner already pins CUDA_VISIBLE_DEVICES=3,4,5,6,7,
-    # and the recipe's own "0,1,2,3,4" default would grab the 3gpu runner's cards.
-    args=["--num-rollout", "2", "--cuda-visible-devices", ""],
+    args=["--num-rollout", "2"],
     metrics=[
         "rollout/reward/raw_num_samples",
         "rollout/reward/raw_mean",

--- a/tests/e2e/short/test_sd3_ocr_grpo_2xGPU.py
+++ b/tests/e2e/short/test_sd3_ocr_grpo_2xGPU.py
@@ -10,7 +10,7 @@ register_e2e_ci(
     est_time=1200,
     suite="stage-c-3-gpu-h200",
     script="scripts/run_diffusion_grpo_sd3_ocr_sglang.py",
-    args=["--num-rollout", "2", "--cuda-visible-devices", "0,1"],
+    args=["--num-rollout", "2"],
     metrics=[
         "rollout/reward/raw_num_samples",
         "rollout/reward/raw_mean",

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -1,3 +1,10 @@
+"""`_cvd_export` turns the recipe's device list into a `ray start` prefix:
+
+    unset        -> ""                                     inherit the environment
+    "4,5,2", 3   -> "export CUDA_VISIBLE_DEVICES=4,5,2 && " pin the raylet
+    "0,1",   5   -> AssertionError                          ray would hand out unknown ids
+"""
+
 from tests.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])

--- a/tests/fast/utils/test_command_utils.py
+++ b/tests/fast/utils/test_command_utils.py
@@ -1,0 +1,22 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import pytest
+
+from miles.utils.external_utils.command_utils import ExecuteTrainConfig, _cvd_export
+
+
+def test_unset_inherits_the_environment():
+    assert _cvd_export(ExecuteTrainConfig(), num_gpus_per_node=4) == ""
+
+
+def test_set_exports_for_ray_start():
+    config = ExecuteTrainConfig(cuda_visible_devices="4,5,2")
+    assert _cvd_export(config, num_gpus_per_node=3) == "export CUDA_VISIBLE_DEVICES=4,5,2 && "
+
+
+def test_count_mismatch_is_rejected():
+    config = ExecuteTrainConfig(cuda_visible_devices="0,1")
+    with pytest.raises(AssertionError, match="lists 2 GPU"):
+        _cvd_export(config, num_gpus_per_node=5)


### PR DESCRIPTION
## What

- The six recipes stop declaring a `cuda_visible_devices` default. The flag is still there,
  inherited from `ExecuteTrainConfig` with an empty default, i.e. *inherit the environment*.
- When it **is** set, it is applied by exporting it for `ray start` instead of being injected
  into the ray job's `runtime_env`, and its count is asserted against the recipe's GPU count.
- With `MILES_SCRIPT_EXTERNAL_RAY=1` the flag now errors instead of silently doing nothing —
  the cluster already exists, so there is no `ray start` to pin.
- The two e2e tests stop passing the flag; docs follow.

## Why

Ray fixes its GPU namespace once, when the raylet comes up, and schedules from it forever
after. Measured on a 4×H200 node:

```
CVD=2,3 ray start --head --num-gpus 2
  ray.get_gpu_ids()            -> ['2','3']     physical labels, not renumbered 0..N-1
  normal actor's CVD           -> '2' / '3'     Ray composes its assignment with the list
  NOSET actor's ambient CVD    -> '2,3'
```

A CVD applied *after* that — in the job's `runtime_env`, which is what this code did — is just
an env var. The scheduler never sees it and keeps allocating from the raylet's full list, so
the job can be placed on GPUs it was told not to touch.

That is not hypothetical here. The CI node's 8 GPUs are split into a 3gpu and a 5gpu runner by
per-runner `CUDA_VISIBLE_DEVICES`, and `_run-ci.yml` passes that pin into the job container
(`--env CUDA_VISIBLE_DEVICES`). A recipe whose own default says `"0,1,2,3,4"` then overrides
the runner's pin and reaches into the neighbouring runner's cards. The LTX e2e test already
worked around it by passing an empty value, with a comment naming the exact hazard; the SD3
test still passed `"0,1"` and was correct only because that runner happens to start at 0.

miles core does not have this knob at all — zero occurrences of `cuda_visible_devices` in its
Python. Its scripts `export CUDA_VISIBLE_DEVICES=4,5,6,7` in the shell before the launcher, and
its CI hands the runner's pin to the container the same way ours does. This change puts
miles-diffusion on that same single-source-of-truth model.

The added assert covers the other half of the trap: `--cuda-visible-devices 0,1` on a 5-GPU
recipe used to leave `ray start --num-gpus 5` advertising GPUs the visible list does not have.

## Validation

| Check | Result |
| --- | --- |
| `pytest tests/fast/utils/test_command_utils.py` | 3 passed (new test) |
| `--help` on the recipes | parses; `--cuda-visible-devices` still offered via the base class |
| GPU e2e | **not run** — see the draft note |

## Files

| File | Change |
| --- | --- |
| `miles/utils/external_utils/command_utils.py` | `_cvd_export` helper; export for `ray start`; drop the `runtime_env` entry; guard for external ray |
| `scripts/run_diffusion_*.py` (6) | drop the hardcoded `cuda_visible_devices` default |
| `tests/e2e/short/test_{ltx23_pickscore_grpo_4xGPU,sd3_ocr_grpo_2xGPU}.py` | stop passing the flag |
| `tests/fast/utils/test_command_utils.py` | new: covers unset / set / count-mismatch |
| `docs/user-guide/launch-script.md`, `docs/developer/contributor-guide.md` | flag semantics and examples |

The usage examples elsewhere in the docs (`--cuda-visible-devices 6,7`, `4,5,2`) stay valid:
their counts already match their recipes' GPU counts.

## Open questions

1. The count assert rejects `--cuda-visible-devices 4,5,2 --smoke` on the NFT recipe, since
   smoke mode runs on 2 GPUs. Keep the assert strict, or warn and let it through?
2. Should the flag be removed outright for full miles parity, leaving only a shell export?
   I kept it because it is genuinely convenient on a shared bare machine.

## Checklist

- [x] `pre-commit run --all-files` passes — ran on the touched files; all hooks pass
- [x] Added/updated tests for new behaviour — `tests/fast/utils/test_command_utils.py`
- [x] `pytest -x` is green — for the new fast test (3 passed); the GPU suites were not run
- [x] If launch flags changed, `python3 train.py --help` still parses — checked the recipes' `--help`
- [x] If a public flag was added, it appears in the CLI reference docs — no new flag; the existing row in `docs/user-guide/launch-script.md` is updated
- [x] If an example was added, it has a real walkthrough — no new examples
