### PR TITLE
fix(wan precision)(1/n): drop the wan wildcard fp32 pins

### DIFF
--- a/miles/backends/fsdp_utils/models/diffusers/wan2_2/parallel_plan.py
+++ b/miles/backends/fsdp_utils/models/diffusers/wan2_2/parallel_plan.py
@@ -3,8 +3,6 @@ from miles.backends.fsdp_utils.models.parallel_plan import FSDPParallelPlan
 
 FSDP_PARALLEL_PLAN = FSDPParallelPlan(
     param_dtype_patterns={
-        "*scale_shift_table": "fp32",
-        "*time_embedder*": "fp32",
         "*.norm2.*": "fp32",
     },
 )

--- a/tests/fast/backends/fsdp_utils/test_model_backend.py
+++ b/tests/fast/backends/fsdp_utils/test_model_backend.py
@@ -4,7 +4,6 @@ register_cpu_ci(est_time=15, suite="stage-a-cpu", labels=[])
 
 import torch
 
-from miles.backends.fsdp_utils.configs.wan2_2 import Wan2_2TrainPipelineConfig
 from miles.backends.fsdp_utils.model_backend import BaseModelBackend, DiffusersModelBackend, MilesModelBackend
 from miles.backends.fsdp_utils.models.diffusers import load_fsdp_parallel_plan
 
@@ -41,16 +40,6 @@ class TestBackendHierarchy:
         assert model.selected == "flash"
         assert plan.no_split_modules == ("TransformerBlock",)
         assert plan.param_dtype_patterns == {}
-
-    def test_diffusers_model_family_owns_fsdp_precision_plan(self):
-        backend = DiffusersModelBackend(Wan2_2TrainPipelineConfig())
-        plan = backend.fsdp_parallel_plan(_RecordingModel())
-
-        assert plan.param_dtype_patterns == {
-            "*scale_shift_table": "fp32",
-            "*time_embedder*": "fp32",
-            "*.norm2.*": "fp32",
-        }
 
     def test_all_diffusers_model_plans_load(self):
         assert load_fsdp_parallel_plan("sd3").param_dtype_patterns == {}


### PR DESCRIPTION
First of a stack that makes Wan2.2 train↔rollout forwards bitwise equal under batch replay. **This PR alone does not
make the diff zero** — it removes one of the things that prevents it. The other pieces (the wan
rollout patch group, the GEMM patchify, the engine-side root-table handling) follow as separate PRs.

## What is wrong with the current pins

`param_dtype_patterns` is matched with `fnmatch.fnmatchcase` against the **full FQN**, so the scope
is much wider than the names suggest:

- `*scale_shift_table` matches the root table **and all 40 `blocks.N.scale_shift_table`**. The
  per-block tables are bf16 on both stacks today and the block modulation already agrees; pinning
  the trainer's compute copy to fp32 makes it disagree.
- `*time_embedder*` matches the whole time-embedding MLP. Its `Linear` weights get cast back to
  bf16 by autocast anyway, so this pin does not do what it looks like it does.

Neither belongs in the plan: the parameter that genuinely needs different treatment is the **root**
`scale_shift_table`, and it needs it on the **engine** side (the engine's copy has to carry the same
precision the trainer's FSDP-gathered bf16 copy has). Pinning the trainer instead moves the mismatch
rather than removing it.

## Measurement

Wan2.2-T2V-A14B, 16 GPUs (2×8 H200), full finetune, engine sp4/tp1, trainer ulysses sp4,
`--rollout-patch-group wan`, `--deterministic-mode`, with the rest of the stack applied:

| trainer-side pin on the root `scale_shift_table` | rollout 0 | rollout 1 |
|---|---|---|
| present | **2.937951e-03** | 0 |
| absent (this PR) | **0** | 0 |

Same data, same sampled SDE step, real optimizer steps between the rollouts. The pin's effect is on
rollout 0 specifically: at that point the master still holds checkpoint values, and pinning the
trainer to fp32 while the engine's copy is bf16-rounded is exactly when the two part company.

The wider `*`-scope harm (the 40 per-block tables, the time embedder) is a code-level argument about
fnmatch semantics, not separately measured — those pins were already removed from the working
configuration before these runs.

`*.norm2.*` **stays**: that one is required. `FP32LayerNorm` uses an fp32 weight on both sides, and
dropping it takes rollout 0 from 0 to 1.65e-2.

## Test plan

- [x] 16-GPU multi-node GRPO, full stack applied: `model_output_mean_abs_diff`, `max_abs_diff` and
      `rel_max` all exactly 0 at rollouts 0 and 1, with `train/ratio_abs_minus_1 = 0`
- [x] Re-adding the root pin reproduces 2.937951e-03 at rollout 0
- [ ] No CI covers wan train↔rollout parity yet

## Why the test is deleted rather than updated

`test_diffusers_model_family_owns_fsdp_precision_plan` asserted the wan `param_dtype_patterns` which doesn't make sense. Remove it instead.
