### PR TITLE
feat(wan precision)(3/n): add the wan fp32-once rollout patch group

### DIFF
--- a/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py
@@ -55,6 +55,13 @@ def apply_sgld_monkey_patches() -> None:
     patch_qk_norm_rope.apply()
 
 
+@register_rollout_patch_group("wan")
+def apply_wan_rollout_patches() -> None:
+    from miles.backends.sglang_diffusion_utils.monkey_patches import patch_wan_norm_ops
+
+    patch_wan_norm_ops.apply()
+
+
 @register_rollout_patch_group("ltx")
 def apply_ltx2_rollout_patches() -> None:
     from miles.backends.sglang_diffusion_utils.monkey_patches import (

--- a/miles/backends/sglang_diffusion_utils/monkey_patches/patch_wan_norm_ops.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/patch_wan_norm_ops.py
@@ -10,10 +10,7 @@ and is anti-parity for Wan; these mirror the Wan fp32-once shape.
 import torch
 import torch.nn.functional as F
 from sglang.multimodal_gen.runtime.layers.elementwise import MulAdd
-from sglang.multimodal_gen.runtime.layers.layernorm import (
-    LayerNormScaleShift,
-    ScaleResidualLayerNormScaleShift,
-)
+from sglang.multimodal_gen.runtime.layers.layernorm import LayerNormScaleShift, ScaleResidualLayerNormScaleShift
 
 from miles.backends.sglang_diffusion_utils.monkey_patches._common import ensure_broadcast
 
@@ -107,22 +104,19 @@ def _patched_apply_rotary_emb(x, cos, sin, is_neox_style, interleaved=False):
 
 
 def _upcast_head_table_pre_hook(module, args, kwargs=None):
-    """Two jobs, both required for `scale_shift_table + temb` parity at the root norm_out.
+    """Keep the root `scale_shift_table + temb` identical on both sides.
 
-    Promote the container to fp32: the trainer's temb is fp32 so its sum promotes; the engine's
-    temb is bf16, so with a bf16 table the sum rounds.
+    Container fp32: the trainer adds a fp32 temb, the engine a bf16 one -- with a bf16 table the
+    engine's sum rounds where the trainer's promotes.
 
-    Re-round the values to bf16 on every call, not once: each weight sync refills the (now fp32)
-    param with the trainer's full fp32 master, while the trainer's own forward reads the bf16 copy
-    FSDP gathered -- a one-time rounding is undone by the first sync. 10240 elements, cost is nil.
+    Values re-rounded to bf16 every call: weight sync writes the fp32 master into this param, but
+    the trainer's own forward computes with its bf16 copy.
     """
     table = getattr(module, "scale_shift_table", None)
     if table is None:
         return
     if table.dtype != torch.float32:
-        module.scale_shift_table = torch.nn.Parameter(
-            table.data.float(), requires_grad=table.requires_grad
-        )
+        module.scale_shift_table = torch.nn.Parameter(table.data.float(), requires_grad=table.requires_grad)
         table = module.scale_shift_table
     table.data.copy_(table.data.to(torch.bfloat16).to(torch.float32))
 

--- a/miles/backends/sglang_diffusion_utils/monkey_patches/patch_wan_norm_ops.py
+++ b/miles/backends/sglang_diffusion_utils/monkey_patches/patch_wan_norm_ops.py
@@ -1,0 +1,162 @@
+"""Wan-exact eager parity for the fused norm/residual kernels.
+
+diffusers' WanTransformerBlock computes every norm/residual site in fp32 and
+rounds once via .type_as (sole exception: the cross-attention residual is a
+plain bf16 add). The fused kernels round to bf16 mid-chain instead, ~3e-3 rel
+per site on a bit-exact input. The sgld group mirrors SD3's bf16-eager shape
+and is anti-parity for Wan; these mirror the Wan fp32-once shape.
+"""
+
+import torch
+import torch.nn.functional as F
+from sglang.multimodal_gen.runtime.layers.elementwise import MulAdd
+from sglang.multimodal_gen.runtime.layers.layernorm import (
+    LayerNormScaleShift,
+    ScaleResidualLayerNormScaleShift,
+)
+
+from miles.backends.sglang_diffusion_utils.monkey_patches._common import ensure_broadcast
+
+
+def _layer_norm_f32(norm: torch.nn.LayerNorm, x_f32: torch.Tensor) -> torch.Tensor:
+    weight = norm.weight.float() if norm.weight is not None else None
+    bias = norm.bias.float() if norm.bias is not None else None
+    return F.layer_norm(x_f32, norm.normalized_shape, weight, bias, norm.eps)
+
+
+def _lnss_forward(self, x: torch.Tensor, shift=None, scale=None):
+    # diffusers: (norm1(x.float()) * (1 + scale) + shift).type_as(x) -- one rounding.
+    normed = _layer_norm_f32(self.norm, x.float())
+    if shift is None and scale is None:
+        return normed.type_as(x)
+    scale = ensure_broadcast(scale, normed).float()
+    shift = ensure_broadcast(shift, normed).float()
+    return (normed * (1 + scale) + shift).type_as(x)
+
+
+def _residual_f32(residual: torch.Tensor, x: torch.Tensor, gate):
+    # diffusers: (residual.float() + x * gate).type_as(residual); the ungated
+    # cross-attention residual is a plain same-dtype add.
+    if isinstance(gate, int):
+        assert gate == 1
+        return residual + x
+    if gate.dim() == 4:
+        num_frames = gate.shape[1]
+        frame_seqlen = x.shape[1] // num_frames
+        gated = (x.unflatten(dim=1, sizes=(num_frames, frame_seqlen)).float() * gate.float()).flatten(1, 2)
+    else:
+        gated = x.float() * gate.float()
+    return (residual.float() + gated).type_as(residual)
+
+
+def _srlnss_forward(self, residual: torch.Tensor, x: torch.Tensor, gate, shift, scale):
+    residual_out = _residual_f32(residual, x, gate)
+    normed = _layer_norm_f32(self.norm, residual_out.float())
+    if shift is None and scale is None:
+        return normed.type_as(residual_out), residual_out
+    scale = ensure_broadcast(scale, normed).float()
+    shift = ensure_broadcast(shift, normed).float()
+    return (normed * (1 + scale) + shift).type_as(residual_out), residual_out
+
+
+def _mul_add_forward(self, a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, k: int = 0):
+    # diffusers ffn residual: (c.float() + a.float() * (k + b.float())).type_as(c)
+    if b.dim() == 4:
+        num_frames = b.shape[1]
+        frame_seqlen = a.shape[1] // num_frames
+        gated = (a.unflatten(dim=1, sizes=(num_frames, frame_seqlen)).float() * (k + b.float())).flatten(1, 2)
+    else:
+        gated = a.float() * (k + b.float())
+    return (c.float() + gated).type_as(c)
+
+
+def _rms_norm_forward(self, x: torch.Tensor, residual=None):
+    # Wan norm_q/norm_k are torch.nn.RMSNorm on the train side. NOT sgld's
+    # patch_rmsnorm semantics: diffusers-generic RMSNorm rounds before the
+    # weight mul, torch.nn.RMSNorm does not.
+    assert residual is None, "wan attention rmsnorm never fuses a residual"
+    return F.rms_norm(x, (x.shape[-1],), self.weight, self.variance_epsilon)
+
+
+def _rope_fp32(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    # diffusers WanAttnProcessor: fp32 rotation over interleaved pairs with
+    # half-size tables, rounded once. The fused kernels rotate in bf16.
+    cos = cos.float().unsqueeze(-2)
+    sin = sin.float().unsqueeze(-2)
+    x1 = x[..., 0::2].float()
+    x2 = x[..., 1::2].float()
+    o1 = x1 * cos - x2 * sin
+    o2 = x1 * sin + x2 * cos
+    return torch.stack((o1, o2), dim=-1).flatten(-2).type_as(x)
+
+
+def _patched_flashinfer_rope_qk_inplace(q, k, cos_sin_cache, is_neox=False):
+    # wanvideo builds the cache as cat([cos, sin], dim=-1), each [tokens, D/2].
+    assert not is_neox
+    half = cos_sin_cache.shape[-1] // 2
+    cos, sin = cos_sin_cache[..., :half], cos_sin_cache[..., half:]
+    return _rope_fp32(q, cos, sin), _rope_fp32(k, cos, sin)
+
+
+def _patched_apply_rotary_emb(x, cos, sin, is_neox_style, interleaved=False):
+    assert not is_neox_style
+    if interleaved and cos.shape[-1] == x.shape[-1]:
+        cos = cos[..., ::2]
+        sin = sin[..., ::2]
+    return _rope_fp32(x, cos, sin)
+
+
+def _upcast_head_table_pre_hook(module, args, kwargs=None):
+    """Two jobs, both required for `scale_shift_table + temb` parity at the root norm_out.
+
+    Promote the container to fp32: the trainer's temb is fp32 so its sum promotes; the engine's
+    temb is bf16, so with a bf16 table the sum rounds.
+
+    Re-round the values to bf16 on every call, not once: each weight sync refills the (now fp32)
+    param with the trainer's full fp32 master, while the trainer's own forward reads the bf16 copy
+    FSDP gathered -- a one-time rounding is undone by the first sync. 10240 elements, cost is nil.
+    """
+    table = getattr(module, "scale_shift_table", None)
+    if table is None:
+        return
+    if table.dtype != torch.float32:
+        module.scale_shift_table = torch.nn.Parameter(
+            table.data.float(), requires_grad=table.requires_grad
+        )
+        table = module.scale_shift_table
+    table.data.copy_(table.data.to(torch.bfloat16).to(torch.float32))
+
+
+def apply() -> None:
+    import importlib
+
+    from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
+
+    LayerNormScaleShift.forward = _lnss_forward
+    ScaleResidualLayerNormScaleShift.forward = _srlnss_forward
+    MulAdd.forward = _mul_add_forward
+    RMSNorm.forward = _rms_norm_forward
+    # The wan DiT modules bind the rope entry points at import time.
+    for mod_path in (
+        "sglang.multimodal_gen.runtime.models.dits.wanvideo",
+        "sglang.multimodal_gen.runtime.models.dits.causal_wanvideo",
+    ):
+        try:
+            mod = importlib.import_module(mod_path)
+        except ImportError:
+            continue
+        if hasattr(mod, "apply_flashinfer_rope_qk_inplace"):
+            mod.apply_flashinfer_rope_qk_inplace = _patched_flashinfer_rope_qk_inplace
+        if hasattr(mod, "_apply_rotary_emb"):
+            mod._apply_rotary_emb = _patched_apply_rotary_emb
+        for cls_name in ("WanTransformer3DModel",):
+            cls = getattr(mod, cls_name, None)
+            if cls is not None and not getattr(cls, "_wan_head_table_hooked", False):
+                orig_init = cls.__init__
+
+                def _init(self, *a, _orig=orig_init, **kw):
+                    _orig(self, *a, **kw)
+                    self.register_forward_pre_hook(_upcast_head_table_pre_hook)
+
+                cls.__init__ = _init
+                cls._wan_head_table_hooked = True

--- a/tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py
+++ b/tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py
@@ -42,8 +42,9 @@ class TestRolloutPatchGroups:
             mp.apply_env_selected_rollout_patches()
 
     def test_builtin_group_registered(self):
-        # The decorator ran at import time for the in-repo group.
+        # The decorator ran at import time for the in-repo groups.
         assert "sgld" in mp._ROLLOUT_PATCH_APPLIERS
+        assert "wan" in mp._ROLLOUT_PATCH_APPLIERS
 
 
 class TestValidateRolloutPatchGroups:
@@ -51,6 +52,6 @@ class TestValidateRolloutPatchGroups:
     #   --rollout-patch-group "sgld,ltx"  ──► registered appliers ──► pass
     #   --rollout-patch-group "sgld,bogus" ─► "bogus" unregistered ─► ValueError
     def test_known_pass_unknown_raises(self):
-        mp.validate_rollout_patch_groups(["sgld", "ltx"])
+        mp.validate_rollout_patch_groups(["sgld", "ltx", "wan"])
         with pytest.raises(ValueError, match="Unknown rollout patch group"):
             mp.validate_rollout_patch_groups(["sgld", "bogus"])


### PR DESCRIPTION
**Stack position: 3/n**, on top of #167 (1/n) and #168 (2/n). This PR alone does not make the
train↔rollout diff zero — 1/n through 3/n together do.

## What

- Add the `wan` rollout patch group: `patch_wan_norm_ops.py`, selected through the existing
  `--rollout-patch-group wan`. No new flags.

## Why

The engine's fused norm/residual/rope kernels round to bf16 mid-chain; diffusers'
`WanTransformerBlock` computes those sites in fp32 and rounds once via `.type_as`. The existing
`sgld` group mirrors SD3's bf16-eager shape and is **anti-parity for Wan** — Wan needs the
fp32-once shape.

The root `scale_shift_table` additionally gets a forward pre-hook that does two jobs, both
required (code-level argument, documented in the hook docstring):

- promote the container to fp32, so the engine's `scale_shift_table + temb` sum promotes the way
  the trainer's does (the engine holds temb in bf16, the trainer in fp32);
- re-round the values to bf16 on **every** call, because each weight sync refills the param with
  the trainer's full fp32 master while the trainer's own forward reads the bf16 copy FSDP
  gathered — a one-time rounding is undone by the first sync.

## Measurement

`train/model_output_mean_abs_diff` (trainer recompute vs engine `rollout_step_model_output`),
wan2.2-T2V-A14B, 16×H200, tp1, `--sglang-attention-backend torch_sdpa`, batch replay:

| config | mean_abs_diff |
|---|---|
| without this group | 2.978e-3 (rollout 1) |
| this group minus the head-table hook | 3.206e-3 (rollout 0) |
| this group | **0.0 exact** — sustained across a 100+-rollout production run |

## Files

- `miles/backends/sglang_diffusion_utils/monkey_patches/patch_wan_norm_ops.py` — the six
  fp32-once forward replacements + the head-table pre-hook
- `miles/backends/sglang_diffusion_utils/monkey_patches/__init__.py` — register the `wan` group
  (lazy import; registration does not import sglang)
- `tests/fast/backends/sglang_diffusion_utils/test_rollout_patch_groups.py` — registry coverage
  for the new group

## Checklist

- [x] Added/updated tests for new behaviour (`test_rollout_patch_groups.py`, 5 passed)
- [ ] `pre-commit run --all-files` — **not run locally**
- [ ] `pytest -x` full suite — **not run** (fast scope only; no CI covers wan train↔rollout parity yet)
- [x] No launch flags changed (`--rollout-patch-group` already exists)
