### PR TITLE
fix(wan rollout)(4/n): colocate-reward worker bound and cross-node placement

### DIFF
--- a/miles/rollout/rm_hub/core.py
+++ b/miles/rollout/rm_hub/core.py
@@ -42,10 +42,13 @@ class AsyncRewardActorPool:
     ) -> None:
         if colocate:
             pg, bundle_indices, _ = get_reward_placement_group()
+            # bundle_indices is sorted by (node, gpu); stride so workers spread across nodes
+            # instead of stacking onto the first node's GPUs.
+            stride = max(1, len(bundle_indices) // num_workers)
             strategies = [
                 PlacementGroupSchedulingStrategy(
                     placement_group=pg,
-                    placement_group_bundle_index=bundle_indices[w],
+                    placement_group_bundle_index=bundle_indices[w * stride],
                 )
                 for w in range(num_workers)
             ]

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1659,11 +1659,9 @@ def miles_validate_args(args):
 
     if args.colocate_reward:
         assert args.colocate, "--colocate-reward requires --colocate."
-        num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
-        num_engines = args.rollout_num_gpus // num_gpu_per_engine
-        assert args.pickscore_num_workers <= num_engines, (
+        assert args.pickscore_num_workers <= args.rollout_num_gpus, (
             f"--colocate-reward requires pickscore_num_workers ({args.pickscore_num_workers}) "
-            f"<= rollout engines ({num_engines})."
+            f"<= rollout_num_gpus ({args.rollout_num_gpus}): the placement group has one bundle per GPU."
         )
 
     if args.eval_function_path is None:


### PR DESCRIPTION
**Stack position: 4/n**, on top of #169 (3/n). Two bugs in `--colocate-reward`, both measured on the
wan2.2 16-GPU run (2 nodes × 8×H200, 8 engines, 4 pickscore workers).

## What

- Raise the worker bound from `<= num_engines` to `<= rollout_num_gpus`: the placement group builds
  **one bundle per GPU** and a colocated worker reserves 0.05 GPU, so engines was never the real
  limit. The old bound capped reward parallelism at a quarter of what fits.
- Stride workers across the sorted bundle list instead of taking the first N:
  `bundle_indices` is sorted by (node, gpu), so `bundle_indices[w]` stacked every worker onto the
  first node's first GPUs.

## Measurement

With 4 workers under the old placement, all four landed on node0 GPUs 0-3:

| | node0 util | node1 util |
|---|---|---|
| old placement | 100% on all 8 GPUs | 0–13%, engines idle waiting on node0 |
| strided | balanced (both nodes 100% during rollout) | |

Stride behavior (16 GPUs): 4 workers → bundles 0,4,8,12 (2 per node); 16 workers → all bundles;
`(W-1)·⌊N/W⌋ < N` keeps every index in range for any `W ≤ N`.

## Files

- `miles/utils/arguments.py` — bound raised; the engines computation existed only for the old
  assert and is removed with it
- `miles/rollout/rm_hub/core.py` — strided bundle selection

## Checklist

- [ ] Added/updated tests — **none**: exercising the placement needs a live ray placement group;
  the stride arithmetic is covered by the in-range argument above
- [x] `isort`/`black --check` clean against the repo config
- [ ] `pre-commit run --all-files` — **not run locally** (formatters verified individually)
- [x] No launch flags added or changed (an existing assert's bound is corrected)
