### PR TITLE
fix(wan rollout)(5/n): drop the FlowGRPO negative-prompt fallback, use the engine default

### DIFF
--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -40,13 +40,15 @@ def build_rollout_sampling_params(
 
     sampling_params: dict[str, Any] = {
         "generator_device": args.diffusion_generator_device,
-        "negative_prompt": neg,
         "width": args.diffusion_width,
         "height": args.diffusion_height,
         "num_inference_steps": num_steps,
         "guidance_scale": args.diffusion_guidance_scale,
         "true_cfg_scale": args.diffusion_true_cfg_scale,
     }
+
+    if neg is not None:
+        sampling_params["negative_prompt"] = neg
 
     if evaluation:
         sampling_params["rollout"] = False
@@ -87,8 +89,6 @@ def build_rollout_generate_payload(
 ) -> dict[str, Any]:
     """Build full JSON payload for ``POST /rollout/generate`` (``RolloutImageRequest``)."""
     sampling_params["prompt"] = prompt
-    if sampling_params.get("negative_prompt") is None and float(sampling_params.get("guidance_scale", 1.0)) != 1.0:
-        sampling_params["negative_prompt"] = " "  # FlowGRPO default when CFG is on
     sampling_params["num_outputs_per_prompt"] = num_outputs_per_prompt
     return sampling_params
 

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -58,6 +58,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--diffusion-train-iter-order sample_major "
         "--diffusion-num-steps 10 "
         "--diffusion-guidance-scale 4.0 "
+        "--diffusion-negative-prompt ' ' "
         "--diffusion-true-cfg-scale 4.0 "
         "--diffusion-noise-level 1.2 "
         "--diffusion-height 512 "

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -58,6 +58,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--train-dp-split-mode stride "
         "--diffusion-num-steps 10 "
         "--diffusion-guidance-scale 4.5 "
+        "--diffusion-negative-prompt ' ' "
         "--diffusion-noise-level 0.7 "
         "--diffusion-height 512 "
         "--diffusion-width 512 "

--- a/tests/fast/rollout/test_rollout_negative_prompt.py
+++ b/tests/fast/rollout/test_rollout_negative_prompt.py
@@ -1,0 +1,48 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+# The negative_prompt contract of the rollout payload:
+#
+#   --diffusion-negative-prompt <unset>  ─►  key absent from the payload
+#                                            ─► engine strips nothing, per-model default applies
+#   --diffusion-negative-prompt " "      ─►  " " passes through verbatim (FlowGRPO recipes)
+
+from argparse import Namespace
+
+from miles.rollout.sglang_diffusion_rollout import (
+    build_rollout_generate_payload,
+    build_rollout_sampling_params,
+)
+
+
+def _args(**overrides):
+    values = dict(
+        diffusion_negative_prompt=None,
+        diffusion_generator_device=None,
+        diffusion_eval_num_steps=None,
+        diffusion_num_steps=10,
+        diffusion_width=832,
+        diffusion_height=480,
+        diffusion_guidance_scale=4.0,
+        diffusion_guidance_scale_2=None,
+        diffusion_true_cfg_scale=None,
+        diffusion_output_num_frames=None,
+        diffusion_fps=None,
+        diffusion_sde_type="sde",
+        diffusion_noise_level=0.7,
+        diffusion_log_prob_no_const=False,
+        diffusion_debug_mode=False,
+    )
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_unset_negative_prompt_is_omitted():
+    payload = build_rollout_generate_payload(build_rollout_sampling_params(_args()), "p")
+    assert "negative_prompt" not in payload
+
+
+def test_explicit_negative_prompt_passes_through():
+    payload = build_rollout_generate_payload(build_rollout_sampling_params(_args(diffusion_negative_prompt=" ")), "p")
+    assert payload["negative_prompt"] == " "

--- a/tests/fast/rollout/test_rollout_negative_prompt.py
+++ b/tests/fast/rollout/test_rollout_negative_prompt.py
@@ -10,10 +10,7 @@ register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
 
 from argparse import Namespace
 
-from miles.rollout.sglang_diffusion_rollout import (
-    build_rollout_generate_payload,
-    build_rollout_sampling_params,
-)
+from miles.rollout.sglang_diffusion_rollout import build_rollout_generate_payload, build_rollout_sampling_params
 
 
 def _args(**overrides):


### PR DESCRIPTION
**Stack position: 5/n**, on top of #170 (4/n).

## What

- `build_rollout_generate_payload` no longer forces `negative_prompt = " "` whenever CFG is on,
  and `build_rollout_sampling_params` omits the key entirely when `--diffusion-negative-prompt`
  is unset. The engine then applies its own per-model default (`rollout_api.py` strips absent
  fields; for wan2.2 the default is the official 137-char Chinese negative prompt from
  `wan/configs/shared_config.py`).
- The SD3 recipes pass `--diffusion-negative-prompt ' '` explicitly to keep their FlowGRPO
  alignment byte-for-byte.

## Why

The `" "` fallback is an SD3/FlowGRPO convention that was silently imposed on every model family.
Model-specific defaults belong to the engine; miles should transmit what the user set and nothing
else. Measured on wan2.2 true inference (same prompt/seed/steps): the official negative prompt cuts
whole-video entropy ~20% and visibly cleans the first frame vs `" "`.

Parity-safe: the trainer recomputes from the engine-returned cond_kwargs, so both sides always see
the same negative embedding. Verified in production — `model_output_mean_abs_diff = 0.0` sustained
after the switch (run `wan22_16gpu_480p5f_ns16_n07_shift5`).

## Landing note

`scripts/run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` landed on main after this stack's base
and also relies on the fallback (CFG on, no explicit negative prompt). It needs the same one-line
`--diffusion-negative-prompt ' '` when this stack merges; it does not exist on this branch.

## Files

- `miles/rollout/sglang_diffusion_rollout.py` — drop the fallback; omit the key when unset
- `scripts/run_diffusion_grpo_sd3_ocr_sglang.py`, `scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py`
  — explicit `' '` to preserve behavior
- `tests/fast/rollout/test_rollout_negative_prompt.py` — unset ⇒ key absent; explicit ⇒ verbatim

## Checklist

- [x] Added/updated tests (`test_rollout_negative_prompt.py`, 2 passed, registered stage-a-cpu)
- [x] `isort`/`black --check` clean against the repo config
- [ ] `pre-commit run --all-files` — **not run locally** (formatters verified individually)
- [x] No new launch flags (`--diffusion-negative-prompt` already exists; its unset semantics change
  from `" "` to engine default — that is the fix)
