### PR TITLE
ci: authorize PR tests and skip docs-only GPU

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -82,6 +82,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Review-triggered callers otherwise check out the default branch.
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
 
       - name: Cleanup Ray processes
         shell: bash
@@ -199,6 +202,8 @@ jobs:
 
       - name: Checkout miles-diffusion
         uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,7 +67,7 @@ jobs:
   ci-gate:
     runs-on: ubuntu-latest
     outputs:
-      approved: ${{ steps.trusted.outputs.approved || steps.pr.outputs.approved }}
+      authorized: ${{ steps.trusted.outputs.authorized || steps.pr.outputs.authorized }}
       docs_only: ${{ steps.trusted.outputs.docs_only || steps.pr.outputs.docs_only }}
     steps:
       - name: Allow trusted non-PR runs
@@ -75,10 +75,10 @@ jobs:
         id: trusted
         shell: bash
         run: |
-          echo "approved=true" >> "$GITHUB_OUTPUT"
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
           echo "docs_only=false" >> "$GITHUB_OUTPUT"
 
-      - name: Check approval and changed files
+      - name: Check authorization and changed files
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
         id: pr
         uses: actions/github-script@v7
@@ -106,9 +106,15 @@ jobs:
                 decisiveReviews.set(review.user.id, review);
               }
             }
-            const approved = [...decisiveReviews.values()].some(
+            const reviewApproved = [...decisiveReviews.values()].some(
               (review) => review.state === "APPROVED",
             );
+            // Applying labels requires triage (or stronger) repository
+            // permission, so run-ci-* also acts as a maintainer authorization.
+            const labelAuthorized = context.payload.pull_request.labels.some(
+              (label) => label.name.startsWith("run-ci-"),
+            );
+            const authorized = reviewApproved || labelAuthorized;
 
             const files = await github.paginate(
               github.rest.pulls.listFiles,
@@ -135,14 +141,16 @@ jobs:
                 (!file.previous_filename || isDocumentation(file.previous_filename)),
             );
 
-            core.setOutput("approved", String(approved));
+            core.setOutput("authorized", String(authorized));
             core.setOutput("docs_only", String(docsOnly));
             core.info(
-              `CI gate: approved=${approved}, docs_only=${docsOnly}, changed_files=${files.length}`,
+              `CI gate: review_approved=${reviewApproved}, ` +
+                `label_authorized=${labelAuthorized}, docs_only=${docsOnly}, ` +
+                `changed_files=${files.length}`,
             );
-            if (!approved) {
+            if (!authorized) {
               core.setFailed(
-                "PR CI requires an approval from a repository owner, member, or collaborator.",
+                "PR CI requires a trusted approval or a maintainer-applied run-ci-* label.",
               );
             }
 
@@ -150,7 +158,7 @@ jobs:
   docker-paths:
     needs: [ci-gate]
     if: |
-      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.authorized == 'true' &&
       needs.ci-gate.outputs.docs_only != 'true' &&
       github.event_name != 'workflow_dispatch' &&
       github.event_name != 'schedule'
@@ -215,7 +223,7 @@ jobs:
     # A failed build must skip this job so the GPU stages' `success` guard stops the matrix.
     if: |
       always() && !cancelled() &&
-      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.authorized == 'true' &&
       needs.ci-gate.outputs.docs_only != 'true' &&
       (needs.docker-build.result == 'success' || needs.docker-build.result == 'skipped') &&
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
@@ -247,11 +255,11 @@ jobs:
           echo "container_image=rockdu/miles_diffusion:${CI_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved CI image: rockdu/miles_diffusion:${CI_IMAGE_TAG}"
 
-  # Stage A: CPU-only fast tests. PRs require approval; docs-only PRs run
+  # Stage A: CPU-only fast tests. PRs require authorization; docs-only PRs run
   # the full CPU suite and stop before the GPU stages.
   stage-a-cpu:
     needs: [ci-gate]
-    if: needs.ci-gate.outputs.approved == 'true'
+    if: needs.ci-gate.outputs.authorized == 'true'
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
@@ -267,7 +275,7 @@ jobs:
   # Empty result exits 0 in run_suite.py.
   stage-b-cpu:
     needs: [ci-gate, stage-a-cpu]
-    if: needs.ci-gate.outputs.approved == 'true' && needs.stage-a-cpu.result == 'success'
+    if: needs.ci-gate.outputs.authorized == 'true' && needs.stage-a-cpu.result == 'success'
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
@@ -286,7 +294,7 @@ jobs:
     needs: [ci-gate, resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.authorized == 'true' &&
       needs.ci-gate.outputs.docs_only != 'true' &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&
@@ -308,7 +316,7 @@ jobs:
     needs: [ci-gate, resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
-      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.authorized == 'true' &&
       needs.ci-gate.outputs.docs_only != 'true' &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -19,6 +19,8 @@ name: PR Test
 on:
   pull_request:
     types: [synchronize, labeled, opened, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
   schedule:
     # 16:30 UTC = 09:30 PDT / 08:30 PST (cron is UTC, no DST).
     - cron: '30 16 * * *'
@@ -42,6 +44,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   # PR updates supersede their previous run; cron and manual runs on main
@@ -58,15 +61,102 @@ concurrency:
 # every enabled test in the suite.
 
 jobs:
+  # Keep unreviewed code off the expensive self-hosted runners. Review events
+  # retrigger this workflow, while schedule and manual runs remain trusted.
+  # The same gate also identifies documentation-only PRs.
+  ci-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.trusted.outputs.approved || steps.pr.outputs.approved }}
+      docs_only: ${{ steps.trusted.outputs.docs_only || steps.pr.outputs.docs_only }}
+    steps:
+      - name: Allow trusted non-PR runs
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        id: trusted
+        shell: bash
+        run: |
+          echo "approved=true" >> "$GITHUB_OUTPUT"
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check approval and changed files
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number, per_page: 100 },
+            );
+            const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const decisiveReviews = new Map();
+            for (const review of reviews) {
+              if (!review.user || !trustedAssociations.has(review.author_association)) {
+                continue;
+              }
+              if (!["APPROVED", "CHANGES_REQUESTED", "DISMISSED"].includes(review.state)) {
+                continue;
+              }
+              const previous = decisiveReviews.get(review.user.id);
+              if (!previous || review.id > previous.id) {
+                decisiveReviews.set(review.user.id, review);
+              }
+            }
+            const approved = [...decisiveReviews.values()].some(
+              (review) => review.state === "APPROVED",
+            );
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number, per_page: 100 },
+            );
+            const isDocumentation = (filename) => {
+              if (filename.startsWith("docs/")) {
+                return true;
+              }
+              if (
+                filename.startsWith(".github/ISSUE_TEMPLATE/") ||
+                filename.startsWith(".github/PULL_REQUEST_TEMPLATE/")
+              ) {
+                return true;
+              }
+              if (/\.(md|mdx|rst)$/i.test(filename)) {
+                return true;
+              }
+              return /^(LICENSE|NOTICE|CITATION\.cff)$/i.test(filename);
+            };
+            const docsOnly = files.length > 0 && files.every(
+              (file) =>
+                isDocumentation(file.filename) &&
+                (!file.previous_filename || isDocumentation(file.previous_filename)),
+            );
+
+            core.setOutput("approved", String(approved));
+            core.setOutput("docs_only", String(docsOnly));
+            core.info(
+              `CI gate: approved=${approved}, docs_only=${docsOnly}, changed_files=${files.length}`,
+            );
+
   # Nothing rebuilds the CI image for a PR, so a docker PR would otherwise be tested inside the old `latest`.
   docker-paths:
-    if: github.event_name == 'pull_request'
+    needs: [ci-gate]
+    if: |
+      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.docs_only != 'true' &&
+      github.event_name != 'workflow_dispatch' &&
+      github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:
       - uses: actions/checkout@v4
         with:
+          # pull_request_review otherwise checks out the default branch.
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 2
           persist-credentials: false
       - id: diff
@@ -94,6 +184,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -114,10 +206,12 @@ jobs:
         run: docker image prune -f
 
   resolve-ci-image:
-    needs: [docker-build]
+    needs: [ci-gate, docker-build]
     # A failed build must skip this job so the GPU stages' `success` guard stops the matrix.
     if: |
       always() && !cancelled() &&
+      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.docs_only != 'true' &&
       (needs.docker-build.result == 'success' || needs.docker-build.result == 'skipped') &&
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
     runs-on: ubuntu-latest
@@ -148,32 +242,34 @@ jobs:
           echo "container_image=rockdu/miles_diffusion:${CI_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved CI image: rockdu/miles_diffusion:${CI_IMAGE_TAG}"
 
-  # Stage A: CPU-only fast tests (always runs on PR)
+  # Stage A: CPU-only fast tests. PRs require approval; docs-only PRs run
+  # the full CPU suite and stop before the GPU stages.
   stage-a-cpu:
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request)
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.approved == 'true'
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-a-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.ci-gate.outputs.docs_only == 'true' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
         ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
   # Stage B: CPU-only slower bucket (currently empty; reserved for future
-  # CPU tests that don't fit stage-a-cpu's fast budget). Always runs on PR.
+  # CPU tests that don't fit stage-a-cpu's fast budget). Runs after stage A.
   # Empty result exits 0 in run_suite.py.
   stage-b-cpu:
-    needs: [stage-a-cpu]
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request)
+    needs: [ci-gate, stage-a-cpu]
+    if: needs.ci-gate.outputs.approved == 'true' && needs.stage-a-cpu.result == 'success'
     uses: ./.github/workflows/_run-ci.yml
     with:
       cpu_runner: true
       execute_command: >-
         python tests/ci/run_suite.py --hw cpu --suite stage-b-cpu
         --labels ${{ join(github.event.pull_request.labels.*.name, ' ') }}
-        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
+        ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.ci-gate.outputs.docs_only == 'true' || contains(github.event.pull_request.labels.*.name, 'run-ci-image') || contains(github.event.pull_request.labels.*.name, 'run-ci-all')) && '--match-all-labels' || '' }}
         ${{ github.event_name == 'schedule' && '--nightly' || '' }}
     secrets: inherit
 
@@ -182,9 +278,11 @@ jobs:
   # guards are load-bearing: docker-build skips on non-docker PRs, and a bare
   # `if` would inherit that skip and cascade it downstream (#67 regression).
   stage-b-3-gpu-h200:
-    needs: [resolve-ci-image, stage-a-cpu]
+    needs: [ci-gate, resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
+      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.docs_only != 'true' &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))
@@ -202,9 +300,11 @@ jobs:
 
   # Stage B GPU: 4-GPU distributed tests on the 5gpu runner.
   stage-b-5-gpu-h200:
-    needs: [resolve-ci-image, stage-a-cpu]
+    needs: [ci-gate, resolve-ci-image, stage-a-cpu]
     if: |
       always() && !cancelled() &&
+      needs.ci-gate.outputs.approved == 'true' &&
+      needs.ci-gate.outputs.docs_only != 'true' &&
       needs.resolve-ci-image.result == 'success' &&
       needs.stage-a-cpu.result == 'success' &&
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule') || (github.event.pull_request))

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -140,6 +140,11 @@ jobs:
             core.info(
               `CI gate: approved=${approved}, docs_only=${docsOnly}, changed_files=${files.length}`,
             );
+            if (!approved) {
+              core.setFailed(
+                "PR CI requires an approval from a repository owner, member, or collaborator.",
+              );
+            }
 
   # Nothing rebuilds the CI image for a PR, so a docker PR would otherwise be tested inside the old `latest`.
   docker-paths:

--- a/tests/ci/labels.py
+++ b/tests/ci/labels.py
@@ -11,9 +11,11 @@ Adding a new label:
    The workflow does not need editing -- the generic stage job filters tests
    by labels at runtime.
 
-The meta-labels `run-ci-image` / `run-ci-all` are intentionally NOT listed
-here: they bypass the per-test labels filter and run the full suite via the
-`--match-all-labels` flag (handled in run_suite.py).
+The meta-labels are intentionally NOT listed here:
+* `run-ci-basic` authorizes CI but matches no domain, so only tests without
+  labels run.
+* `run-ci-image` / `run-ci-all` authorize CI and bypass the per-test labels
+  filter via `--match-all-labels` (handled in run_suite.py).
 """
 
 KNOWN_LABELS: dict[str, str] = {


### PR DESCRIPTION
## What
- Accept either a trusted review approval or a maintainer-applied `run-ci-*` label as authorization to start PR CI.
- Add `run-ci-basic` for running only the existing unlabeled basic suites; domain labels continue to run basic plus their selected tests.
- Detect documentation-only PRs and run the full CPU suites without scheduling Docker builds or GPU stages.
- Preserve trusted nightly/manual runs and explicitly check out the PR merge ref for review-triggered runs.

## Why
GitHub does not allow PR authors to approve their own changes, while this repository has changes that only one maintainer may be able to review. Label authorization follows the Miles CI model: applying labels already requires trusted repository permission, so maintainers can explicitly spend CI capacity without manufacturing a second-party review.

## Validation
- `actionlint -shellcheck='' .github/workflows/pr-test.yml .github/workflows/_run-ci.yml`
- `git diff --check`

## Files
- `.github/workflows/pr-test.yml` — adds review/label authorization and documentation classification, then gates CPU, Docker, and GPU jobs.
- `.github/workflows/_run-ci.yml` — checks out the PR merge ref when a review event triggers the reusable workflow.
- `tests/ci/labels.py` — documents `run-ci-basic` as a meta-label that selects only unlabeled tests.

## Checklist
- [ ] `pre-commit run --all-files` passes — **not run locally**
- [ ] Added/updated tests for new behaviour — **workflow-only change; no automated workflow tests added**
- [ ] `pytest -x` is green — **not run; no Python runtime code changed**
- [ ] If launch flags changed, `python3 train.py --help` still parses — **not applicable**
- [ ] If a public flag was added, it appears in the CLI reference docs — **not applicable**
- [ ] If an example was added, it has a real walkthrough — **not applicable**