### PR TITLE
docs: use GitHub-relative paths for inter-page links

### DIFF
--- a/docs/advanced/deterministic.md
+++ b/docs/advanced/deterministic.md
@@ -80,7 +80,7 @@ same rollout data.
 across ranks, so a 4-rank and an 8-rank run will not match even in deterministic mode. Setting
 `--fsdp-reduce-dtype bf16` is **strongly not recommended**; keep the `fp32` default.
 - **Train/rollout agreement.** Determinism removes run-to-run variance; it does not make the two
-forwards equal. That is a precision problem — see [Dtype Control](/advanced/dtype-control).
+forwards equal. That is a precision problem — see [Dtype Control](dtype-control.md).
 
 ## Cost
 
@@ -104,5 +104,5 @@ Because reward metrics are compared too, the CI recipes also pin the engine side
 
 ## Related
 
-- [Dtype Control](/advanced/dtype-control) — the other half of train/rollout numeric agreement.
+- [Dtype Control](dtype-control.md) — the other half of train/rollout numeric agreement.
 

--- a/docs/advanced/lora.md
+++ b/docs/advanced/lora.md
@@ -46,7 +46,7 @@ colocation, CUDA IPC handles cannot cross the train/rollout process boundary.
 
 LoRA target modules default from the model family's
 `TrainPipelineConfig.lora_target_modules`. For SD3, see
-[SD3 model guide](/models/sd3/sd3).
+[SD3 model guide](../models/sd3/sd3.md).
 
 ## 3. Three weight-sync strategies
 

--- a/docs/advanced/sde-backend.md
+++ b/docs/advanced/sde-backend.md
@@ -82,6 +82,6 @@ Checklist:
 
 ## 5. Pairs well with
 
-- [Customization](/user-guide/customization) — `--diffusion-step-strategy-path` and `--sde-step-backend-path`.
-- [SD3 model guide](/models/sd3/sd3) — Flow-GRPO vs NFT recipe flags.
-- [Quick Start](/getting-started/quick-start) — SD3.5 Flow-GRPO OCR walkthrough.
+- [Customization](../user-guide/customization.md) — `--diffusion-step-strategy-path` and `--sde-step-backend-path`.
+- [SD3 model guide](../models/sd3/sd3.md) — Flow-GRPO vs NFT recipe flags.
+- [Quick Start](../getting-started/quick-start.md) — SD3.5 Flow-GRPO OCR walkthrough.

--- a/docs/advanced/single-prompt-multi-gen.md
+++ b/docs/advanced/single-prompt-multi-gen.md
@@ -50,12 +50,12 @@ microgroup_seed = seed_base + idx   # idx = offset of the microgroup in its grou
 ```
 
 `group_index` is monotonic across the run, so every `(rollout, prompt-group, sample)` triple gets a distinct seed. This
-is what makes rollout replay and [deterministic mode](/advanced/deterministic) possible at microgroup granularity.
+is what makes rollout replay and [deterministic mode](deterministic.md) possible at microgroup granularity.
 
 
 ## 3. Pairs well with
 
-- [Streaming Reward and Deserialization](/advanced/streaming-reward) — what happens to a microgroup response after
+- [Streaming Reward and Deserialization](streaming-reward.md) — what happens to a microgroup response after
   generation.
-- [Deterministic Training](/advanced/deterministic) — seed layout is half of run reproducibility.
-- [Core Concepts](/user-guide/concepts) — where microgroup size sits among the batch knobs.
+- [Deterministic Training](deterministic.md) — seed layout is half of run reproducibility.
+- [Core Concepts](../user-guide/concepts.md) — where microgroup size sits among the batch knobs.

--- a/docs/advanced/streaming-reward.md
+++ b/docs/advanced/streaming-reward.md
@@ -64,7 +64,7 @@ microgroup = await generate_microgroup(...)   # generate + deserialize
 rewards    = await batched_async_rm(args, microgroup)   # score right away
 ```
 
-Reward workers are Ray actor pools (see [Rewards](/user-guide/rewards) for per-reward flags), so scoring one microgroup
+Reward workers are Ray actor pools (see [Rewards](../user-guide/rewards.md) for per-reward flags), so scoring one microgroup
 overlaps with generation and deserialization of the others.
 
 ## 4. Diagnosing the pipeline
@@ -84,8 +84,4 @@ For quick triage from `perf/*` metrics alone:
 | `perf/rollout_time` high, engines idle between requests | `deserialize` stage time | Raise `--rollout-parser-num-workers`                                       |
 | Rollout stalls at the end of each iteration             | `reward` stage time      | More reward workers, or a dedicated reward GPU                             |
 | Event loop warnings / slow heartbeat                    | main-process CPU         | Confirm parsing is going through the actor pool (it always does on `main`) |
-
-## 5. Pairs well with
-
-- [Monitoring](/user-guide/monitoring) — the `perf/*` metrics referenced above.
 

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -207,7 +207,7 @@ The body explains **why**; the diff already shows what.
 - [ ] `pre-commit run --all-files` passes.
 - [ ] `pytest tests/fast -x -q` is green.
 - [ ] `python3 train_diffusion.py --help` still parses (any argparse change).
-- [ ] A new public flag is documented in [CLI Reference](/user-guide/cli-reference).
+- [ ] A new public flag is documented in [CLI Reference](../user-guide/cli-reference.md).
 - [ ] A new model family has a page under `docs/models/`.
 - [ ] Numeric changes are called out, and e2e standards re-recorded if they moved.
 - [ ] New behaviour has a test, registered with the right suite and label.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -167,6 +167,6 @@ so the floor is set by whichever of the two needs more memory, not by their sum.
 
 ## Next
 
-- [Launch Scripts](/user-guide/launch-script) — what a launch script does and how to override a
+- [Launch Scripts](../user-guide/launch-script.md) — what a launch script does and how to override a
   recipe.
-- [CLI Reference](/user-guide/cli-reference) — every flag.
+- [CLI Reference](../user-guide/cli-reference.md) — every flag.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,7 @@ Installation and environment setup are documented separately — this page start
 inside a ready container or machine.
 
 Deeper SD3 recipe config, reference curves, and the DiffusionNFT + PickScore
-recipe are in the [SD3 model guide](/models/sd3/sd3).
+recipe are in the [SD3 model guide](../models/sd3/sd3.md).
 
 ## 1. Start the container
 
@@ -78,7 +78,7 @@ hf download --repo-type dataset rockdu/miles-diffusion-datasets \
 |---|---|
 | Train | `${DATASETS_DIR}/flowgrpo_ocr/train.jsonl` |
 
-See [Rewards](/user-guide/rewards) for OCR scoring and prompt format.
+See [Rewards](../user-guide/rewards.md) for OCR scoring and prompt format.
 
 ## 3. Launch training
 
@@ -144,7 +144,7 @@ Which denoising steps enter the loss is selected by a **step strategy**
 | `sde_window` | Random contiguous window (this recipe) | `--diffusion-num-sde-steps 10`, `--diffusion-sde-window-range 0,10` |
 | `epoch_global_random_choice` | Per-epoch random subset of candidate steps | `--diffusion-sde-candidate-steps …`, `--diffusion-num-sde-steps` |
 
-Train-side dynamics and more on these strategies: [SDE step backend](/advanced/sde-backend).
+Train-side dynamics and more on these strategies: [SDE step backend](../advanced/sde-backend.md).
 
 **DiffusionNFT + PickScore** (3 GPUs, ODE, EMA reference) is a separate recipe
 covered in the SD3 model guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,11 @@ reproducible.
   architectures plug in without touching the trainer.
 - **LoRA training with ipc-handle weight sync.** PEFT LoRA on the FSDP2 actor; each iteration ships only
   `lora_A`/`lora_B` pairs to the rollout engines over CUDA IPC and merges them engine-side — no full-weight transfer, no
-  separate merge or conversion step. See [LoRA Training and Weight Sync](/advanced/lora).
+  separate merge or conversion step. See [LoRA Training and Weight Sync](advanced/lora.md).
 - **Quality control on three fronts.** Deterministic mode makes runs bitwise reproducible and backs the CI e2e
   regression suite; sglang-side monkey patches manage train/rollout alignment; and an FSDP2 param-dtype patch manages
   precision — by providing per-parameter level fp32 precision control over FSDP2 under the mixed-precision policy. See
-  [Deterministic Training](/advanced/deterministic) and [Dtype Control](/advanced/dtype-control).
+  [Deterministic Training](advanced/deterministic.md) and [Dtype Control](advanced/dtype-control.md).
 - **SFT, DiffusionNFT, and Flow-GRPO under one trainer.** The loss type, training-batch preparation, rollout function,
   and reward function are all **replaceable components**, so integrating a new algorithm — or swapping in your own
   customized component — is easy.
@@ -38,17 +38,17 @@ reproducible.
 ## Supported models
 
 Each model name links to its recipe page. Every documented recipe is labeled with a
-[recipe verification level](/user-guide/recipe-verification).
+[recipe verification level](user-guide/recipe-verification.md).
 
 
 | Model                                                   | Task      | Canonical recipes                         |
 | ------------------------------------------------------- | --------- | ----------------------------------------- |
-| [Stable Diffusion 3.5](/models/sd3/sd3)                 | T2I       | Flow-GRPO + OCR, DiffusionNFT + PickScore |
-| [Qwen-Image](/models/qwen-image/qwen-image)             | T2I       | Flow-GRPO + PickScore (flow_grpo-aligned) |
-| [Wan2.2-T2V-A14B](/models/wan/wan2-2)                   | T2V       | Flow-GRPO + PickScore, LoRA SFT           |
-| [LTX-2.3](/models/ltx/ltx2)                             | T2V       | Flow-GRPO + PickScore                     |
-| [Cosmos3 (Edge / Nano / Super)](/models/cosmos/cosmos3) | T2I       | Flow-GRPO + PickScore                     |
-| [MiniMax H3](/models/h3/h3)                             | T2VA      | **Not merged** — [PR #154](https://github.com/radixark/miles_diffusion/pull/154); 2-GPU recipe; large-scale coming soon |
+| [Stable Diffusion 3.5](models/sd3/sd3.md)                 | T2I       | Flow-GRPO + OCR, DiffusionNFT + PickScore |
+| [Qwen-Image](models/qwen-image/qwen-image.md)             | T2I       | Flow-GRPO + PickScore (flow_grpo-aligned) |
+| [Wan2.2-T2V-A14B](models/wan/wan2-2.md)                   | T2V       | Flow-GRPO + PickScore, LoRA SFT           |
+| [LTX-2.3](models/ltx/ltx2.md)                             | T2V       | Flow-GRPO + PickScore                     |
+| [Cosmos3 (Edge / Nano / Super)](models/cosmos/cosmos3.md) | T2I       | Flow-GRPO + PickScore                     |
+| [MiniMax H3](models/h3/h3.md)                             | T2VA      | **Not merged** — [PR #154](https://github.com/radixark/miles_diffusion/pull/154); 2-GPU recipe; large-scale coming soon |
 
 
 
@@ -74,13 +74,12 @@ Each model name links to its recipe page. Every documented recipe is labeled wit
 
 ## Start here
 
-1. **[Installation](/getting-started/installation)** — Docker image, pinned dependency versions, bare-metal setup.
-2. **[Quick Start](/getting-started/quick-start)** — a working Flow-GRPO run on SD3.5 with 2 GPUs.
-3. **[Core Concepts](/user-guide/concepts)** — the four objects in every miles-diffusion job and the loop that connects
+1. **[Installation](getting-started/installation.md)** — Docker image, pinned dependency versions, bare-metal setup.
+2. **[Quick Start](getting-started/quick-start.md)** — a working Flow-GRPO run on SD3.5 with 2 GPUs.
+3. **[Core Concepts](user-guide/concepts.md)** — the four objects in every miles-diffusion job and the loop that connects
    them.
-4. **[Training Script Walkthrough](/user-guide/training-script-walkthrough)** — every argument group in a launch script,
-   annotated.
-5. **[Rewards](/user-guide/rewards)** — built-in reward models and custom reward hooks.
+4. **[Launch Scripts](user-guide/launch-script.md)** — every argument group in a launch script, annotated.
+5. **[Rewards](user-guide/rewards.md)** — built-in reward models and custom reward hooks.
 6. **Model guides** — per-model config and recipes, starting from the [supported models](#supported-models) table above.
 
 

--- a/docs/models/cosmos/cosmos3.md
+++ b/docs/models/cosmos/cosmos3.md
@@ -58,7 +58,7 @@ From `miles/backends/fsdp_utils/configs/cosmos3.py`:
 Canonical recipe: `scripts/run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` — train, rollout,
 and PickScore colocated on 4 GPUs; T2I (832×480, 1 frame).
 
-**Status:** [📈 V — Verified](/user-guide/recipe-verification#v)
+**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
 
 ```bash
 export SGLANG_DISABLE_COSMOS3_GUARDRAILS=1   # RL scores raw samples; skip serving-side guardrail models
@@ -87,6 +87,6 @@ The 4-GPU colocated Cosmos3-Nano recipe raises PickScore
 
 ## 7. Pairs well with
 
-- [LoRA Training and Weight Sync](/advanced/lora) — GEN-tower LoRA sync.
-- [Rewards](/user-guide/rewards) — PickScore worker pool configuration.
+- [LoRA Training and Weight Sync](../../advanced/lora.md) — GEN-tower LoRA sync.
+- [Rewards](../../user-guide/rewards.md) — PickScore worker pool configuration.
 

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -25,7 +25,7 @@ branch only — the audio stream is rolled out but not trained.
 
 ## 3. Setup
 
-H3 is not on `main` of either repo. Finish [Installation](/getting-started/installation) first
+H3 is not on `main` of either repo. Finish [Installation](../../getting-started/installation.md) first
 (Docker image or from source), then move **both** halves onto the open PRs — a `main` trainer
 against a `main` engine will not run this recipe.
 
@@ -60,7 +60,7 @@ The 2-GPU recipe lives on [PR #154](https://github.com/radixark/miles_diffusion/
 (sglang pins `short_edge=768`, so the canvas is 1344×768 / 107 frames). Requires `--use-lora --lora-ipc-weight-sync`
 (the recipe already sets both).
 
-**Status:** [📈 V — Verified](/user-guide/recipe-verification#v)
+**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
 
 ```bash
 # alignment check (optimizer frozen)

--- a/docs/models/ltx/ltx2.md
+++ b/docs/models/ltx/ltx2.md
@@ -37,7 +37,7 @@ Registered in `miles/backends/fsdp_utils/configs/ltx.py`:
 | Property | Value | Why |
 |---|---|---|
 | Velocity → noise | `forward_velocity` reconstructs x0 via `ltx_core.utils.to_denoised` in fp32 and divides back out | Algebraically an identity, but the fp32 rounding path is what the e2e standards were recorded against |
-| Boundary dtypes | `latents` / `cond` cast to the forward dtype, `timestep` passthrough | Element-wise math anchors on `latents.dtype` and rollout runs bf16 — see [Dtype Control](/advanced/dtype-control) |
+| Boundary dtypes | `latents` / `cond` cast to the forward dtype, `timestep` passthrough | Element-wise math anchors on `latents.dtype` and rollout runs bf16 — see [Dtype Control](../../advanced/dtype-control.md) |
 | Precision | bf16 end to end (master, reduce, forward, engine) + math-SDPA on both sides | Matches the original bitwise E2E reference; math-SDPA is deterministic by construction |
 | SDE | CPS kernel, `sde_timestep_divisor = 1000.0` | σ comes straight from the carried rollout timesteps rather than a scheduler lookup; log-prob drops its constants |
 | LoRA targets | Attention + FFN: `to_q`, `to_k`, `to_v`, `to_out.0`, `net.0.proj`, `net.2` | |
@@ -48,7 +48,7 @@ Registered in `miles/backends/fsdp_utils/configs/ltx.py`:
 Canonical recipe: `scripts/run_diffusion_grpo_ltx23_sglang.py` — 4 colocate GPUs + 1 PickScore
 GPU, 57 frames @ 24 fps, 512×768, PickScore reward.
 
-**Status:** [🛡️ FG — Fully gated](/user-guide/recipe-verification#fg)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 python3 scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -80,6 +80,6 @@ A future LTX update will make `train/model_output_mean_abs_diff` **0.0** and swi
 
 ## 7. Pairs well with
 
-- [Dtype Control](/advanced/dtype-control) — the boundary-dtype policy is why LTX has one.
-- [Deterministic Training](/advanced/deterministic) — `sdpa_math` is the deterministic-safe
+- [Dtype Control](../../advanced/dtype-control.md) — the boundary-dtype policy is why LTX has one.
+- [Deterministic Training](../../advanced/deterministic.md) — `sdpa_math` is the deterministic-safe
   backend this recipe relies on.

--- a/docs/models/qwen-image/qwen-image.md
+++ b/docs/models/qwen-image/qwen-image.md
@@ -48,7 +48,7 @@ Registered in `miles/backends/fsdp_utils/configs/qwen_image.py`:
 Canonical recipe: `scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` — 4 colocate
 GPUs + 1 PickScore GPU, 512×512, PickScore reward.
 
-**Status:** [📈 V — Verified](/user-guide/recipe-verification#v)
+**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
 
 ```bash
 python3 scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -69,6 +69,6 @@ Overrides go through the dataclass CLI, e.g.
 
 ## 6. Pairs well with
 
-- [LoRA weight sync](/advanced/lora) — `--lora-ipc-weight-sync` is on in this recipe.
-- [Dtype Control](/advanced/dtype-control) — why fp32 master + bf16 forward.
-- [Deterministic Training](/advanced/deterministic) — `--deterministic-mode` is on.
+- [LoRA weight sync](../../advanced/lora.md) — `--lora-ipc-weight-sync` is on in this recipe.
+- [Dtype Control](../../advanced/dtype-control.md) — why fp32 master + bf16 forward.
+- [Deterministic Training](../../advanced/deterministic.md) — `--deterministic-mode` is on.

--- a/docs/models/sd3/sd3.md
+++ b/docs/models/sd3/sd3.md
@@ -108,7 +108,7 @@ All recipes are Python modules under `scripts/`. Each exposes a Typer CLI
 
 Canonical script: `scripts/run_diffusion_grpo_sd3_ocr_sglang.py`
 
-**Status:** [🛡️ FG — Fully gated](/user-guide/recipe-verification#fg)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 export HF_TOKEN=...
@@ -116,7 +116,7 @@ python3 scripts/run_diffusion_grpo_sd3_ocr_sglang.py \
   --cuda-visible-devices 6,7
 ```
 
-Walkthrough: [Quick Start](/getting-started/quick-start).
+Walkthrough: [Quick Start](../../getting-started/quick-start.md).
 
 This script prepends `master_sglang` to `PYTHONPATH` for native SD3
 `/rollout/generate` support. See the module docstring for details.
@@ -127,7 +127,7 @@ E2E test: `tests/e2e/short/test_sd3_ocr_grpo_2xGPU.py`.
 
 Script: `scripts/run_diffusion_nft_sd3_pickscore.py`
 
-**Status:** [📈 V — Verified](/user-guide/recipe-verification#v)
+**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
 
 ```bash
 export HF_TOKEN=...
@@ -208,7 +208,7 @@ Both SD3 recipes use LoRA with IPC weight sync:
 --update-weight-buffer-size 2147483648
 ```
 
-See [LoRA weight sync](/advanced/lora) for the three updater paths and IPC
+See [LoRA weight sync](../../advanced/lora.md) for the three updater paths and IPC
 merge internals.
 
 ## 8. Precision notes
@@ -229,7 +229,7 @@ Flow-GRPO recipes also set **`--diffusion-clip-range`** (e.g. `1e-4` in the OCR
 script) to clip importance ratios during the policy update.
 
 Train/rollout dtype alignment for Flow-GRPO is covered in
-[SDE step backend](/advanced/sde-backend).
+[SDE step backend](../../advanced/sde-backend.md).
 
 ## 9. Reference results
 
@@ -255,8 +255,8 @@ Online runs: wandb project **`miles-diffusion-nft`**. Held-out
 
 ## 10. Pairs well with
 
-- [Quick Start](/getting-started/quick-start) — SD3.5 Flow-GRPO OCR walkthrough.
-- [Rewards](/user-guide/rewards) — OCR and PickScore scoring.
-- [Customization](/user-guide/customization) — `--*-path` plug-points.
-- [SDE step backend](/advanced/sde-backend) — SDE window (GRPO) vs ODE (NFT).
-- [LoRA weight sync](/advanced/lora) — IPC merge used by both recipes.
+- [Quick Start](../../getting-started/quick-start.md) — SD3.5 Flow-GRPO OCR walkthrough.
+- [Rewards](../../user-guide/rewards.md) — OCR and PickScore scoring.
+- [Customization](../../user-guide/customization.md) — `--*-path` plug-points.
+- [SDE step backend](../../advanced/sde-backend.md) — SDE window (GRPO) vs ODE (NFT).
+- [LoRA weight sync](../../advanced/lora.md) — IPC merge used by both recipes.

--- a/docs/models/wan/wan2-2.md
+++ b/docs/models/wan/wan2-2.md
@@ -46,7 +46,7 @@ Registered in `miles/backends/fsdp_utils/configs/wan2_2.py`:
 
 Canonical recipe: `scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py`
 
-**Status:** [○ NV — Not verified](/user-guide/recipe-verification#nv)
+**Status:** [○ NV — Not verified](../../user-guide/recipe-verification.md#nv)
 
 ```bash
 python3 scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
@@ -57,9 +57,9 @@ python3 scripts/run_diffusion_grpo_wan22_pickscore_5gpu.py
 
 Recipe: `scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py`
 (full finetune, no LoRA, true on-policy). Start the
-[multi-node Ray cluster](/user-guide/launch-script#multi-node-training), then run on the head node:
+[multi-node Ray cluster](../../user-guide/launch-script.md#multi-node-training), then run on the head node:
 
-**Status:** [🧩 PG — Proxy gated](/user-guide/recipe-verification#pg)
+**Status:** [🧩 PG — Proxy gated](../../user-guide/recipe-verification.md#pg)
 
 ```bash
 MILES_SCRIPT_EXTERNAL_RAY=1 python3 scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py
@@ -71,7 +71,7 @@ MILES_SCRIPT_EXTERNAL_RAY=1 python3 scripts/run_diffusion_grpo_wan22_pickscore_1
 
 Recipe: `scripts/run_diffusion_sft_wan22.py`
 
-**Status:** [○ NV — Not verified](/user-guide/recipe-verification#nv)
+**Status:** [○ NV — Not verified](../../user-guide/recipe-verification.md#nv)
 
 ```bash
 MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_wan22.py
@@ -100,8 +100,8 @@ MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_wan22.
 
 ## 6. Pairs well with
 
-- [Single-Prompt Multi-Generation](/advanced/single-prompt-multi-gen) — the microgroup mechanics behind
+- [Single-Prompt Multi-Generation](../../advanced/single-prompt-multi-gen.md) — the microgroup mechanics behind
   `--rollout-microgroup-size 8`.
-- [LoRA Training and Weight Sync](/advanced/lora) — IPC merge used by the GRPO recipe.
-- [SDE Step Backend](/advanced/sde-backend) — how the trained SDE step is scored train-side.
-- [Rewards](/user-guide/rewards) — PickScore worker pool configuration.
+- [LoRA Training and Weight Sync](../../advanced/lora.md) — IPC merge used by the GRPO recipe.
+- [SDE Step Backend](../../advanced/sde-backend.md) — how the trained SDE step is scored train-side.
+- [Rewards](../../user-guide/rewards.md) — PickScore worker pool configuration.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -66,7 +66,7 @@ do not.
 | `--num-epoch` | – | Alternative to `--num-rollout`; ignored if both are set. |
 
 To check how these batch-related arguments interact and related to each other — see
-[the batch-knob invariant](/user-guide/concepts#the-batch-knob-invariant).
+[the batch-knob invariant](concepts.md#the-batch-knob-invariant).
 
 ### Diffusion sampling
 
@@ -89,7 +89,7 @@ To check how these batch-related arguments interact and related to each other �
 | `--fsdp-master-dtype` | `fp32` | Sharded master weights and optimizer state. |
 | `--fsdp-reduce-dtype` | `fp32` | Gradient reduce-scatter. |
 
-See [Dtype Control](/advanced/dtype-control).
+See [Dtype Control](../advanced/dtype-control.md).
 
 ### Algorithm
 
@@ -139,7 +139,7 @@ See [Dtype Control](/advanced/dtype-control).
 | `--fsdp-attention-backend` | str | – | diffusers `set_attention_backend` value. |
 | `--fsdp-flow-shift` | float | – | Training-side sigma grid shift, regenerated when no engine supplies scheduler meta (SFT). Distinct from `--diffusion-flow-shift`. |
 | `--gradient-checkpointing` | flag | off | |
-| `--deterministic-mode` | flag | off | See [Deterministic Training](/advanced/deterministic). |
+| `--deterministic-mode` | flag | off | See [Deterministic Training](../advanced/deterministic.md). |
 | `--train-env-vars` | JSON | `{}` | Extra env for the training processes. |
 
 ### Optimizer and schedule

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -110,9 +110,8 @@ tbd
 
 ## Next
 
-- [Training Script Walkthrough](/user-guide/training-script-walkthrough) — a canonical launcher, group by group.
-- [Rewards](/user-guide/rewards) — `rm_hub`, custom reward functions, prompt data format.
-- [CLI Reference](/user-guide/cli-reference) — every flag, fully cataloged.
-- [SDE Step Backend](/advanced/sde-backend) — how train-side log-probs mirror rollout stepping.
-- [Monitoring](/user-guide/monitoring) — the metrics that tell you whether a run is healthy.
+- [Launch Scripts](launch-script.md) — a canonical launcher, group by group.
+- [Rewards](rewards.md) — `rm_hub`, custom reward functions, prompt data format.
+- [CLI Reference](cli-reference.md) — every flag, fully cataloged.
+- [SDE Step Backend](../advanced/sde-backend.md) — how train-side log-probs mirror rollout stepping.
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -102,14 +102,14 @@ def strategy(args, sample, num_steps, seed) -> tuple[list[int] | None, list[int]
 | `sde_window` | Random contiguous window (`--diffusion-num-sde-steps`, `--diffusion-sde-window-range`) |
 | `epoch_global_random_choice` | Per-epoch subset of `--diffusion-sde-candidate-steps` |
 
-Details: [SDE step backend](/advanced/sde-backend).
+Details: [SDE step backend](../advanced/sde-backend.md).
 
 ***
 
 ## Reward
 
 Built-in scorers (`--rm-type pickscore` / `ocr`) are documented in
-[Rewards](/user-guide/rewards). The hooks below replace that dispatch entirely.
+[Rewards](rewards.md). The hooks below replace that dispatch entirely.
 
 ### `--custom-rm-path`
 
@@ -263,7 +263,7 @@ def loss_formula(ctx, batch, prepared, *, new_pred, ref_pred, metrics, **kwargs)
 **Class** implementing `SdeStepBackend`. Auto-selected from
 `--diffusion-sde-type` (`sde` / `ode` → `DiffusersSdeStepBackend`, `cps` →
 `CpsSdeStepBackend`) unless overridden. See
-[SDE step backend](/advanced/sde-backend).
+[SDE step backend](../advanced/sde-backend.md).
 
 ***
 
@@ -318,7 +318,7 @@ flags into a forked recipe.)
 
 ## Pairs well with
 
-- [Rewards](/user-guide/rewards) — built-in PickScore / OCR and prompt JSONL.
-- [SDE step backend](/advanced/sde-backend) — step strategies and SDE kernels.
-- [LoRA weight sync](/advanced/lora) — IPC merge path used by most recipes.
-- [SD3 model guide](/models/sd3/sd3) — end-to-end recipe flags.
+- [Rewards](rewards.md) — built-in PickScore / OCR and prompt JSONL.
+- [SDE step backend](../advanced/sde-backend.md) — step strategies and SDE kernels.
+- [LoRA weight sync](../advanced/lora.md) — IPC merge path used by most recipes.
+- [SD3 model guide](../models/sd3/sd3.md) — end-to-end recipe flags.

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -9,7 +9,7 @@ python3 scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
 ```
 
 This page explains what that command does and how to change what it runs. For the meaning of
-individual flags, see the [CLI Reference](/user-guide/cli-reference).
+individual flags, see the [CLI Reference](cli-reference.md).
 
 ## How a launch script starts a training job
 
@@ -137,7 +137,7 @@ train pairs           = samples × (number of SDE step indices)
 ```
 
 The trajectory-level knobs are locked by
-[the batch-knob invariant](/user-guide/concepts#the-batch-knob-invariant); contradictory values
+[the batch-knob invariant](concepts.md#the-batch-knob-invariant); contradictory values
 abort at parse time. `global_batch_size` counts samples and must divide by `dp_size`
 (= train world size ÷ `--sequence-parallel-size`).
 
@@ -258,6 +258,6 @@ Reward workers (`--pickscore-num-workers 4 --pickscore-num-gpus-per-worker 0.25`
 
 ## Next
 
-- [CLI Reference](/user-guide/cli-reference) — every flag, grouped.
-- [Core Concepts](/user-guide/concepts) — what one rollout iteration does, object by object.
-- [Dtype Control](/advanced/dtype-control) — what the three dtype flags actually do.
+- [CLI Reference](cli-reference.md) — every flag, grouped.
+- [Core Concepts](concepts.md) — what one rollout iteration does, object by object.
+- [Dtype Control](../advanced/dtype-control.md) — what the three dtype flags actually do.

--- a/docs/user-guide/rewards.md
+++ b/docs/user-guide/rewards.md
@@ -7,7 +7,7 @@ microgroup. Reward computation lives in `miles/rollout/rm_hub/` and is invoked
 from `sglang_diffusion_rollout.generate_and_rm_microgroup`.
 
 For `--custom-rm-path`, `--custom-reward-post-process-path`, and other
-`--*-path` hooks, see [Customization](/user-guide/customization).
+`--*-path` hooks, see [Customization](customization.md).
 
 ## 1. At a glance
 
@@ -15,7 +15,7 @@ For `--custom-rm-path`, `--custom-reward-post-process-path`, and other
 |---|---|---|
 | Reward type | `--rm-type` | Selects built-in scorer (`pickscore`, `ocr`) |
 | Per-sample override | `metadata.rm_type` in JSONL | Overrides global `--rm-type` |
-| Custom reward / norm | see [Customization](/user-guide/customization) | `--custom-rm-path`, `--custom-reward-post-process-path` |
+| Custom reward / norm | see [Customization](customization.md) | `--custom-rm-path`, `--custom-reward-post-process-path` |
 
 ## 2. Built-in reward models
 
@@ -103,7 +103,7 @@ generate_and_rm_microgroup()
 After rollout, `RolloutManager._post_process_rewards` subtracts the mean and
 optionally divides by std to produce normalized advantages for training.
 Override that path with `--custom-reward-post-process-path` — see
-[Customization](/user-guide/customization) § Reward.
+[Customization](customization.md) § Reward.
 
 ## 4. Prompt data
 


### PR DESCRIPTION
## What

- Switch inter-page docs links from Mintlify `/path` form to GitHub-relative `.md` paths so they resolve in the repo.
- Retarget leftover `training-script-walkthrough` links to `launch-script.md` and drop the `monitoring` links (that page was never written).
- When these docs are ported into Miles under `docs/diffusion/`, the port rewrites every inter-page link back to Mintlify form (`/diffusion/...`, no `.md`) so they resolve on the Miles docs site.

## Why

This repo has no Mintlify `docs.json` / docs site. Absolute `/user-guide/...` links 404 on GitHub (`github.com/user-guide/...`). Relative `.md` paths work here; the Miles port is the step that restores Mintlify paths, namespaced under `/diffusion/` so they do not collide with Miles LLM pages.

## Checklist

- [ ] `pre-commit run --all-files` passes — **not run** (docs-only; commit hooks passed on the touched files)
- [ ] Added/updated tests for new behaviour — **no tests added** (docs-only)
- [ ] `pytest -x` is green — **not run**
- [ ] If launch flags changed, `python3 train.py --help` still parses — **N/A**
- [ ] If a public flag was added, it appears in the CLI reference docs — **N/A**
- [ ] If an example was added, it has a real walkthrough — **N/A**
