### PR TITLE
docs: correct claims and references

### DIFF
--- a/docs/advanced/deterministic.md
+++ b/docs/advanced/deterministic.md
@@ -4,9 +4,8 @@ description: What --deterministic-mode covers, which attention backends it accep
 ---
 
 `--deterministic-mode` configures the **training actor's** forward and backward for repeatable execution with the same
-hardware, topology, software stack, and inputs. Its argument-level gate is not yet complete: it rejects known
-nondeterministic attention backends, but it cannot prove that every selected kernel or operator is deterministic. The
-committed E2E standards demonstrate bit-for-bit repeatability only for the specific recipes they cover.
+hardware, topology, software stack, and inputs. However, some argument gates are still incomplete, so configurations
+that do not support deterministic execution may still pass validation.
 
 ## What it turns on
 

--- a/docs/advanced/deterministic.md
+++ b/docs/advanced/deterministic.md
@@ -3,9 +3,10 @@ title: Deterministic Training
 description: What --deterministic-mode covers, which attention backends it accepts, and what it deliberately does not fix.
 ---
 
-`--deterministic-mode` makes the **training actor's** forward and backward bit-reproducible across
-runs. Most shipped recipes keep it on: when chasing a train/rollout numeric gap, run-to-run noise
-has to be zero before any measurement means anything.
+`--deterministic-mode` configures the **training actor's** forward and backward for repeatable execution with the same
+hardware, topology, software stack, and inputs. Its argument-level gate is not yet complete: it rejects known
+nondeterministic attention backends, but it cannot prove that every selected kernel or operator is deterministic. The
+committed E2E standards demonstrate bit-for-bit repeatability only for the specific recipes they cover.
 
 ## What it turns on
 
@@ -91,8 +92,8 @@ Recipes that need reproducibility more than throughput keep it on permanently.
 ## In CI
 
 The e2e suite is built on this flag. Each test under `tests/e2e/short/` runs a real recipe with
-`--deterministic-mode` for two rollouts and compares every logged metric series — reward
-statistics, old/new log-probs, grad norm — **bit for bit** against a standard committed under
+`--deterministic-mode` for its registered short run (currently two or four rollouts) and compares every registered
+metric series — reward statistics, old/new log-probs, grad norm — **bit for bit** against a standard committed under
 `tests/ci/fixtures/e2e_standards/` (strict unless the test registers a per-metric tolerance).
 Determinism is what makes strict comparison viable: a tolerance wide enough to absorb run-to-run
 noise would also absorb small regressions. Standards are re-recorded by the PR author

--- a/docs/advanced/streaming-reward.md
+++ b/docs/advanced/streaming-reward.md
@@ -27,7 +27,7 @@ Nothing waits for the full batch.
 ## 2. Deserialization: msgpack + parser-actor pool
 
 Trajectory tensors are large — for video models the response for one microgroup can be gigabytes, and encoding tensors
-into base64 further increases the size. In an naive implementation, tensors were base64-encoded inside a JSON body and
+into base64 further increases the size. In a naive implementation, tensors were base64-encoded inside a JSON body and
 parsed on the main asyncio event loop, one sample at a time.
 
 The current path:

--- a/docs/developer/contributor-guide.md
+++ b/docs/developer/contributor-guide.md
@@ -65,7 +65,7 @@ Four tiers, by what they need:
 |---|---|---|
 | `tests/fast/` | CPU only | Argument validation, config registry, dtype-map compilation, loss math, data splitting. The bulk of the suite. |
 | `tests/fast-gpu/` | 1-2 GPUs | FSDP behaviour that only exists on device: param-dtype maps, hybrid shard, SP attention parity, LoRA weight sync. Includes ported upstream PyTorch FSDP tests. |
-| `tests/e2e/short/` | 2-4 GPUs | Runs an actual launch script for a couple of rollouts and compares its **metric series** against a recorded standard. |
+| `tests/e2e/short/` | 2-5 GPUs | Runs an actual launch script for a few rollouts and compares its **metric series** against a recorded standard. |
 | `tests/ci/` | — | The harness itself: registry, label filter, suite runner, e2e standards. |
 
 Run the CPU tier before every push; it is fast and catches most regressions. On a CPU-only box
@@ -123,7 +123,6 @@ them. The canonical registry is `tests/ci/labels.py`:
 | `ray` | Actors and placement groups |
 | `router` | Routing decisions |
 | `arguments` | Top-level argparse / `validate_args` |
-| `model-scripts` | `train_diffusion.py` + `scripts/*.py` smoke tests |
 
 Two meta-labels bypass the filter and run everything: `run-ci-all` and `run-ci-image`.
 
@@ -216,4 +215,3 @@ The body explains **why**; the diff already shows what.
 
 - Design discussion: open a GitHub Issue or Discussion on
   [radixark/miles_diffusion](https://github.com/radixark/miles_diffusion).
-- Security: email security@radixark.ai — do not open a public issue.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,10 +2,11 @@
 title: Installation
 description: Get a working miles-diffusion environment — Docker (recommended) or from source.
 ---
-miles-diffusion trains a diffusion DiT with FSDP2 while [sglang-diffusion](https://github.com/sgl-project/sglang)
-serves the rollout. The two halves must agree numerically, so the pinned versions matter more
-than usual: the rollout engine tracks **sglang main**, not a release tag, and the training side
-pins **torch 2.11.0** (an FSDP monkey patch is version-gated on it).
+miles-diffusion trains a diffusion DiT with FSDP2 while
+[sglang-diffusion](https://github.com/sgl-project/sglang/tree/main/python/sglang/multimodal_gen) serves the rollout.
+The two halves must agree numerically, so the pinned versions matter more than usual: the rollout engine tracks
+**sglang main**, not a release tag, and the training side pins **torch 2.11.0** (an FSDP monkey patch is version-gated
+on it).
 
 Use Docker unless you have a reason not to.
 
@@ -102,9 +103,8 @@ Written against a CUDA 12.9 / Ubuntu 24.04 host, to match the image. Nothing enf
 but the apt versions are unpinned, so another release hands out different versions of the
 apt-sourced dists and the verify step reports drift.
 
-About 20 minutes cold, ~4 with a warm pip cache; six idempotent steps, and `--from STEP`
-resumes a failed run. The last step diffs every installed package against the image's
-snapshot — a clean run ends with:
+The installer has six idempotent steps, and `--from STEP` resumes a failed run. The last step diffs every installed
+package against the image's snapshot — a clean run ends with:
 
 ```
 matched 369   mismatched 0   missing 0   expected-absent 4   extra 0
@@ -149,9 +149,10 @@ On a machine with no sglang GPU kernels installed, install the CPU stubs first, 
 
 | | |
 |---|---|
-| Validated GPUs | H200 — what the CI runners are, and what every shipped recipe was tuned on. The default image pulls a Hopper FlashAttention-3 wheel. |
+| CI hardware | H200. The default image pulls a Hopper FlashAttention-3 wheel. |
 | Minimum for a real run | 2 GPUs — SD3.5-medium LoRA GRPO colocated (`scripts/run_diffusion_grpo_sd3_ocr_sglang.py`) |
-| Typical | 4 train GPUs + 1 dedicated reward GPU (the Qwen-Image / Wan2.2 / LTX recipes) |
+| Dedicated reward layout | 4 train/rollout GPUs + 1 reward GPU (the Qwen-Image, Wan2.2 5-GPU, and LTX recipes) |
+| Fully colocated layout | 4 GPUs shared by train, rollout, and reward (the Cosmos3-Nano recipe) |
 
 Under `--colocate` the training actor and the rollout engines time-share the same GPUs,
 so the floor is set by whichever of the two needs more memory, not by their sum.
@@ -163,7 +164,7 @@ so the floor is set by whichever of the two needs more memory, not by their sum.
 | `HF_TOKEN` | Gated checkpoints. SD3.5 needs it **even when the weights are cached** — sglang still fetches `model_index.json` from the hub at startup. |
 | `WANDB_API_KEY` | Without it the launch scripts silently drop all `--use-wandb` flags. |
 | `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` | Set by every launch script; reduces fragmentation OOMs. |
-| `MILES_DIFFUSION_MODEL_FAMILY` | Escape hatch for family auto-detection. Prefer the `--diffusion-model-family` flag; the env var still wins over both. |
+| `MILES_DIFFUSION_MODEL_FAMILY` | Escape hatch when `--diffusion-model-family` is unset. It overrides checkpoint-name auto-detection, but an explicit CLI family takes precedence. |
 
 ## Next
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -149,7 +149,7 @@ On a machine with no sglang GPU kernels installed, install the CPU stubs first, 
 
 | | |
 |---|---|
-| CI hardware | H200. The default image pulls a Hopper FlashAttention-3 wheel. |
+| CI hardware | H200 |
 | Minimum for a real run | 2 GPUs — SD3.5-medium LoRA GRPO colocated (`scripts/run_diffusion_grpo_sd3_ocr_sglang.py`) |
 | Dedicated reward layout | 4 train/rollout GPUs + 1 reward GPU (the Qwen-Image, Wan2.2 5-GPU, and LTX recipes) |
 | Fully colocated layout | 4 GPUs shared by train, rollout, and reward (the Cosmos3-Nano recipe) |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -149,10 +149,9 @@ On a machine with no sglang GPU kernels installed, install the CPU stubs first, 
 
 | | |
 |---|---|
-| CI hardware | H200 |
+| Validated GPUs | H200 — what the CI runners are, and what every shipped recipe was tuned on. |
 | Minimum for a real run | 2 GPUs — SD3.5-medium LoRA GRPO colocated (`scripts/run_diffusion_grpo_sd3_ocr_sglang.py`) |
-| Dedicated reward layout | 4 train/rollout GPUs + 1 reward GPU (the Qwen-Image, Wan2.2 5-GPU, and LTX recipes) |
-| Fully colocated layout | 4 GPUs shared by train, rollout, and reward (the Cosmos3-Nano recipe) |
+| Typical | 4 train GPUs + 1 dedicated reward GPU (the Qwen-Image / Wan2.2 / LTX recipes) |
 
 Under `--colocate` the training actor and the rollout engines time-share the same GPUs,
 so the floor is set by whichever of the two needs more memory, not by their sum.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ miles-diffusion trains a diffusion DiT with FSDP2 while
 [sglang-diffusion](https://github.com/sgl-project/sglang/tree/main/python/sglang/multimodal_gen) serves the rollout.
 The two halves must agree numerically, so the pinned versions matter more than usual: the rollout engine tracks
 **sglang main**, not a release tag, and the training side pins **torch 2.11.0** (an FSDP monkey patch is version-gated
-on it).
+on it). A future update will upgrade the training stack to **torch 2.13**.
 
 Use Docker unless you have a reason not to.
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,9 +4,8 @@ description: A working Flow-GRPO training job on SD3.5 + OCR — default script 
 ---
 This page takes you from `docker pull` to a running **Flow-GRPO** job on
 **Stable Diffusion 3.5 Medium** with **OCR** reward. The launch script below
-targets **2 GPUs** (colocate train + rollout); a single GPU also works if you
-override the GPU layout. You need Hugging Face access to the gated SD3.5
-checkpoint.
+targets **2 GPUs** (colocate train + rollout). A single-GPU topology is not
+provided or verified. You need Hugging Face access to the gated SD3.5 checkpoint.
 
 Installation and environment setup are documented separately — this page starts
 inside a ready container or machine.
@@ -93,7 +92,7 @@ FSDP actor with LoRA, syncs weights via CUDA IPC (`--lora-ipc-weight-sync`),
 and runs the Flow-GRPO rollout / train loop. With `WANDB_API_KEY` set, images
 and metrics are logged to project `miles-diffusion-grpo`.
 
-After a minute or two you should see rollout/train metrics such as
+Once rollout begins, you should see rollout/train metrics such as
 `rollout/reward/raw_mean`, `train/loss`, and `train/log_prob_mean_abs_diff`
 (stdout and WandB when configured).
 
@@ -133,8 +132,8 @@ flowchart LR
 4. Push updated LoRA weights to rollout engines via `--lora-ipc-weight-sync`.
 
 This recipe uses **Flow-GRPO** (`--loss-type policy_loss`, the default) with
-LoRA-base KL (`--diffusion-kl-beta 0.04`), noise level 0.7, and CFG 4.5.
-`--deterministic-mode` and `--global-batch-size 64` match the CI e2e recipe.
+LoRA-base KL (`--diffusion-kl-beta 0.04`), noise level 0.7, CFG 4.5, and batch-wide reward-standard-deviation
+normalization (`--globalize-reward-std`). `--deterministic-mode` and `--global-batch-size 64` match the CI e2e recipe.
 
 Which denoising steps enter the loss is selected by a **step strategy**
 (`--diffusion-step-strategy-path` in `miles/rollout/step_strategy_hub.py`):

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,36 +1,32 @@
 ---
 title: Miles-Diffusion Documentation
 ---
-Miles-diffusion is [Miles](https://github.com/radixark/miles) for **diffusion models** — RL post-training for any
-diffusion process, across image generation, video generation, and robotics.
-[sglang-diffusion](https://github.com/sgl-project/sglang) serves the rollout, and the DiT trains under **FSDP2** on a
-backend that co-evolves with Miles' own. Models load from a diffusers pipeline, or from a native package when a family
-brings its own modeling. The shipped recipes are tuned and validated end to end. Custom rewards, losses, or rollout
-functions plug in through a flag.
-
-*"A journey of a thousand miles begins with a single rollout."* — For DiT models the rollout is a full denoising
-trajectory, and miles-diffusion focuses on the system work that makes trajectory-level RL stable at scale, efficient,
-and reproducible.
+[Miles-diffusion](https://github.com/radixark/miles_diffusion) is currently a standalone repository built on
+[Miles](https://github.com/radixark/miles)' design philosophy, focused on RL post-training for image and video diffusion
+models. [sglang-diffusion](https://github.com/sgl-project/sglang/tree/main/python/sglang/multimodal_gen) serves the
+rollout, and the DiT trains under **FSDP2** on a backend that co-evolves with Miles' own. Models load from a diffusers
+pipeline, or from a native package when a family brings its own modeling. Shipped recipes carry explicit
+[verification levels](user-guide/recipe-verification.md); not every recipe has a complete training run or a default CI
+gate. Custom rewards, losses, and rollout functions plug in through flags.
 
 ## Core features
 
-- **Fast and stable support for the latest diffusion models.** Launch-ready recipes for Wan2.2-T2V-A14B, Qwen-Image,
+- **Recipes for supported diffusion models.** Launchers for Wan2.2-T2V-A14B, Qwen-Image,
   LTX-2.3, the Cosmos3 MoT omni family, and SD3.5. A per-family `TrainPipelineConfig` isolates model quirks so new
   architectures plug in without touching the trainer.
-- **LoRA training with ipc-handle weight sync.** PEFT LoRA on the FSDP2 actor; each iteration ships only
-  `lora_A`/`lora_B` pairs to the rollout engines over CUDA IPC and merges them engine-side — no full-weight transfer, no
-  separate merge or conversion step. See [LoRA Training and Weight Sync](advanced/lora.md).
-- **Quality control on three fronts.** Deterministic mode makes runs bitwise reproducible and backs the CI e2e
-  regression suite; sglang-side monkey patches manage train/rollout alignment; and an FSDP2 param-dtype patch manages
-  precision — by providing per-parameter level fp32 precision control over FSDP2 under the mixed-precision policy. See
-  [Deterministic Training](advanced/deterministic.md) and [Dtype Control](advanced/dtype-control.md).
+- **LoRA training with IPC-handle weight sync.** With `--lora-ipc-weight-sync`, PEFT LoRA on the FSDP2 actor ships only
+  `lora_A`/`lora_B` pairs to colocated rollout engines over CUDA IPC and merges them engine-side. See
+  [LoRA Training and Weight Sync](advanced/lora.md).
+- **Quality control on three fronts.** Deterministic mode supports bit-for-bit comparisons for recipes covered by
+  committed E2E standards; sglang-side monkey patches reduce train/rollout mismatches; and an FSDP2 param-dtype patch
+  provides per-parameter fp32 control under the mixed-precision policy. See [Deterministic
+  Training](advanced/deterministic.md) and [Dtype Control](advanced/dtype-control.md).
 - **SFT, DiffusionNFT, and Flow-GRPO under one trainer.** The loss type, training-batch preparation, rollout function,
   and reward function are all **replaceable components**, so integrating a new algorithm — or swapping in your own
   customized component — is easy.
 - **Sglang native.** Rollout runs **on the inference engine itself** — the sglang-diffusion serving stack — with RL
-  support and optimizations living engine-side, and **train–inference consistency** is managed through a curated set of
-  monkey patches that pin engine kernels to the numerics of the training-side diffusers forward to achieve maximized
-  match.
+  support and optimizations living engine-side. An optional curated set of monkey patches aligns selected engine
+  operations with the training-side forward.
 - **Multiple parallelisms.** The rollout engines scale with **tensor and sequence parallelism** to support large models
   and very long contexts; training scales with **USP (Ulysses × Ring)**, built from each family's diffusers `_cp_plan` —
   or a self-written one — for agile model integration.
@@ -50,7 +46,7 @@ Each model name links to its recipe page. Every documented recipe is labeled wit
 | [Wan2.2-T2V-A14B](models/wan/wan2-2.md)                   | T2V       | Flow-GRPO + PickScore, LoRA SFT           |
 | [LTX-2.3](models/ltx/ltx2.md)                             | T2V       | Flow-GRPO + PickScore                     |
 | [Cosmos3 (Edge / Nano / Super)](models/cosmos/cosmos3.md) | T2I       | Flow-GRPO + PickScore                     |
-| [MiniMax H3](models/h3/h3.md)                             | T2VA      | **Not merged** — [PR #154](https://github.com/radixark/miles_diffusion/pull/154); 2-GPU recipe; large-scale coming soon |
+| [MiniMax H3](models/h3/h3.md)                             | T2VA      | **Not merged** — [PR #154](https://github.com/radixark/miles_diffusion/pull/154); 2-GPU PR-only recipe |
 
 
 
@@ -68,7 +64,7 @@ Each model name links to its recipe page. Every documented recipe is labeled wit
 | DiffusionNFT (`nft`)                     | ✅     | 🟡         | 🟡     | 🟡      | 🟡      |
 | SFT (`sft_loss`, `--train-only`)         | 🟡    | 🟡         | ✅      | 🟡      | 🟡      |
 | LoRA + IPC weight sync                   | ✅     | ✅          | ✅      | 🟡    | ✅       |
-| Single-prompt multi-gen (microgroup > 1) | ✅     | ✅          | ✅      | ❌       | ❌      |
+| Single-prompt multi-gen (microgroup > 1) | ✅     | ✅          | ✅      | 🟡       | ❌      |
 | USP sequence parallelism                 | ❌     | ❌          | ✅    | ❌       | ❌       |
 | Deterministic mode                       | ✅     | ✅          | ✅      | ✅       | ❌       |
 

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -7,7 +7,7 @@ description: Text-to-audio-video Flow-GRPO + PickScore on MiniMax H3 — 2-GPU r
 > [miles-diffusion#154](https://github.com/radixark/miles_diffusion/pull/154) and
 > [sglang-diffusion#34365](https://github.com/sgl-project/sglang/pull/34365).
 > Neither repo has it on `main`. After a normal install, follow [Setup](#3-setup) to
-> move both checkouts onto those PRs. A large-scale recipe is coming soon.
+> move both checkouts onto those PRs.
 
 ## 1. Model introduction
 
@@ -60,7 +60,8 @@ The 2-GPU recipe lives on [PR #154](https://github.com/radixark/miles_diffusion/
 (sglang pins `short_edge=768`, so the canvas is 1344×768 / 107 frames). Requires `--use-lora --lora-ipc-weight-sync`
 (the recipe already sets both).
 
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v), based on the complete run reported on PR #154.
+The command does not exist on `main`.
 
 ```bash
 # alignment check (optimizer frozen)
@@ -78,9 +79,9 @@ python3 scripts/run_diffusion_grpo_h3_t2va_2gpu.py \
   --cuda-visible-devices 0,1
 ```
 
-**Large-scale recipe coming soon.** The commands above are the 2-GPU verification path on
-[PR #154](https://github.com/radixark/miles_diffusion/pull/154). A multi-GPU recipe
-(`rollout_batch_size=8`, group 16) will land in a follow-up.
+The commands above are the 2-GPU verification path on
+[PR #154](https://github.com/radixark/miles_diffusion/pull/154). No larger canonical H3 topology is committed to
+`main`.
 
 ## 5. Reference results
 
@@ -91,7 +92,8 @@ python3 scripts/run_diffusion_grpo_h3_t2va_2gpu.py \
 - Eval PickScore (`eval/pickscore_test`, every 10 rollouts): **0.806 → 0.814**, peak **0.816** at step 59.
 - Train `rollout/reward/raw_mean` sits around **~0.79** (64 samples / step; noisier than eval).
 
-This is the batch-4 curve from [PR #154](https://github.com/radixark/miles_diffusion/pull/154), not the forthcoming large-scale recipe.
+This is the batch-4 curve reported on [PR #154](https://github.com/radixark/miles_diffusion/pull/154); it is not evidence
+for a larger topology.
 
 ![MiniMax H3 log_prob_mean_abs_diff](../../assets/images/h3/log_prob_diff.png)
 

--- a/docs/models/ltx/ltx2.md
+++ b/docs/models/ltx/ltx2.md
@@ -45,8 +45,8 @@ Registered in `miles/backends/fsdp_utils/configs/ltx.py`:
 
 ## 4. Launch
 
-Canonical recipe: `scripts/run_diffusion_grpo_ltx23_sglang.py` — 4 colocate GPUs + 1 PickScore
-GPU, 57 frames @ 24 fps, 512×768, PickScore reward.
+Canonical recipe: `scripts/run_diffusion_grpo_ltx23_sglang.py` — a 5-GPU Ray node with 4 GPUs shared by FSDP and
+rollout plus 1 separately scheduled PickScore GPU, 57 frames @ 24 fps, 512×768.
 
 **Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 

--- a/docs/models/qwen-image/qwen-image.md
+++ b/docs/models/qwen-image/qwen-image.md
@@ -15,9 +15,9 @@ baseline.
   alone) is exactly flow_grpo's `PerPromptStatTracker` with `global_std=True`; `gaussian` LoRA
   init and `adam-beta2 0.999` match likewise.
 - **RoPE caches rebuilt on CUDA.** diffusers builds `QwenEmbedRope`'s frequency tables on CPU
-  while sglang-d builds them on CUDA; the fp32 ULP difference drifts every block (frozen-weight
-  `noise_pred` mean |Δ| ≈ 2e-2). `postprocess_model_after_materialize` rebuilds the caches on
-  device after FSDP wrapping.
+  while sglang-d builds them on CUDA; the fp32 ULP difference drifts every block. In one frozen-weight comparison,
+  `noise_pred` mean |Δ| was approximately `2e-2`. `postprocess_model_after_materialize` rebuilds the caches on device
+  after FSDP wrapping.
 - **Variable-length text.** Conditioning is padded per batch with the attention mask derived
   from `txt_seq_lens` — the mask itself is never transmitted from rollout.
 

--- a/docs/models/sd3/sd3.md
+++ b/docs/models/sd3/sd3.md
@@ -118,16 +118,13 @@ python3 scripts/run_diffusion_grpo_sd3_ocr_sglang.py \
 
 Walkthrough: [Quick Start](../../getting-started/quick-start.md).
 
-This script prepends `master_sglang` to `PYTHONPATH` for native SD3
-`/rollout/generate` support. See the module docstring for details.
-
 E2E test: `tests/e2e/short/test_sd3_ocr_grpo_2xGPU.py`.
 
 ### 5.3 DiffusionNFT + PickScore (3 GPU)
 
 Script: `scripts/run_diffusion_nft_sd3_pickscore.py`
 
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 export HF_TOKEN=...
@@ -150,7 +147,7 @@ MILES_SCRIPT_SMOKE=1 python3 scripts/run_diffusion_nft_sd3_pickscore.py
 | SDE | Full window, noise=0.7, CFG=4.5 | ODE, noise=0 |
 | Reference | LoRA base KL | EMA (`--use-ema`) |
 | Reward GPU | None (CPU OCR) | Dedicated (3 GPU total) |
-| Deterministic e2e | `test_sd3_ocr_grpo_2xGPU` | — (smoke via `MILES_SCRIPT_SMOKE=1`) |
+| Deterministic e2e | `test_sd3_ocr_grpo_2xGPU` | `test_sd3_nft_pickscore_3xGPU` |
 
 ## 6. Recipe configuration
 
@@ -235,8 +232,9 @@ Train/rollout dtype alignment for Flow-GRPO is covered in
 
 ### Flow-GRPO + OCR
 
-`rollout/reward/raw_mean` from `scripts/run_diffusion_grpo_sd3_ocr_sglang.py`
-(default batch, 600 rollouts):
+Observed `rollout/reward/raw_mean` from one
+`scripts/run_diffusion_grpo_sd3_ocr_sglang.py` run (default batch, 600 rollouts). The curve is an example, not a CI
+acceptance range:
 
 ![Flow-GRPO OCR raw reward](../../assets/images/sd3/grpo-ocr-raw-reward.png)
 
@@ -244,14 +242,13 @@ Online runs: wandb project **`miles-diffusion-grpo`**.
 
 ### DiffusionNFT + PickScore
 
-`rollout/reward/raw_mean` from `scripts/run_diffusion_nft_sd3_pickscore.py` (100
-rollouts):
+Observed `rollout/reward/raw_mean` from one `scripts/run_diffusion_nft_sd3_pickscore.py` run (100 rollouts):
 
 ![DiffusionNFT PickScore raw reward](../../assets/images/sd3/nft-pickscore-raw-reward.png)
 
-Online runs: wandb project **`miles-diffusion-nft`**. Held-out
-**`eval/pickscore_test` ≈ 0.78** on the default eval config (`--eval-interval 30`,
-50 denoise steps at eval time).
+Online runs: wandb project **`miles-diffusion-nft`**. That run observed held-out
+**`eval/pickscore_test` ≈ 0.78** with `--eval-interval 30` and 50 denoise steps at eval time; this value is not asserted
+by the E2E fixture.
 
 ## 10. Pairs well with
 

--- a/docs/models/wan/wan2-2.md
+++ b/docs/models/wan/wan2-2.md
@@ -39,7 +39,7 @@ Registered in `miles/backends/fsdp_utils/configs/wan2_2.py`:
 | Condition inputs | `encoder_hidden_states` only (fixed-length UMT5 embeds) | Concat-collate, no padding needed |
 | CFG combine | `neg + scale × (pos − neg)` | Standard |
 | CFG batching | Off | |
-| fp32 param islands | `scale_shift_table`, `time_embedder`, `norm2` kept fp32 under FSDP mixed precision | `models/diffusers/wan2_2/parallel_plan.py` |
+| FSDP fp32 param map | `norm2` parameters only | `models/diffusers/wan2_2/parallel_plan.py`; the separate rollout patch group aligns selected norm and `scale_shift_table` arithmetic engine-side |
 
 ## 4. Launch
 ### 4.1 Flow-GRPO + PickScore (4 train GPUs + 1 reward GPU)

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -50,7 +50,7 @@ do not.
 | `--rollout-num-gpus` | – | GPUs for rollout-side work. Forced to the train world size under `--colocate`. |
 | `--rollout-num-gpus-per-engine` | `1` | GPUs per sglang-d engine (its TP × SP). |
 | `--num-gpus-per-node` | `8` | Total GPUs the job may use per node. **Set this when using fewer than 8.** |
-| `--colocate` | off | Time-share GPUs between trainer and engines; forces `--offload-train` and `--offload-rollout` on. The flag defaults off, but every shipped GRPO/NFT recipe enables it because the implemented RL weight-sync path uses CUDA IPC over shared GPU ids. `--debug-rollout-only` and train-only SFT can run without it. |
+| `--colocate` | off | Required: CUDA IPC weight sync currently supports only colocated trainer and rollout execution. |
 
 ### Batch sizing
 
@@ -116,7 +116,7 @@ See [Dtype Control](../advanced/dtype-control.md).
 | `--rollout-num-gpus` | int | – | For train-only SFT, unset colocates encoders with training; set it to reserve dedicated encoder GPUs. |
 | `--rollout-num-gpus-per-engine` | int | `1` | Like sglang's `tp_size`. |
 | `--num-gpus-per-node` | int | `8` | |
-| `--colocate` | flag | off | Also sets `--offload`. Shipped RL recipes enable it explicitly because weight sync uses CUDA IPC and assumes trainer and engines share GPU ids. |
+| `--colocate` | flag | off | Required: CUDA IPC weight sync currently supports only colocated trainer and rollout execution. |
 | `--offload` | flag | off | `--offload-train` + `--offload-rollout`. |
 | `--offload-train` / `--no-offload-train` | tri-state | – | Always on under `--colocate`. |
 | `--offload-rollout` / `--no-offload-rollout` | tri-state | – | Always on under `--colocate`. |

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -50,7 +50,7 @@ do not.
 | `--rollout-num-gpus` | – | GPUs for rollout-side work. Forced to the train world size under `--colocate`. |
 | `--rollout-num-gpus-per-engine` | `1` | GPUs per sglang-d engine (its TP × SP). |
 | `--num-gpus-per-node` | `8` | Total GPUs the job may use per node. **Set this when using fewer than 8.** |
-| `--colocate` | on | Time-share GPUs between trainer and engines; forces `--offload-train` and `--offload-rollout` on. **Effectively required for RL** — the only weight-sync transport is CUDA IPC over shared GPUs. Every GRPO recipe sets it; only `--debug-rollout-only` / train-only SFT run without. |
+| `--colocate` | off | Time-share GPUs between trainer and engines; forces `--offload-train` and `--offload-rollout` on. The flag defaults off, but every shipped GRPO/NFT recipe enables it because the implemented RL weight-sync path uses CUDA IPC over shared GPU ids. `--debug-rollout-only` and train-only SFT can run without it. |
 
 ### Batch sizing
 
@@ -116,7 +116,7 @@ See [Dtype Control](../advanced/dtype-control.md).
 | `--rollout-num-gpus` | int | – | For train-only SFT, unset colocates encoders with training; set it to reserve dedicated encoder GPUs. |
 | `--rollout-num-gpus-per-engine` | int | `1` | Like sglang's `tp_size`. |
 | `--num-gpus-per-node` | int | `8` | |
-| `--colocate` | flag | on | Also sets `--offload`. Effectively required for RL: weight sync is CUDA-IPC-only and assumes trainer and engines share GPU ids. Non-colocate layouts exist only for `--debug-rollout-only` and train-only SFT. |
+| `--colocate` | flag | off | Also sets `--offload`. Shipped RL recipes enable it explicitly because weight sync uses CUDA IPC and assumes trainer and engines share GPU ids. |
 | `--offload` | flag | off | `--offload-train` + `--offload-rollout`. |
 | `--offload-train` / `--no-offload-train` | tri-state | – | Always on under `--colocate`. |
 | `--offload-rollout` / `--no-offload-rollout` | tri-state | – | Always on under `--colocate`. |
@@ -167,8 +167,8 @@ See [Dtype Control](../advanced/dtype-control.md).
 | Flag | Type | Default | Notes |
 |---|---|---|---|
 | `--hf-checkpoint` | str | – | **Required.** Pipeline to train and to serve; also the family source. |
-| `--diffusion-model-family` | str | – | Registered family key: `sd3`, `wan2_2`, `ltx`, `qwen_image`. Overrides name matching. |
-| `--rollout-function-path` | str | – | Use `miles.rollout.sglang_diffusion_rollout.generate_rollout`. |
+| `--diffusion-model-family` | str | – | Registered family key: `sd3`, `wan2_2`, `ltx`, `qwen_image`, `cosmos3`. Overrides name matching. |
+| `--rollout-function-path` | str | `miles.rollout.sglang_rollout.generate_rollout` | Generic Miles default. Diffusion recipes explicitly set `miles.rollout.sglang_diffusion_rollout.generate_rollout`. |
 | `--train-pipeline-config-path` | str | – | Your own `TrainPipelineConfig` for an unregistered family. Mutually exclusive with `--diffusion-model-family`. |
 | `--model-backend-path` | str | – | Override the family's model loader. |
 | `--diffusion-num-steps` | int | `10` | |
@@ -336,7 +336,7 @@ Every one takes a dotted path.
 | `--wandb-group` / `--wandb-run-id` / `--wandb-team` / `--wandb-host` / `--wandb-key` | str | – | |
 | `--wandb-mode` | enum | – | `online` / `offline` / `disabled`. Overrides `WANDB_MODE`. |
 | `--wandb-dir` | str | – | Defaults to `./wandb`. |
-| `--disable-wandb-random-suffix` | flag | off | |
+| `--disable-wandb-random-suffix` | flag | off | Run names include a random suffix by default; pass this flag to disable it. |
 | `--wandb-log-num-images` | int | `0` | Images/videos per rollout; `0` disables. |
 | `--wandb-log-image-interval` | int | `1` | Send media every N rollouts. |
 | `--use-miles-dashboard` | flag | off | Async phase/trajectory telemetry. |

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -1,10 +1,10 @@
 ---
 title: Core Concepts
-description: The four objects that make up every miles-diffusion job, the trajectory-level training loop, and where every flag goes.
+description: The four objects that make up every miles-diffusion job and the trajectory-level training loop.
 ---
 
 A miles-diffusion training job is a loop over four objects. Once you understand what each one *is* and how data flows
-between them, every flag in the system has an obvious home.
+between them, the major flag groups are easier to place.
 
 ## The four objects
 
@@ -22,7 +22,7 @@ flowchart LR
 | Object                                 | Role                                                           | Lives in                                                                                            |
 | -------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | **Prompt dataset**                     | Source of prompts (plus optional metadata)                     | JSONL on disk (`--prompt-data`, `--input-key`)                                                      |
-| **Rollout (sglang-diffusion engines)** | Denoises prompts into images/videos and records the trajectory | One engine per `--rollout-num-gpus-per-engine` GPUs, behind the miles router (`--use-miles-router`) |
+| **Rollout (sglang-diffusion engines)** | Denoises prompts into images/videos and records the trajectory | One engine per `--rollout-num-gpus-per-engine` GPUs; shipped diffusion recipes explicitly enable the miles router with `--use-miles-router` |
 | **Reward workers**                     | Map `(prompt, generated output) → score`                       | Built-in `rm_hub` (`--rm-type ocr / pickscore`) or custom (`--custom-rm-path`) — Ray actor pools    |
 | **Actor (FSDP2 + diffusers)**          | The DiT being trained, usually via LoRA                        | HF checkpoint (`--hf-checkpoint`), family resolved by `TrainPipelineConfig`                         |
 
@@ -103,10 +103,6 @@ flowchart TD
     classDef op fill:#f3f3f3,stroke:none
     style T fill:#fdf6d8,stroke:#b8a23e
 ```
-
-## Where every flag goes
-
-tbd
 
 ## Next
 

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -45,13 +45,15 @@ Replace the entire train rollout. Diffusion recipes use
 `miles.rollout.sglang_diffusion_rollout.generate_rollout` (not the LLM default).
 
 ```python
-def generate_rollout(args, rollout_id, data_source, evaluation=False):
+def generate_rollout(
+    args, rollout_id, data_source, evaluation=False
+) -> RolloutFnTrainOutput | RolloutFnEvalOutput:
     ...
 ```
 
-Help text also documents
-`def generate_rollout(args, rollout_id, *, evaluation=False) -> list[list[Sample]]`
-— follow the call site in `miles/ray/rollout.py` (`call_rollout_fn`).
+`miles/ray/rollout.py` passes the data source positionally through `call_rollout_fn`.
+Legacy list/dict returns are still wrapped into the corresponding output dataclass by
+`miles.rollout.base_types.call_rollout_fn`.
 
 ### `--eval-function-path`
 

--- a/docs/user-guide/launch-script.md
+++ b/docs/user-guide/launch-script.md
@@ -241,9 +241,10 @@ Reward workers (`--pickscore-num-workers 4 --pickscore-num-gpus-per-worker 0.25`
 
 ### Verify the run is healthy
 
-- `train/model_output_mean_abs_diff` must be exactly `0.0` from the first optimizer step — with
-  `--rollout-patch-group wan` and `--sglang-attention-backend torch_sdpa` the trainer recompute and
-  the engine forward are the same function. Any nonzero value means a patch missed some rank.
+- With `--rollout-patch-group wan` and `--sglang-attention-backend torch_sdpa`,
+  `train/model_output_mean_abs_diff` is expected to be exactly `0.0` from the first optimizer step. The 4-GPU proxy E2E
+  standard records `0.0`, and the documented 17-GPU runs sustained it over 200 rollouts. Any nonzero value indicates a
+  train/rollout parity regression; check the patch group, backend, dtype, and versions on every rank.
 - Both training nodes near 100% GPU util during rollout; a 100%-vs-idle split between nodes means
   the reward workers were packed onto one node.
 
@@ -253,7 +254,7 @@ Reward workers (`--pickscore-num-workers 4 --pickscore-num-gpus-per-worker 0.25`
 |---|---|
 | Stale engine hijacks the port | Killing a driver by name leaves its spawned engine alive; the next driver's health check talks to the old, unpatched server while the new one dies on `EADDRINUSE`. Between runs kill by GPU pid and check `nvidia-smi` shows no compute processes |
 | Version strings lie under editable installs | `pip show sglang` reports the install-time commit; trust `git rev-parse HEAD` in the checkout (or the `-e git+...@<sha>` line in `pip freeze`) |
-| Weight-sync bucket | `--update-weight-buffer-size 4294967296` (4 GiB): the sync is latency-bound on per-bucket round-trips — 512 MiB costs ~92 s for the A14B pair, 4 GiB ~15 s; output diff stays 0 at any size |
+| Weight-sync bucket | `--update-weight-buffer-size 4294967296` (4 GiB). In one documented A14B run, 512 MiB took ~92 s and 4 GiB ~15 s; these are run-specific observations, not a benchmark guarantee. |
 | Determinism env vars are trainer-side | `--deterministic-mode` sets `NCCL_DETERMINISTIC` and `CUBLAS_WORKSPACE_CONFIG` on the FSDP actors; check rollout parity with `train/model_output_mean_abs_diff` |
 
 ## Next

--- a/docs/user-guide/recipe-verification.md
+++ b/docs/user-guide/recipe-verification.md
@@ -11,20 +11,20 @@ topology named in the model guide, not to the model family as a whole.
 ## 🛡️ FG — Fully gated
 
 - A complete training curve has been run.
-- Deterministic E2E CI runs the canonical recipe itself for two rollouts.
+- A deterministic E2E runs the canonical recipe itself at least nightly.
 - Every registered metric matches the committed standard exactly.
 
 <a id="pg"></a>
 ## 🧩 PG — Proxy gated
 
 - A complete training curve has been run.
-- Deterministic E2E CI runs a documented, scaled single-node proxy for two rollouts.
+- A deterministic E2E runs a documented, scaled single-node proxy at least nightly.
 - Every registered metric matches the committed standard exactly.
 
 <a id="v"></a>
 ## 📈 V — Verified
 
-A complete training curve has been run, but the recipe has no E2E CI gate.
+A complete training curve has been run, but no deterministic E2E satisfies the FG or PG criteria above.
 
 <a id="nv"></a>
 ## ○ NV — Not verified
@@ -37,17 +37,17 @@ count as verification.
 - **🛡️ FG**
   - `run_diffusion_grpo_sd3_ocr_sglang.py` — SD3.5 Flow-GRPO + OCR.
   - `run_diffusion_grpo_ltx23_sglang.py` — LTX-2.3 Flow-GRPO + PickScore.
+  - `run_diffusion_nft_sd3_pickscore.py` — SD3.5 DiffusionNFT + PickScore.
 - **🧩 PG**
   - `run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py` — Wan2.2 17-GPU
     full-finetune Flow-GRPO + PickScore.
 - **📈 V**
-  - `run_diffusion_nft_sd3_pickscore.py` — SD3.5 DiffusionNFT + PickScore.
   - `run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` — Qwen-Image
     Flow-GRPO + PickScore.
   - `run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` — Cosmos3-Nano
     Flow-GRPO + PickScore.
   - `run_diffusion_grpo_h3_t2va_2gpu.py` — MiniMax H3 Flow-GRPO + PickScore
-    ([implementation PR #154](https://github.com/radixark/miles_diffusion/pull/154)).
+    ([PR #154](https://github.com/radixark/miles_diffusion/pull/154) only; not on `main`).
 - **○ NV**
   - `run_diffusion_grpo_wan22_pickscore_5gpu.py` — Wan2.2 5-GPU LoRA
     Flow-GRPO + PickScore.


### PR DESCRIPTION
## What

- Many document modification bundle

## Files

- `docs/index.md` — project positioning, feature scope, and support-matrix semantics.
- `docs/getting-started/installation.md` — precise links, hardware layouts, and model-family precedence.
- `docs/getting-started/quick-start.md` — verified GPU requirement and recipe flags.
- `docs/user-guide/cli-reference.md` — corrected defaults, family list, and rollout/W&B semantics.
- `docs/user-guide/concepts.md` — router wording and removal of an unfinished section.
- `docs/user-guide/customization.md` — actual rollout function contract.
- `docs/user-guide/launch-script.md` — evidence-backed Wan parity diagnostics.
- `docs/user-guide/recipe-verification.md` — nightly/basic E2E cadence and recipe evidence levels.
- `docs/models/sd3/sd3.md` — canonical E2E status and recipe evidence.
- `docs/models/wan/wan2-2.md` — FSDP fp32 mapping.
- `docs/models/ltx/ltx2.md` — current topology and master-dtype behavior.
- `docs/models/qwen-image/qwen-image.md` — scoped alignment and numerical observations.
- `docs/models/h3/h3.md` — V status with explicit PR-only availability.
- `docs/advanced/deterministic.md` — incomplete argument gate and bounded determinism guarantees.
- `docs/advanced/streaming-reward.md` — grammar correction.
- `docs/developer/contributor-guide.md` — current E2E GPU range and supported contact paths.

## Checklist

- [ ] `pre-commit run --all-files` passes — **not run; all changed files pass**
- [ ] Added/updated tests for new behaviour — **not applicable; documentation only**
- [ ] `pytest -x` is green — **not run; documentation only**
- [x] If launch flags changed, `python3 train.py --help` still parses — **no launch flags changed**
- [x] If a public flag was added, it appears in the CLI reference docs — **no public flags added**
- [x] If an example was added, it has a real walkthrough — **no examples added**

Made with [Cursor](https://cursor.com)