### PR TITLE
docs: align model support with validated recipes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ pipeline, or from a native package when a family brings its own modeling. Shippe
 ## Core features
 
 - **Verified Recipes for Latest Diffusion Models.** Launchers for Wan2.2-T2V-A14B, Qwen-Image,
-  LTX-2.3, the Cosmos3 MoT omni family, and SD3.5. `TrainPipelineConfig` allows for easy model support.
+  LTX-2.3, Cosmos3-Nano, and SD3.5. `TrainPipelineConfig` allows for easy model support.
 - **Quality control on three fronts.** Deterministic mode supports bit-for-bit comparisons for recipes covered by
   committed E2E standards; sglang-side monkey patches reduce train/rollout mismatches; and an FSDP2 param-dtype patch
   provides per-parameter fp32 control under the mixed-precision policy. See [Deterministic
@@ -34,7 +34,8 @@ pipeline, or from a native package when a family brings its own modeling. Shippe
 ## Supported models
 
 Each model name links to its recipe page. Every documented recipe is labeled with a
-[recipe verification level](user-guide/recipe-verification.md).
+[recipe verification level](user-guide/recipe-verification.md). Validated models also
+appear in the [Miles model list](https://miles.radixark.com/docs#supported-models).
 
 
 | Model                                                   | Task      | Canonical recipes                         |
@@ -43,7 +44,7 @@ Each model name links to its recipe page. Every documented recipe is labeled wit
 | [Qwen-Image](models/qwen-image/qwen-image.md)             | T2I       | Flow-GRPO + PickScore (flow_grpo-aligned) |
 | [Wan2.2-T2V-A14B](models/wan/wan2-2.md)                   | T2V       | Flow-GRPO + PickScore, LoRA SFT           |
 | [LTX-2.3](models/ltx/ltx2.md)                             | T2V       | Flow-GRPO + PickScore                     |
-| [Cosmos3 (Edge / Nano / Super)](models/cosmos/cosmos3.md) | T2I       | Flow-GRPO + PickScore                     |
+| [Cosmos3-Nano](models/cosmos/cosmos3.md)                   | T2I       | Flow-GRPO + PickScore                     |
 | [MiniMax H3](models/h3/h3.md)                             | T2VA      | **Not merged** — [PR #154](https://github.com/radixark/miles_diffusion/pull/154); 2-GPU PR-only recipe |
 
 

--- a/docs/models/cosmos/cosmos3.md
+++ b/docs/models/cosmos/cosmos3.md
@@ -1,14 +1,14 @@
 ---
 title: Cosmos3
-description: The Cosmos3 MoT omni family (UND + GEN towers) — token-level conditioning, packed single-sample forward, Flow-GRPO + PickScore recipe.
+description: Cosmos3-Nano Flow-GRPO and PickScore recipe with token-level conditioning and packed single-sample forwards.
 ---
 
 ## 1. Model introduction
 
 [Cosmos3](https://huggingface.co/collections/nvidia/cosmos3) is NVIDIA's Mixture-of-Transformers (MoT) omni family: an
 **UND** (understanding) tower and a **GEN** (generation) tower over a joint text+vision packed sequence, with the Wan2.2
-VAE (4× temporal compression). All sizes share this architecture and differ only in layer count and hidden dim, so
-everything below applies family-wide; the canonical recipes are validated on **Cosmos3-Nano**.
+VAE (4× temporal compression). This guide covers **Cosmos3-Nano**, the variant validated by the canonical recipe and
+training curve.
 
 **Key highlights for RL training:**
 
@@ -24,16 +24,14 @@ everything below applies family-wide; the canonical recipes are validated on **C
 
 
 
-## 2. Supported variants
+## 2. Validated variant
 
-All sizes resolve to the same family config — detection matches any checkpoint name containing `cosmos3` / `cosmos-3`.
+Only Nano has a validated recipe and training curve.
 
 
-| Size  | Composition              | HF checkpoints                                                                                                                                                                                                                         | Status                              |
-| ----- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| Nano  | 16 B (8 B UND + 8 B GEN) | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano), [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)                                                                                       | **Validated** — canonical recipes   |
-| Edge  | 4 B (2 B + 2 B)          | [Cosmos3-Edge](https://huggingface.co/nvidia/Cosmos3-Edge), [Cosmos3-Edge-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Edge-Policy-DROID)                                                                                       | Untested                            |
-| Super | 64 B (32 B + 32 B)       | [Cosmos3-Super](https://huggingface.co/nvidia/Cosmos3-Super), [Cosmos3-Super-Text2Image](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image), [Cosmos3-Super-Image2Video](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) | Untested; needs a larger GPU layout |
+| Size  | Composition              | HF checkpoints                                                                                                                                                                                                   | Status                            |
+| ----- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Nano  | 16 B (8 B UND + 8 B GEN) | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano), [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)                                                                 | **Validated** — canonical recipes |
 
 
 


### PR DESCRIPTION
## Summary

- Limit Cosmos3 support claims to Nano, the variant backed by a canonical recipe and training curve.
- Link validated diffusion models to the top-level Miles model list.

## Test plan

- [x] `git diff --check`
- [x] Documentation diagnostics report no errors

## Checklist

- [ ] `pre-commit run --all-files` passes — not run
- [ ] Added/updated tests for new behaviour — docs-only change
- [ ] `pytest -x` is green — not run for docs-only change
- [x] If launch flags changed, `python3 train.py --help` still parses — not applicable
- [x] If a public flag was added, it appears in the CLI reference docs — not applicable
- [x] If an example was added, it has a real walkthrough — not applicable
