### PR TITLE
chore(deps): pin diffusers to the commit that merged MiniMax H3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ accelerate==1.12.0
 addict==2.4.0
 blobfile==3.0.0
 datasets==4.4.2
-diffusers==0.38.0
+# MiniMax H3 (PR #14355) is merged into diffusers main but ships in no release yet:
+# 0.39.0 predates the merge. Pinned to the merge commit on main; switch to the next
+# stable release once it is out.
+diffusers @ git+https://github.com/huggingface/diffusers.git@f53d552036a0d1bd5570782a39cd40cfabf112bc
 fastapi==0.128.8
 httpx[http2]==0.28.1
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@780984275fd47128b02bef9b5c085404276866ee#subdirectory=packages/ltx-core


### PR DESCRIPTION
## What

- Move `diffusers` from `0.38.0` to a git pin on the main commit that merged MiniMax H3 (`f53d5520`, [huggingface/diffusers#14355](https://github.com/huggingface/diffusers/pull/14355)).

## Why

MiniMax H3 support is needed by #154, but no diffusers release carries it: `v0.39.0` (2026-07-03) predates the merge (2026-08-05), and nothing has shipped since. A git pin is the only option until the next stable release.

Split out of #154 so the dependency upgrade is validated on its own. This is a two-minor jump (`0.38.0` → post-`0.39.0` main) and can break models that have nothing to do with H3 — that is exactly what this PR asks CI to answer, without the H3 training code in the way. `requirements.txt` here is byte-identical to #154's.

Upstream has four later commits touching H3 (SDNQ loading #14398, context parallel #14407, LoRA loading #14408, CUDA test fixes #14464). They are deliberately not picked up: pinning the merge commit keeps this identical to what #154 was validated against.

## Files

| File | Role |
|---|---|
| `requirements.txt` | the pin, plus a comment recording why it is a git ref and when to drop it |

## Checklist

- [ ] `pre-commit run --all-files` passes — **not run locally**
- [ ] Added/updated tests for new behaviour — **none added**; a dependency pin has no behaviour of its own, CI is the test
- [ ] `pytest -x` is green — **not run locally** (no torch in this environment); relying on CI
- [x] If launch flags changed, `python3 train.py --help` still parses — no flags changed
- [x] If a public flag was added, it appears in the CLI reference docs — no flags added
- [x] If an example was added, it has a real walkthrough — no examples added
