### PR TITLE
fix(qwen-image): drop the txt_seq_lens kwarg removed by diffusers

### DIFF
--- a/miles/backends/fsdp_utils/configs/qwen_image.py
+++ b/miles/backends/fsdp_utils/configs/qwen_image.py
@@ -114,7 +114,7 @@ class QwenImageTrainPipelineConfig(TrainPipelineConfig):
     ) -> dict:
         """Pad+stack per-sample encoder_hidden_states to (M, max_len, D), build
         the corresponding (M, max_len) bool mask from txt_seq_lens, and
-        list-concat img_shapes / txt_seq_lens. Mask isn't transmitted from
+        list-concat img_shapes. Mask isn't transmitted from
         rollout — it is fully derivable from txt_seq_lens which is.
 
         When ``pad_to_len`` is given, pad to ``max(max(seq_lens), pad_to_len)``
@@ -165,7 +165,6 @@ class QwenImageTrainPipelineConfig(TrainPipelineConfig):
         return {
             "encoder_hidden_states": encoder_hidden_states,
             "encoder_hidden_states_mask": mask,
-            "txt_seq_lens": seq_lens,
             "img_shapes": img_shapes,
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ accelerate==1.12.0
 addict==2.4.0
 blobfile==3.0.0
 datasets==4.4.2
-diffusers==0.38.0
+# MiniMax H3 (PR #14355) is merged into diffusers main but ships in no release yet:
+# 0.39.0 predates the merge. Pinned to the merge commit on main; switch to the next
+# stable release once it is out.
+diffusers @ git+https://github.com/huggingface/diffusers.git@f53d552036a0d1bd5570782a39cd40cfabf112bc
 fastapi==0.128.8
 httpx[http2]==0.28.1
 ltx-core @ git+https://github.com/Lightricks/LTX-2.git@780984275fd47128b02bef9b5c085404276866ee#subdirectory=packages/ltx-core


### PR DESCRIPTION
## What

Stop passing `txt_seq_lens` into `QwenImageTransformer2DModel.forward`. It stays a
per-sample input — `collate_cond_for_sample_batch` still reads it to derive the text
mask and the padding width — it just no longer travels in the collated dict that the
trainer splats into the model.

## Why

`txt_seq_lens` was removed from both `QwenImageTransformer2DModel.forward` and
`QwenEmbedRope.forward` after diffusers 0.39. Under the pin in #189
(`f53d5520`, post-0.39 main) the qwen-image training forward raises
`TypeError: forward() got an unexpected keyword argument 'txt_seq_lens'`.

## Numerically a no-op on 0.38

Removing the kwarg cannot move a single bit on the current pin:

- In 0.38 the parameter only triggered a `deprecate()` warning in
  `QwenImageTransformer2DModel.forward` — nothing read it.
- The RoPE length comes from `compute_text_seq_len_from_mask` (identical in 0.38 and
  `f53d5520`), passed to `pos_embed` as `max_txt_seq_len=text_seq_len`. That path never
  consults `txt_seq_lens`.
- `QwenEmbedRope.forward` would fall back to `max(txt_seq_lens)` only when
  `max_txt_seq_len is None`, which the transformer never does.

## Verified bitwise under #189's diffusers pin

`tests/e2e/short/test_qwenimage_pickscore_grpo_5xGPU.py` run on this branch inside the
pinned-diffusers image, compared against the standard recorded on 0.38:

| | |
|---|---|
| image | `radixark/miles_diffusion:test-pr-189` |
| diffusers | `0.40.0.dev0` @ `f53d552036a0d1bd5570782a39cd40cfabf112bc` |
| sglang | `7605529` |
| hardware | 5x H200 |
| command | `--num-rollout 2` (the test's own args, unmodified) |

| metric series | points | vs standard |
|---|---|---|
| `rollout/reward/raw_num_samples` | 2 | identical |
| `rollout/reward/raw_mean` | 2 | identical |
| `rollout/reward/raw_median` | 2 | identical |
| `rollout/reward/raw_std` | 2 | identical |
| `train/log_prob_old_idx_0` | 4 | identical |
| `train/log_prob_new_idx_0` | 4 | identical |
| `train/log_prob_mean_abs_diff` | 4 | identical |
| `train/model_output_mean_abs_diff` | 4 | identical |
| `train/model_output_rel_max` | 4 | identical |
| `train/grad_norm` | 4 | identical |

```
[e2e-metrics] PASSED: 10 metric series match test_qwenimage_pickscore_grpo_5xGPU.json
```

32/32 points bit-for-bit, so the 311 commits between `v0.38.0` and `f53d5520` leave the
qwen-image train and rollout numerics untouched. The e2e is the guard for this change,
hence no new unit test.

## Not covered here

`test_wan22_pickscore_grpo_17xGPU_single_node_4xGPU_proxy` still OOMs under #189's pin.
That failure is memory headroom, not numerics: at the OOM the trainer needed 1.31 GiB
with 1.25 GiB free while a rollout engine still held 25.3 GiB and the colocated
pickscore reward 4.7 GiB on the same device. The wan-side diffusers delta is a fp32
`rope` buffer pin (~0.5 MiB) and one added `hidden_states.contiguous()` (~32 MiB after
the ulysses-4 split) — enough to tip a device already at 99% occupancy, and tracked
separately.
