### PR TITLE
docs: center README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/radixark/miles_diffusion" alt="License"></a>
 </p>
 
-**[News](#news)** | **[Quick Start](#quick-start)** | **[Key Features](#key-features)** | **[Documentation](https://miles.radixark.com/docs/diffusion)**
-
-
+<p align="center">
+  <a href="#news"><strong>News</strong></a> |
+  <a href="#quick-start"><strong>Quick Start</strong></a> |
+  <a href="#key-features"><strong>Key Features</strong></a> |
+  <a href="https://miles.radixark.com/docs/diffusion"><strong>Documentation</strong></a>
+</p>
 
 ---
 


### PR DESCRIPTION
## Summary

- Center the README section navigation below the badges.
- Preserve the existing links and labels.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] Documentation diagnostics report no errors

## Checklist

- [ ] `pre-commit run --all-files` passes — not run
- [ ] Added/updated tests for new behaviour — docs-only change
- [ ] `pytest -x` is green — not run for docs-only change
- [x] If launch flags changed, `python3 train.py --help` still parses — not applicable
- [x] If a public flag was added, it appears in the CLI reference docs — not applicable
- [x] If an example was added, it has a real walkthrough — not applicable
