### PR TITLE
fix(cosmos3): request the tuple form from the diffusers f53d5520 forward

### DIFF
--- a/miles/backends/fsdp_utils/configs/cosmos3.py
+++ b/miles/backends/fsdp_utils/configs/cosmos3.py
@@ -150,6 +150,7 @@ class Cosmos3TrainPipelineConfig(TrainPipelineConfig):
             vision_mse_loss_indexes=vision_sequence_indexes,
             vision_timesteps=torch.full((num_vision_tokens,), timestep, device=device, dtype=torch.float32),
             vision_noisy_frame_indexes=[torch.arange(latent_t, dtype=torch.long, device=device)],
+            return_dict=False,
         )
         return preds_vision[0]
 


### PR DESCRIPTION
One line: `return_dict=False` in the cosmos3 packed forward.

Since the f53d5520 requirements pin, `Cosmos3OmniTransformer.forward` defaults to returning a `Cosmos3OmniTransformerOutput`; unpacking it yields only the non-None fields, and T2I has neither sound nor action — so the existing 3-tuple unpack gets 1 value and raises `ValueError` on the first train step. `return_dict=False` returns the unchanged tuple.

Validation:
- Local e2e on the f53d5520 environment: the cosmos3 e2e standard reproduces **bitwise, 10/10 metric series** (grad_norm identical to 7 significant digits across diffusers 0.39.0 → f53d5520).
- Isolated CI run of the cosmos3 e2e with this line: https://github.com/radixark/miles_diffusion/actions/runs/32164334101
