### PR TITLE
chore(deps): bump transformers to 5.12.1 for MiniMax H3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,9 @@ tensorboard==2.20.0
 torch==2.11.0
 torchaudio==2.11.0
 torchvision==0.26.0
-transformers==5.5.4
+# MiniMax H3's Qwen3-VL text encoder imports transformers.vision_utils, which
+# first ships in 5.9.0; 5.12.1 is the version H3 has been run end to end on.
+transformers==5.12.1
 typer==0.23.2
 uvicorn==0.39.0
 wandb==0.28.1


### PR DESCRIPTION
## What

- Bump `transformers` from `5.5.4` to `5.12.1`.

## Why

MiniMax H3's text encoder (Qwen3-VL) imports `transformers.vision_utils`, which does not exist in `5.5.4`. The current H3 document requires extra environment setup, so here we bump transformers and run end-to-end CI.

## Validation

`uv pip install --dry-run -r requirements.txt` against the CI image (`transformers 5.5.4`, `huggingface-hub 1.15.0`, `torch 2.11.0+cu129`):

```
Resolved 207 packages
 - transformers==5.5.4
 + transformers==5.12.1
```

Only `transformers` changes; no other pin is disturbed and nothing else is downgraded. (`cryptography` / `distro` / `pyparsing` also appear as installs, but they show up identically on an unmodified `requirements.txt` — pre-existing gaps in the image, not caused by this bump.)

## Files

| File | Role |
|---|---|
| `requirements.txt` | the bump, plus a comment recording the `vision_utils` floor and why 5.12.1 |

## Checklist

- [ ] `pre-commit run --all-files` passes — **not run locally**
- [ ] Added/updated tests for new behaviour — **none added**; a version bump has no behaviour of its own, CI is the test
- [ ] `pytest -x` is green — **not run locally** (no torch in this environment); relying on CI
- [x] If launch flags changed, `python3 train.py --help` still parses — no flags changed
- [x] If a public flag was added, it appears in the CLI reference docs — no flags added
- [x] If an example was added, it has a real walkthrough — no examples added
