### PR TITLE
ci(docker): build the rollout engine from sglang's sglang-miles-h3 branch

### DIFF
--- a/.claude/skills/install-miles-diffusion/SKILL.md
+++ b/.claude/skills/install-miles-diffusion/SKILL.md
@@ -57,12 +57,13 @@ Two packages cannot be reproduced at all: `deep_ep` and `flash_mla` are compiled
 an unresolvable `file://` path. `refresh.sh` rewrites it to the release asset the Dockerfile
 pulls from (`FA3_WHEELS_REPO` / `FA3_WHEELS_TAG`), so pip installs it like any other pin.
 
-## sglang and miles are anchored to main
+## sglang and miles are anchored to the refs the Dockerfile builds from
 
-Both come from `main` upstream, as in the Dockerfile (`SGLANG_DIFFUSION_BRANCH=main`,
-`MILES_DIFFUSION_COMMIT=main`). The difference is that the Dockerfile follows the branch tip at
-build time while this pins a commit and checks it is an ancestor of the branch. That check
-matters: the first capture pinned a local cherry-pick that exists in no remote.
+sglang comes from the `sglang-miles-h3` integration branch and miles from `main`, as in the
+Dockerfile (`SGLANG_DIFFUSION_BRANCH=sglang-miles-h3`, `MILES_DIFFUSION_COMMIT=main`). The
+difference is that the Dockerfile follows the branch tip at build time while this pins a commit
+and checks it is an ancestor of the branch. That check matters: the first capture pinned a local
+cherry-pick that exists in no remote.
 
 Because the ancestor check needs real history, the checkout is a blob-filtered full clone rather
 than the image's `--depth=1`, so setuptools_scm reports a different commit count for the same

--- a/.claude/skills/install-miles-diffusion/snapshot/pins.env
+++ b/.claude/skills/install-miles-diffusion/snapshot/pins.env
@@ -9,7 +9,7 @@ PY_VER="${PY_VER:-3.12}"
 PIP_VER="${PIP_VER:-26.1.1}"
 
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
-SGLANG_BRANCH="${SGLANG_BRANCH:-main}"
+SGLANG_BRANCH="${SGLANG_BRANCH:-sglang-miles-h3}"
 SGLANG_DIR="${SGLANG_DIR:-/sgl-workspace/sglang}"
 SGLANG_COMMIT="${SGLANG_COMMIT:-94eef833fe40460230cd6856e2602e038c8305e0}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,9 +34,11 @@ RUN mkdir -p /tmp/fa3-wheel && \
     python -c "import flash_attn_interface" && \
     rm -rf /tmp/fa3-wheel
 
-# sglang-diffusion is merged upstream: track sgl-project/sglang main; SGLANG_DIFFUSION_COMMIT=<sha> pins, "none" follows the branch tip.
+# sglang-diffusion is merged upstream, but the diffusion RL rollouts this repo drives land on the
+# sglang-miles-h3 integration branch before upstream main, so build the engine from there.
+# SGLANG_DIFFUSION_COMMIT=<sha> pins, "none" follows the branch tip.
 ARG SGLANG_DIFFUSION_REPO=https://github.com/sgl-project/sglang.git
-ARG SGLANG_DIFFUSION_BRANCH=main
+ARG SGLANG_DIFFUSION_BRANCH=sglang-miles-h3
 ARG SGLANG_DIFFUSION_COMMIT=none
 # SGLANG_BUILD_RUST_EXTS=none skips the gRPC Rust extension: unused here and the base image has no Rust toolchain.
 RUN cd /sgl-workspace/sglang && \

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,7 +34,7 @@ Useful build args:
 | Arg | Default | What it does |
 |---|---|---|
 | `SGLANG_IMAGE_TAG` | `v0.5.12-cu129` | Base `lmsysorg/sglang` image. |
-| `SGLANG_DIFFUSION_BRANCH` | `main` | sglang branch the rollout engine is built from. |
+| `SGLANG_DIFFUSION_BRANCH` | `sglang-miles-h3` | sglang branch the rollout engine is built from; carries upstream `main` plus the diffusion rollouts this repo needs ahead of it. |
 | `SGLANG_DIFFUSION_COMMIT` | `none` | Pin a sglang sha; `none` follows the branch tip. |
 | `FA3_WHEELS_TAG` | `cu129-x86_64` | Which prebuilt FlashAttention-3 wheel to pull. |
 | `MILES_DIFFUSION_COMMIT` | `main` | Ref of miles_diffusion baked into the image. |


### PR DESCRIPTION
## What

Point the image's rollout engine at sglang's `sglang-miles-h3` branch instead of `main`:
`SGLANG_DIFFUSION_BRANCH=sglang-miles-h3`, plus the three places that document or mirror that
default (`docs/getting-started/installation.md`, the install skill's prose, and
`snapshot/pins.env`).

## Why

`sglang-miles-h3` is upstream `main` plus the diffusion RL rollouts this repo drives before they
reach `main`. Today that is the MiniMax H3 `t2va` rollout (sgl-project/sglang#35598, merged): an
engine built from sglang `main` still rejects the run with `MiniMax H3 does not support rollout`.

Split out of #154 so the image change gets its own build: #154 comes from a fork, and
`pr-test.yml`'s `docker-build` is guarded on `head.repo.full_name == github.repository`, so a fork
PR never builds the image it changes — the GPU suites there run inside the pre-change `latest`.
From a branch in this repo the guard passes and the Dockerfile actually gets built.

## Validation

CI on this PR is the validation: `docker-paths` matches `docker/Dockerfile`, so `docker-build`
builds `radixark/miles_diffusion:pr-<num>` from `sglang-miles-h3` and every GPU suite then runs
inside it.

## Note

`snapshot/pins.env` keeps `SGLANG_COMMIT=94eef833`, which is an ancestor of `sglang-miles-h3`
(so the install skill's ancestor check still passes) but predates the H3 rollout merge. The
snapshot wants a `refresh.sh` pass against the next published image; that is a separate change.
