### PR TITLE
feat(fsdp): add --fsdp-reshard-after-forward for ZeRO-2 style training

### DIFF
--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -130,6 +130,7 @@ See [Dtype Control](../advanced/dtype-control.md).
 | `--train-backend` | enum | `fsdp` | Only value. |
 | `--fsdp-master-dtype` | enum | `fp32` | `fp32` / `bf16` / `fp16`. Load, shard, and optimizer-state precision. |
 | `--fsdp-reduce-dtype` | enum | `fp32` | `bf16` matches flow_grpo's all-bf16 policy but adds cross-rank add-noise. |
+| `--fsdp-reshard-after-forward` / `--no-fsdp-reshard-after-forward` | flag | on | On = ZeRO-3. Off keeps gathered params between forward and backward (ZeRO-2): no backward all-gather, higher memory. |
 | `--diffusion-forward-dtype` | enum | `bf16` | `bf16` / `fp16` / `fp32`. |
 | `--fsdp-cpu-offload` | flag | off | Offloads params, grads, optimizer state; the optimizer then runs on CPU. |
 | `--fsdp-cpu-backend` | str | `gloo` | CPU process group for the above. |

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -656,6 +656,7 @@ def apply_fsdp2(
     logger.info(
         f"FSDP: wrapping {len(modules)} modules of type {layer_cls_to_wrap}, "
         f"param_dtype={param_dtype}, reduce_dtype={reduce_dtype}, "
+        f"reshard_after_forward={args.fsdp_reshard_after_forward}, "
         f"param_dtype_overrides={param_dtype_maps.override_count} "
         f"({param_dtype_maps.override_numel:,} parameters)"
     )
@@ -663,6 +664,7 @@ def apply_fsdp2(
     fsdp_kwargs = {
         "offload_policy": offload_policy,
         "mesh": mesh,
+        "reshard_after_forward": args.fsdp_reshard_after_forward,
     }
 
     # input_dtype_policy owns boundary casts; autocast owns compute and keeps grad-ckpt recompute consistent.

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -147,6 +147,19 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--fsdp-reshard-after-forward",
+                action=argparse.BooleanOptionalAction,
+                default=True,
+                help=(
+                    "Whether FSDP2 reshards parameters after forward "
+                    "(fully_shard's reshard_after_forward). True (default) is "
+                    "ZeRO-3; --no-fsdp-reshard-after-forward keeps gathered "
+                    "parameters between forward and backward (ZeRO-2), saving "
+                    "the backward all-gather at the cost of holding unsharded "
+                    "parameters through the step."
+                ),
+            )
+            parser.add_argument(
                 "--fsdp-flow-shift",
                 type=float,
                 default=None,

--- a/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_integration_worker.py
+++ b/tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_integration_worker.py
@@ -97,6 +97,7 @@ def main():
         args=Namespace(
             diffusion_forward_dtype="bf16",
             fsdp_reduce_dtype="fp32",
+            fsdp_reshard_after_forward=True,
             gradient_checkpointing=False,
         ),
     )


### PR DESCRIPTION
## What

- Add `--fsdp-reshard-after-forward` / `--no-fsdp-reshard-after-forward` (default: on, i.e. current behavior).
- `apply_fsdp2` now forwards the value to every `fully_shard` call (per-block wraps and the root) as `reshard_after_forward`.

## Why

FSDP2 defaults to resharding parameters after forward (ZeRO-3), which re-all-gathers every wrapped block during backward. When the unsharded parameters fit in memory, `--no-fsdp-reshard-after-forward` keeps them gathered between forward and backward (ZeRO-2), removing the backward all-gather at the cost of holding unsharded parameters through the step.

The flag deliberately mirrors `fully_shard`'s own `reshard_after_forward` argument name (prefixed with `fsdp-`) instead of introducing a `zero2` alias, so it maps 1:1 to the PyTorch API.

## Files

- `miles/utils/arguments.py` — new `--fsdp-reshard-after-forward` tri-state flag (BooleanOptionalAction, default `True`).
- `miles/backends/fsdp_utils/actor.py` — pass it via `fsdp_kwargs` to all `fully_shard` calls; include it in the FSDP wrap log line.
- `tests/fast-gpu/backends/fsdp_utils/_param_dtype_map_integration_worker.py` — add the new field to the bare `Namespace` this worker feeds `apply_fsdp2`.
- `docs/user-guide/cli-reference.md` — document the flag in the training-backend table.

## Checklist

- [x] `pre-commit run` passes (run on the touched files; `--all-files` not run)
- [ ] Added/updated tests for new behaviour — **no dedicated test for the ZeRO-2 path** (would need a multi-GPU run); only the existing integration worker's args were updated
- [ ] `pytest -x` is green — **not run locally** (this environment lacks `sglang`, which the test imports require)
- [ ] `python3 train.py --help` still parses — **partially verified**: the new argument's parse behavior (default / `--no-` / explicit on) was verified in an isolated argparse check; full `--help` needs `sglang` locally
- [x] The new flag appears in the CLI reference docs
- [x] No example added (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
