### PR TITLE
perf(h3): overlap the 2-GPU recipe rollout with engine concurrency 2

### DIFF
--- a/scripts/run_diffusion_grpo_h3_t2va_2gpu.py
+++ b/scripts/run_diffusion_grpo_h3_t2va_2gpu.py
@@ -16,6 +16,10 @@ Aligned with verl: LoRA 64/128, lr 1e-4, weight_decay 1e-4, adam_eps 1e-15,
 noise_level 0.7, 10 inference steps, SDE window size 2, flow_shift 12.0 /
 audio_flow_shift 3.0, PickScore over 8 frames.
 
+Engine concurrency is 2, not 1: at 1 the engine idles through the encode and handoff
+of a finished sample before the next denoise starts, and 2 overlaps them. Higher does not
+help -- the extra requests queue inside the engine and only stretch per-sample latency.
+
 The router health-check window is widened well past its 30s x 3 default: H3 denoising
 blocks the engine's uvicorn event loop for ~43s per sample, so /health cannot answer
 while a request runs. A 16-sample eval keeps the loop busy for ~800s straight, which
@@ -156,7 +160,7 @@ def execute(args: ScriptArgs, prompt_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
-        "--sglang-server-concurrency 1 "
+        "--sglang-server-concurrency 2 "
         "--sglang-tp-size 2 "
         "--sglang-sp-degree 1 "
         "--sglang-ulysses-degree 1 "


### PR DESCRIPTION
## What

- `--sglang-server-concurrency` 1 → 2 in the 2-GPU MiniMax H3 t2va recipe.

## Why

At concurrency 1 the engine has nothing queued while a finished sample is encoded and
handed back, so it idles between denoise runs. 2 lets the next sample's denoise overlap
that handoff. 

## Validation

Measured on this recipe, 2x H200, identical `rollout_batch_size` x `n_samples_per_prompt`
(2 x 8 = 16 videos per rollout), medians over 3 rollouts:

| concurrency | run | rollout phase | train_wait | step_time | throughput |
| ---: | :--- | ---: | ---: | ---: | ---: |
| 1 | `diffusion_grpo_h3_t2va_260820-205715-990` | 730 s | 785 s | 1263 s | 0.022 samples/s |
| 2 | `diffusion_grpo_h3_t2va_260821-021535-704` | 445 s | 502 s | 986 s | 0.036 samples/s |

- `pre-commit run --files scripts/run_diffusion_grpo_h3_t2va_2gpu.py` passes.
- `python3 scripts/run_diffusion_grpo_h3_t2va_2gpu.py --help` still parses.

## Files

| File | Role |
| :--- | :--- |
| `scripts/run_diffusion_grpo_h3_t2va_2gpu.py` | recipe: the flag change plus its rationale |

## Checklist

- [x] `pre-commit run --all-files` passes — **run on the touched file only**
- [ ] Added/updated tests for new behaviour — **no tests added**; the change is a launch flag in an example script
- [ ] `pytest -x` is green — **not run**
- [x] If launch flags changed, `python3 train.py --help` still parses — verified on the recipe entrypoint
- [ ] If a public flag was added, it appears in the CLI reference docs — **n/a**, no new flag, only a changed value
- [ ] If an example was added, it has a real walkthrough — **n/a**, existing example
