### PR TITLE
perf(rollout): six independent rollout-path fixes and knobs

### DIFF
--- a/miles/backends/fsdp_utils/checkpoint.py
+++ b/miles/backends/fsdp_utils/checkpoint.py
@@ -85,13 +85,23 @@ class ModelState(Stateful):
 
     def load_state_dict(self, state_dict):
         options = StateDictOptions(strict=False) if self.lora_only else None
-        set_state_dict(
+        incompatible = set_state_dict(
             self.model,
             optimizers=[],
             model_state_dict=state_dict["model"],
             optim_state_dict=None,
             options=options,
         )
+        # strict=False swallows mismatches; lora_only expects missing base keys, anything else is a bad checkpoint
+        unclaimed = list(incompatible.unexpected_keys)
+        unfilled = [k for k in incompatible.missing_keys if not self.lora_only or _is_lora_param_name(k)]
+        if unclaimed or unfilled:
+            logger.error(
+                f"[FSDP] Checkpoint mismatch: {len(unclaimed)} unclaimed checkpoint keys, "
+                f"{len(unfilled)} unfilled model params (e.g. {(unclaimed + unfilled)[:3]})"
+            )
+        else:
+            logger.info(f"[FSDP] Applied {len(state_dict['model'])} params from the checkpoint")
 
 
 class OptimizerState(Stateful):

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -709,6 +709,13 @@ def compute_perf_metrics_from_samples(args, samples, rollout_time):
     if max(non_generation_time) > 0:
         log_dict |= dict_add_prefix(compute_statistics(non_generation_time), "non_generation_time/")
 
+    parser_depths = [s.parser_max_queue_depth for s in samples if s.parser_max_queue_depth is not None]
+    if parser_depths:
+        log_dict |= dict_add_prefix(compute_statistics(parser_depths), "parser_max_queue_depth/")
+    reward_depths = [s.reward_max_queue_depth for s in samples if s.reward_max_queue_depth is not None]
+    if reward_depths:
+        log_dict |= dict_add_prefix(compute_statistics(reward_depths), "reward_max_queue_depth/")
+
     return log_dict
 
 

--- a/miles/rollout/rm_hub/core.py
+++ b/miles/rollout/rm_hub/core.py
@@ -68,6 +68,7 @@ class AsyncRewardActorPool:
         ]
         self._batch_size = batch_size
         self._round_robin_index = 0
+        self._inflight = [0] * num_workers
         logger.info(
             "Initialized %s actor pool with %d workers, %.3f GPUs/worker, batch_size=%d.",
             name,
@@ -76,17 +77,26 @@ class AsyncRewardActorPool:
             batch_size,
         )
 
-    def _next_actor(self):
-        actor = self._actors[self._round_robin_index % len(self._actors)]
+    def _next_actor_idx(self) -> int:
+        i = self._round_robin_index % len(self._actors)
         self._round_robin_index += 1
-        return actor
+        return i
 
-    async def score(self, images: list, prompts: list[str]) -> list[float]:
-        refs = []
+    async def score(self, images: list, prompts: list[str]) -> tuple[list[float], int]:
+        """Score in batches; also report the deepest dispatch-time backlog this call saw."""
+        refs, idxs, max_queue_depth = [], [], 0
         for start in range(0, len(images), self._batch_size):
             end = start + self._batch_size
-            refs.append(self._next_actor().score_batch.remote(images[start:end], prompts[start:end]))
+            i = self._next_actor_idx()
+            max_queue_depth = max(max_queue_depth, self._inflight[i])
+            self._inflight[i] += 1
+            idxs.append(i)
+            refs.append(self._actors[i].score_batch.remote(images[start:end], prompts[start:end]))
 
         loop = asyncio.get_running_loop()
-        chunked_scores = await loop.run_in_executor(None, ray.get, refs)
-        return [float(score) for chunk in chunked_scores for score in chunk]
+        try:
+            chunked_scores = await loop.run_in_executor(None, ray.get, refs)
+        finally:
+            for i in idxs:
+                self._inflight[i] -= 1
+        return [float(score) for chunk in chunked_scores for score in chunk], max_queue_depth

--- a/miles/rollout/rm_hub/ocr.py
+++ b/miles/rollout/rm_hub/ocr.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 import numpy as np
@@ -11,6 +10,8 @@ from PIL import Image
 from miles.utils.misc import SingletonMeta
 from miles.utils.processing_utils import cfhw_to_fhwc, image_or_video_to_uint8
 from miles.utils.types import Sample
+
+from .core import AsyncRewardActorPool
 
 logger = logging.getLogger(__name__)
 
@@ -84,32 +85,24 @@ class OcrRewardActor:
     def __init__(self, use_gpu: bool = False):
         self.scorer = OcrScorer(use_gpu=use_gpu)
 
-    def score_single(self, image: np.ndarray, prompt: str) -> float:
-        return self.scorer([image], [prompt])[0]
+    def score_batch(self, images: list, prompts: list[str]) -> list[float]:
+        assert len(images) == 1, f"OCR scores one image per call, got {len(images)}"
+        return self.scorer(images, prompts)
 
 
-class AsyncOcrPool(metaclass=SingletonMeta):
-    """Ray-backed round-robin pool of :class:`OcrRewardActor` (same lifetime pattern as ``GenerateState``)."""
+class AsyncOcrPool(AsyncRewardActorPool, metaclass=SingletonMeta):
+    """Ray actor pool for CPU PaddleOCR reward inference."""
 
     def __init__(self, args) -> None:
-        if not ray.is_initialized():
-            raise RuntimeError("Ray is not initialized. OCR RM requires Ray for OcrRewardActor.")
-        num_workers = args.ocr_num_workers
-        if num_workers <= 0:
-            raise ValueError(f"ocr_num_workers must be > 0, got {num_workers}")
-        self._actors = [OcrRewardActor.options(num_cpus=1).remote(use_gpu=False) for _ in range(num_workers)]
-        self._round_robin_index = 0
-        logger.info("Initialized OCR reward actor pool with %d workers.", num_workers)
-
-    def _next_actor(self):
-        i = self._round_robin_index % len(self._actors)
-        self._round_robin_index += 1
-        return self._actors[i]
-
-    async def score(self, image: np.ndarray, prompt: str) -> float:
-        ref = self._next_actor().score_single.remote(image, prompt)
-        loop = asyncio.get_running_loop()
-        return float(await loop.run_in_executor(None, ray.get, ref))
+        super().__init__(
+            actor_cls=OcrRewardActor,
+            actor_kwargs={"use_gpu": False},
+            num_workers=args.ocr_num_workers,
+            batch_size=1,
+            num_gpus_per_worker=0,
+            colocate=False,
+            name="OCR",
+        )
 
 
 def _rgb_hwc_from_generated(sample: Sample) -> np.ndarray:
@@ -141,5 +134,6 @@ def _rgb_hwc_from_generated(sample: Sample) -> np.ndarray:
 async def ocr_rm(args, sample: Sample):
     pool = AsyncOcrPool(args)
     image = _rgb_hwc_from_generated(sample)
-    score = await pool.score(image, sample.prompt)
-    return score
+    scores, max_queue_depth = await pool.score([image], [sample.prompt])
+    sample.reward_max_queue_depth = float(max_queue_depth)
+    return scores[0]

--- a/miles/rollout/rm_hub/pickscore.py
+++ b/miles/rollout/rm_hub/pickscore.py
@@ -144,7 +144,9 @@ async def pickscore_rm(args, samples: Sequence[Sample]) -> list[float]:
         prompts.extend([sample.prompt] * len(frames))
         frame_counts.append(len(frames))
 
-    flat_scores = await pool.score(images, prompts)
+    flat_scores, max_queue_depth = await pool.score(images, prompts)
+    for sample in samples:
+        sample.reward_max_queue_depth = float(max_queue_depth)
     scores: list[float] = []
     offset = 0
     for count in frame_counts:

--- a/miles/rollout/rm_hub/pickscore.py
+++ b/miles/rollout/rm_hub/pickscore.py
@@ -39,9 +39,11 @@ def _sample_to_rgb_hwc_uint8_frames(sample: Sample, num_frames: int | None) -> l
     if cfhw is None:
         raise ValueError("generated_output is None")
 
-    fhwc = image_or_video_to_uint8(cfhw_to_fhwc(cfhw.detach().cpu()))
-    indices = sample_frame_indices(fhwc.shape[0], num_frames)
-    return [np.ascontiguousarray(fhwc[i].numpy()) for i in indices]
+    # Convert only the frames that survive: a 107-frame clip yields 8 here, and
+    # converting the whole clip first cost several full-size float32 copies of it
+    indices = sample_frame_indices(cfhw.shape[1], num_frames)
+    fhwc = cfhw_to_fhwc(image_or_video_to_uint8(cfhw[:, indices].detach().cpu()))
+    return [np.ascontiguousarray(fhwc[i].numpy()) for i in range(len(indices))]
 
 
 class PickScoreScorer(torch.nn.Module):

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -122,13 +122,14 @@ class GenerateState(metaclass=SingletonMeta):
             for _ in range(args.rollout_parser_num_workers)
         ]
         self._parser_rr = 0
+        self.parser_inflight = [0] * args.rollout_parser_num_workers
 
         self.reset()
 
-    def next_parser(self):
-        parser = self.response_parsers[self._parser_rr % len(self.response_parsers)]
+    def next_parser_idx(self) -> int:
+        i = self._parser_rr % len(self.response_parsers)
         self._parser_rr += 1
-        return parser
+        return i
 
     @contextmanager
     def dp_rank_context(self):
@@ -196,8 +197,16 @@ async def generate_microgroup(
     with st.stage("generate"):
         raw = await post(url, payload, raw=True)
     with st.stage("deserialize"):
-        ref = state.next_parser().apply_raw.remote(microgroup, raw)
-        microgroup = await asyncio.to_thread(ray.get, ref)
+        i = state.next_parser_idx()
+        queued = state.parser_inflight[i]
+        state.parser_inflight[i] += 1
+        ref = state.response_parsers[i].apply_raw.remote(microgroup, raw)
+        try:
+            microgroup = await asyncio.to_thread(ray.get, ref)
+        finally:
+            state.parser_inflight[i] -= 1
+        for sample in microgroup:
+            sample.parser_max_queue_depth = float(queued)
     st.attach(microgroup)
 
     # Stash the SDE/training step indices on each sample so _train_core can

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -60,6 +60,7 @@ def build_rollout_sampling_params(
                 "rollout_noise_level": args.diffusion_noise_level,
                 "rollout_log_prob_no_const": args.diffusion_log_prob_no_const,
                 "rollout_debug_mode": args.diffusion_debug_mode,
+                "rollout_video_dtype": args.rollout_video_dtype,
                 "rollout_return_denoising_env": True,
                 "rollout_return_dit_trajectory": True,
             }

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -64,6 +64,7 @@ class MilesRouter:
         """Setup all the HTTP routes"""
         # sglang-router api
         self.app.post("/add_worker")(self.add_worker)
+        self.app.post("/remove_worker")(self.remove_worker)
         self.app.get("/list_workers")(self.list_workers)
         # Catch-all route for proxying to SGLang - must be registered LAST
         self.app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])(self.proxy)
@@ -175,6 +176,30 @@ class MilesRouter:
             if self.verbose:
                 print(f"[miles-router] Added new worker: {worker_url}")
 
+        return {"status": "success", "worker_urls": self.worker_request_counts}
+
+    async def remove_worker(self, request: Request):
+        """Drop a worker from the routing pool, same URL forms as add_worker.
+
+        Engines call this on shutdown. Without the route it fell through to the
+        catch-all and was proxied to a worker as if it were a generate request.
+        """
+        worker_url = request.query_params.get("url") or request.query_params.get("worker_url")
+        if not worker_url:
+            body = await request.body()
+            payload = json.loads(body) if body else {}
+            worker_url = payload.get("url") or payload.get("worker_url")
+
+        if not worker_url:
+            return JSONResponse(
+                status_code=400, content={"error": "worker_url is required (use query ?url=... or JSON body)"}
+            )
+
+        self.worker_request_counts.pop(worker_url, None)
+        self.worker_failure_counts.pop(worker_url, None)
+        self.dead_workers.discard(worker_url)
+        if self.verbose:
+            print(f"[miles-router] Removed worker: {worker_url}")
         return {"status": "success", "worker_urls": self.worker_request_counts}
 
     async def list_workers(self, request: Request):

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -253,6 +253,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 help="Samples per prompt sent in one rollout request (sub-batch of the group).",
             )
             parser.add_argument(
+                "--rollout-video-dtype",
+                type=str,
+                choices=["keep", "uint8"],
+                default="keep",
+                help=(
+                    "Dtype of the decoded video in rollout responses. 'keep' returns the "
+                    "engine's raw float tensor; 'uint8' quantises engine-side with the same "
+                    "formula the reward path applies, cutting the response body ~4x. Use "
+                    "'keep' for any consumer that needs the unquantised tensor."
+                ),
+            )
+            parser.add_argument(
                 "--diffusion-fps",
                 type=float,
                 default=None,

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -84,6 +84,9 @@ class Sample:
     dit_trajectory: DiTTrajectory | None = None
 
     inference_time_s: float | None = None
+    # dispatch-time backlog observed when this sample's parse / reward was submitted
+    parser_max_queue_depth: float | None = None
+    reward_max_queue_depth: float | None = None
     peak_memory_mb: float | None = None
 
     # Scalar from single RM (e.g. pickscore) or dict when combining multiple RMs

--- a/tests/fast/rollout/test_rollout_negative_prompt.py
+++ b/tests/fast/rollout/test_rollout_negative_prompt.py
@@ -30,6 +30,7 @@ def _args(**overrides):
         diffusion_noise_level=0.7,
         diffusion_log_prob_no_const=False,
         diffusion_debug_mode=False,
+        rollout_video_dtype="keep",
         train_pipeline_config_path=None,
     )
     values.update(overrides)


### PR DESCRIPTION
## What

Six independent rollout-path improvements, one commit each:

| Commit | Change |
| :--- | :--- |
| `perf(rm_hub)` | select the reward frames before converting a clip to uint8 (8 of 107 frames survive; converting all first cost several full-size float32 copies) |
| `fix(router)` | register `/remove_worker`; engines call it on shutdown and it fell through the catch-all, proxied to a worker as a generate request. The upstream miles-core Python router has the same gap (its engine shutdown posts `/remove_worker`, `miles/router/router.py` never registers it), so this fix is upstreamable as-is |
| `fix(fsdp)` | report checkpoint key mismatches — the LoRA path loads with `strict=False` and discarded `set_state_dict`'s result, so a checkpoint whose keys match nothing "loaded" silently |
| `feat(rollout)` | `--rollout-video-dtype {keep,uint8}`: opt-in engine-side quantisation of the rollout video, default unchanged; needs the sglang counterpart to take effect and is harmless without it |
| `feat(rollout)` | report dispatch queue depth for the reward and parser pools: the pool tracks per-actor in-flight counts, each dispatch reads the chosen actor's backlog, the value rides on the sample (`parser_max_queue_depth` / `reward_max_queue_depth`) and aggregates through `compute_perf_metrics_from_samples` into `perf/{parser,reward}_max_queue_depth/{mean,max,...}` |
| `refactor(rm_hub)` | back the OCR pool with `AsyncRewardActorPool`: `OcrRewardActor` exposes the same `score_batch` interface (asserts one image per call), the bespoke pool/round-robin code is deleted, and OCR inherits the queue-depth metric for free |

## Validation

- Frame selection is bit-identical to the old path on unit-scale, byte-scale and bf16 inputs, 9-11x faster (measured on H200).
- Full stack ran a 17-GPU H3 t2va run resumed from a LoRA checkpoint: `log_prob_mean_abs_diff` 3.0e-05 (in the verified band), 0 faults; with uint8 on, `resp_bytes` 1384 -> 436 MiB.
- Queue-depth metric validated on two 17-GPU first-step ablation runs: the config with frame
  selection reads reward depth ~1.0 (no backlog), the config without it reads 3.0 — matching the
  +58 s rollout-window regression it was built to explain.
- Note on uint8 and throughput: the original 1010-1140 s -> ~490 s train_wait gain measured with
  uint8 was a property of the then-buffering router. The current stack reaches the same steady
  state (502-508 s) at full fp32 with uint8 off, so the flag is bandwidth compression, not the
  performance carrier.
- Rebased branch: `pytest tests/fast` 231 passed; argument parsing (`parse_args --help`) verified.
- Full PR CI green, including the wan2.2 pickscore 4-GPU e2e (exercises the pickscore pool and
  queue metric) and the SD3 OCR e2e (exercises the refactored OCR pool).

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests for new behaviour — **fixture updated for the new arg; no new tests; rm_hub paths are covered by the e2e stages**
- [x] `pytest -x` is green — tests/fast, 231 passed
- [x] If launch flags changed, `python3 train.py --help` still parses
- [ ] If a public flag was added, it appears in the CLI reference docs — **not updated**
- [ ] If an example was added, it has a real walkthrough — n/a


ci-sglang-repo: sgl-project/sglang
ci-sglang-pr: #36754
