### PR TITLE
perf(rollout): stream the rollout data path and fetch in parser actors

### DIFF
--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -716,10 +716,10 @@ def compute_perf_metrics_from_samples(args, samples, rollout_time):
 
     parser_depths = [s.parser_max_queue_depth for s in samples if s.parser_max_queue_depth is not None]
     if parser_depths:
-        log_dict |= dict_add_prefix(compute_statistics(parser_depths), "parser_max_queue_depth/")
+        log_dict["parser_max_queue_depth"] = max(parser_depths)
     reward_depths = [s.reward_max_queue_depth for s in samples if s.reward_max_queue_depth is not None]
     if reward_depths:
-        log_dict |= dict_add_prefix(compute_statistics(reward_depths), "reward_max_queue_depth/")
+        log_dict["reward_max_queue_depth"] = max(reward_depths)
 
     return log_dict
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import multiprocessing
 import random
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -208,7 +209,7 @@ class RolloutManager:
         metrics = _log_eval_rollout_data(rollout_id, self.args, data, result.metrics)
         max_images = self.args.wandb_log_num_images
         if max_images > 0:
-            self._log_images(
+            self._log_images_async(
                 {
                     f"eval_media/{name}_images": payload["samples"]
                     for name, payload in data.items()
@@ -400,7 +401,7 @@ class RolloutManager:
         max_images = self.args.wandb_log_num_images
         interval = self.args.wandb_log_image_interval
         if max_images > 0 and self.rollout_id % interval == 0:
-            self._log_images(
+            self._log_images_async(
                 {"rollout_media/sample_images": samples},
                 max_images=max_images,
                 step_key="rollout/step",
@@ -411,6 +412,10 @@ class RolloutManager:
         if self.custom_expand_samples_to_train_pairs_func is not None:
             return self.custom_expand_samples_to_train_pairs_func(self.args, samples, rewards, raw_rewards)
         return flow_grpo_expand_samples_to_train_pairs(self.args, samples, rewards, raw_rewards)
+
+    def _log_images_async(self, *args, **kwargs) -> None:
+        # mp4 encode + wandb upload take ~1min per log round; keep them off the train barrier
+        threading.Thread(target=self._log_images, args=args, kwargs=kwargs, daemon=True).start()
 
     def _log_images(
         self,

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -194,20 +194,34 @@ async def generate_microgroup(
     )
 
     st = hooks.StageTimer()
-    with st.stage("generate"):
-        raw = await post(url, payload, raw=True)
-    with st.stage("deserialize"):
-        i = state.next_parser_idx()
-        queued = state.parser_inflight[i]
-        state.parser_inflight[i] += 1
-        # .remote() copies the ~1GB body into plasma in the calling thread; keep it off the event loop
-        parser, pending = state.response_parsers[i], microgroup
-        try:
-            microgroup = await asyncio.to_thread(lambda: ray.get(parser.apply_raw.remote(pending, raw)))
-        finally:
-            state.parser_inflight[i] -= 1
-        for sample in microgroup:
-            sample.parser_max_queue_depth = float(queued)
+    if args.rollout_fetch_in_parser:
+        with st.stage("generate"):
+            router_url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}"
+            i = state.next_parser_idx()
+            queued = state.parser_inflight[i]
+            state.parser_inflight[i] += 1
+            parser, pending = state.response_parsers[i], microgroup
+            try:
+                microgroup = await asyncio.to_thread(
+                    lambda: ray.get(parser.fetch_and_apply.remote(pending, router_url, payload))
+                )
+            finally:
+                state.parser_inflight[i] -= 1
+    else:
+        with st.stage("generate"):
+            raw = await post(url, payload, raw=True)
+        with st.stage("deserialize"):
+            i = state.next_parser_idx()
+            queued = state.parser_inflight[i]
+            state.parser_inflight[i] += 1
+            # .remote() copies the ~1GB body into plasma in the calling thread; keep it off the event loop
+            parser, pending = state.response_parsers[i], microgroup
+            try:
+                microgroup = await asyncio.to_thread(lambda: ray.get(parser.apply_raw.remote(pending, raw)))
+            finally:
+                state.parser_inflight[i] -= 1
+    for sample in microgroup:
+        sample.parser_max_queue_depth = float(queued)
     st.attach(microgroup)
 
     # Stash the SDE/training step indices on each sample so _train_core can

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -200,9 +200,10 @@ async def generate_microgroup(
         i = state.next_parser_idx()
         queued = state.parser_inflight[i]
         state.parser_inflight[i] += 1
-        ref = state.response_parsers[i].apply_raw.remote(microgroup, raw)
+        # .remote() copies the ~1GB body into plasma in the calling thread; keep it off the event loop
+        parser, pending = state.response_parsers[i], microgroup
         try:
-            microgroup = await asyncio.to_thread(ray.get, ref)
+            microgroup = await asyncio.to_thread(lambda: ray.get(parser.apply_raw.remote(pending, raw)))
         finally:
             state.parser_inflight[i] -= 1
         for sample in microgroup:

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -8,7 +8,7 @@ import httpx
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from starlette.responses import Response
+from starlette.responses import StreamingResponse
 
 
 logger = logging.getLogger(__name__)
@@ -136,24 +136,27 @@ class MilesRouter:
         headers = dict(request.headers)
 
         try:
-            response = await self.client.request(request.method, url, content=body, headers=headers)
-            # Pass through raw bytes — JSON re-serialization is too expensive for large tensor payloads.
-            content = await response.aread()
-            # uvicorn stamps its own date/server even when present; drop the
-            # worker's so the client does not see them twice. Everything else
-            # forwards verbatim: the relay is byte-transparent, so the worker's
-            # framing headers stay true for this hop as well.
-            out_headers = dict(response.headers)
-            for hop in ("date", "server"):
-                out_headers.pop(hop, None)
-            return Response(
-                content=content,
-                status_code=response.status_code,
-                headers=out_headers,
-            )
-
-        finally:
+            upstream = self.client.build_request(request.method, url, content=body, headers=headers)
+            response = await self.client.send(upstream, stream=True)
+        except Exception:
             self._finish_url(worker_url)
+            raise
+
+        # The relay is byte-transparent, so the worker's headers stay true here;
+        # drop only date/server, which uvicorn re-stamps.
+        out_headers = dict(response.headers)
+        for hop in ("date", "server"):
+            out_headers.pop(hop, None)
+
+        async def relay():
+            try:
+                async for chunk in response.aiter_raw():
+                    yield chunk
+            finally:
+                await response.aclose()
+                self._finish_url(worker_url)
+
+        return StreamingResponse(relay(), status_code=response.status_code, headers=out_headers)
 
     async def add_worker(self, request: Request):
         """Add a new worker to the router.
@@ -214,18 +217,12 @@ class MilesRouter:
         return {"urls": list(self.worker_request_counts.keys())}
 
     def _use_url(self):
-        """Select worker URL with minimal active requests."""
-
-        if not self.dead_workers:
-            # Healthy path: select from all workers
-            url = min(self.worker_request_counts, key=self.worker_request_counts.get)
-        else:
-            # Degraded path: select from workers not in dead_workers
-            valid_workers = (w for w in self.worker_request_counts if w not in self.dead_workers)
-            try:
-                url = min(valid_workers, key=self.worker_request_counts.get)
-            except ValueError:
-                raise RuntimeError("No healthy workers available in the pool") from None
+        """Select the worker URL with the fewest active requests."""
+        candidates = (w for w in self.worker_request_counts if w not in self.dead_workers)
+        try:
+            url = min(candidates, key=self.worker_request_counts.get)
+        except ValueError:
+            raise RuntimeError("No healthy workers available in the pool") from None
 
         self.worker_request_counts[url] += 1
         return url

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -65,6 +65,8 @@ class MilesRouter:
         # sglang-router api
         self.app.post("/add_worker")(self.add_worker)
         self.app.post("/remove_worker")(self.remove_worker)
+        self.app.get("/pick_worker_for_request")(self.pick_worker_for_request)
+        self.app.post("/worker_finish_request")(self.worker_finish_request)
         self.app.get("/list_workers")(self.list_workers)
         # Catch-all route for proxying to SGLang - must be registered LAST
         self.app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])(self.proxy)
@@ -157,6 +159,24 @@ class MilesRouter:
                 self._finish_url(worker_url)
 
         return StreamingResponse(relay(), status_code=response.status_code, headers=out_headers)
+
+    async def pick_worker_for_request(self, request: Request):
+        """Least-loaded engine URL; the pick counts in-flight until /worker_finish_request acks it.
+
+        A client that dies without acking leaks one count -- acceptable until crashes exist.
+        """
+        try:
+            url = self._use_url()
+        except RuntimeError as e:
+            return JSONResponse(status_code=503, content={"error": str(e)})
+        return {"url": url}
+
+    async def worker_finish_request(self, request: Request):
+        worker_url = request.query_params.get("url")
+        if not worker_url or worker_url not in self.worker_request_counts:
+            return JSONResponse(status_code=400, content={"error": f"unknown worker url {worker_url!r}"})
+        self._finish_url(worker_url)
+        return {"status": "success"}
 
     async def add_worker(self, request: Request):
         """Add a new worker to the router.

--- a/miles/router/router.py
+++ b/miles/router/router.py
@@ -139,10 +139,17 @@ class MilesRouter:
             response = await self.client.request(request.method, url, content=body, headers=headers)
             # Pass through raw bytes — JSON re-serialization is too expensive for large tensor payloads.
             content = await response.aread()
+            # uvicorn stamps its own date/server even when present; drop the
+            # worker's so the client does not see them twice. Everything else
+            # forwards verbatim: the relay is byte-transparent, so the worker's
+            # framing headers stay true for this hop as well.
+            out_headers = dict(response.headers)
+            for hop in ("date", "server"):
+                out_headers.pop(hop, None)
             return Response(
                 content=content,
                 status_code=response.status_code,
-                headers=dict(response.headers),
+                headers=out_headers,
             )
 
         finally:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1261,6 +1261,18 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 "engines fed when trajectory tensors are large.",
             )
             parser.add_argument(
+                "--rollout-fetch-in-parser",
+                action="store_true",
+                default=False,
+                help=(
+                    "Parser actors pick a least-loaded engine via the miles router, fetch the "
+                    "rollout response straight from it and parse it in place, so bodies skip "
+                    "both the router's data plane and the manager's event loop. Requires "
+                    "--use-miles-router and at least as many parser workers as concurrency "
+                    "slots, since a fetch occupies its actor for the whole generation."
+                ),
+            )
+            parser.add_argument(
                 "--pickscore-num-gpus-per-worker",
                 type=float,
                 default=1.0,
@@ -1483,6 +1495,17 @@ def miles_validate_args(args):
 
     if args.save_interval is not None:
         assert args.save is not None, "'--save' is required when save_interval is set."
+
+    if args.rollout_fetch_in_parser and not args.use_miles_router:
+        raise ValueError("--rollout-fetch-in-parser requires --use-miles-router for its pick/ack endpoints")
+
+    if args.rollout_fetch_in_parser and args.rollout_num_gpus:
+        slots = args.sglang_server_concurrency * args.rollout_num_gpus // args.rollout_num_gpus_per_engine
+        if args.rollout_parser_num_workers < slots:
+            raise ValueError(
+                f"--rollout-fetch-in-parser needs --rollout-parser-num-workers >= the "
+                f"{slots} concurrency slots, got {args.rollout_parser_num_workers}"
+            )
 
     if (args.micro_batch_size_sample is None) != (args.micro_batch_size_tstep is None):
         raise ValueError("--micro-batch-size-sample and --micro-batch-size-tstep must be set together")

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -215,6 +216,47 @@ def apply_rollout_image_response(
 
 @ray.remote(num_cpus=1)
 class RolloutImageResponseParserActor:
+    def __init__(self) -> None:
+        import httpx
+
+        # Keep-alive off: a pooled connection reused as the server's 5s idle timeout fires dies mid-read
+        self._client = httpx.Client(limits=httpx.Limits(max_keepalive_connections=0), timeout=httpx.Timeout(None))
+
     def apply_raw(self, samples: list[Sample], raw: bytes) -> list[Sample]:
         bodies = msgpack.unpackb(raw, raw=False)
+        return [apply_rollout_image_response(s, b) for s, b in zip(samples, bodies, strict=True)]
+
+    def fetch_and_apply(
+        self, samples: list[Sample], router_url: str, payload: dict, max_retries: int = 60
+    ) -> list[Sample]:
+        """Fetch the rollout response straight from an engine and parse it in this process.
+
+        Args:
+            samples: samples to fill from the response, positionally paired with its bodies.
+            router_url: router base URL, used to pick a least-loaded engine and to ack completion.
+            payload: JSON body of the generate request.
+            max_retries: attempts before giving up; each retry re-picks, so failures re-balance.
+
+        Returns:
+            The filled samples.
+        """
+        for attempt in range(max_retries):
+            try:
+                picked = self._client.get(f"{router_url}/pick_worker_for_request")
+                picked.raise_for_status()
+                worker = picked.json()["url"]
+                try:
+                    response = self._client.post(f"{worker}/rollout/generate", json=payload)
+                    response.raise_for_status()
+                finally:
+                    try:
+                        self._client.post(f"{router_url}/worker_finish_request", params={"url": worker})
+                    except Exception:
+                        pass  # a lost ack costs one count; failing the request costs the sample
+                break
+            except Exception:
+                if attempt + 1 >= max_retries:
+                    raise
+                time.sleep(1)
+        bodies = msgpack.unpackb(response.content, raw=False)
         return [apply_rollout_image_response(s, b) for s, b in zip(samples, bodies, strict=True)]

--- a/scripts/run_diffusion_grpo_ltx23_sglang.py
+++ b/scripts/run_diffusion_grpo_ltx23_sglang.py
@@ -89,6 +89,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
+        "--rollout-fetch-in-parser "
         "--sglang-server-concurrency 4 "
         "--sglang-attention-backend torch_sdpa "
         "--sglang-dit-precision bf16 "
@@ -107,7 +108,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--gradient-checkpointing "
         "--micro-batch-size-sample 1 "
         "--micro-batch-size-tstep 1 "
-        "--rollout-parser-num-workers 8 "
+        "--rollout-parser-num-workers 16 "
     )
 
     misc_args = (

--- a/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
+++ b/scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py
@@ -100,6 +100,8 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
+        "--rollout-fetch-in-parser "
+        "--rollout-parser-num-workers 16 "
         "--sglang-server-concurrency 4 "
         "--sglang-attention-backend torch_sdpa "
         "--update-weight-buffer-size 2147483648 "

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -84,6 +84,8 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
+        "--rollout-fetch-in-parser "
+        "--rollout-parser-num-workers 16 "
         "--sglang-server-concurrency 8 "
         "--sglang-dit-precision fp16 "
         "--sglang-vae-slicing "

--- a/scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py
@@ -130,6 +130,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
+        "--rollout-fetch-in-parser "
         "--sglang-server-concurrency 8 "
         "--miles-router-health-check-failure-threshold 30 "
         "--update-weight-buffer-size 4294967296 "
@@ -149,6 +150,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
             "--num-gpus-per-node 4 "
             "--rollout-num-gpus 4 "
             "--rollout-num-gpus-per-engine 2 "
+            "--rollout-parser-num-workers 16 "
             "--dp-replicate-size 1 "
         )
         if args.four_gpu_ci
@@ -158,6 +160,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
             "--num-gpus-per-node 8 "
             "--rollout-num-gpus 16 "
             "--rollout-num-gpus-per-engine 2 "
+            "--rollout-parser-num-workers 64 "
             "--dp-replicate-size 2 "
         )
     ) + (

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -113,6 +113,8 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     sglang_args = (
         "--use-miles-router "
+        "--rollout-fetch-in-parser "
+        "--rollout-parser-num-workers 16 "
         "--sglang-server-concurrency 8 "
         "--sglang-dit-precision fp16 "
         "--sglang-vae-slicing "

--- a/tests/fast/router/test_pick_worker.py
+++ b/tests/fast/router/test_pick_worker.py
@@ -1,0 +1,60 @@
+"""Router pick/ack endpoints: the in-flight ledger behind direct engine fetch.
+
+Mental model (one request, direct mode):
+
+    actor -- GET /pick_worker_for_request --> router   count[worker] += 1
+    actor -- POST {worker}/rollout/generate            (bytes skip the router)
+    actor -- POST /worker_finish_request?url=worker    count[worker] -= 1
+
+Covered: the pick returns the least-loaded worker and counts it in-flight (1),
+the ack returns the count so load balancing converges (2), an unknown ack is a
+400 and mutates nothing (3), and an empty pool is a 503, not a crash (4).
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+from starlette.testclient import TestClient
+
+from miles.router.router import MilesRouter
+
+
+def _router():
+    args = Namespace(
+        miles_router_max_connections=4,
+        miles_router_timeout=None,
+        miles_router_health_check_failure_threshold=3,
+        sglang_server_concurrency=2,
+        rollout_num_gpus=2,
+        rollout_num_gpus_per_engine=1,
+    )
+    return MilesRouter(args)
+
+
+def test_pick_counts_in_flight_and_ack_returns_it():
+    router = _router()
+    router.worker_request_counts = {"http://a:1": 1, "http://b:2": 0}
+    with TestClient(router.app) as client:
+        picked = client.get("/pick_worker_for_request").json()["url"]
+        assert picked == "http://b:2"  # least loaded
+        assert router.worker_request_counts["http://b:2"] == 1
+
+        assert client.post("/worker_finish_request", params={"url": picked}).status_code == 200
+        assert router.worker_request_counts["http://b:2"] == 0
+
+
+def test_unknown_ack_is_rejected_without_mutation():
+    router = _router()
+    router.worker_request_counts = {"http://a:1": 1}
+    with TestClient(router.app) as client:
+        assert client.post("/worker_finish_request", params={"url": "http://ghost:9"}).status_code == 400
+        assert router.worker_request_counts == {"http://a:1": 1}
+
+
+def test_empty_pool_returns_503():
+    router = _router()
+    with TestClient(router.app) as client:
+        assert client.get("/pick_worker_for_request").status_code == 503


### PR DESCRIPTION
## What

The rollout data path, six commits: response bodies stop passing through single-threaded
choke points and, in fetch-in-parser mode, skip the router's data plane entirely. The router
stays transparent: hitting it is equivalent to hitting the sglang endpoint, headers included.

| Commit | Change |
| :--- | :--- |
| `perf(rollout)` | submit the parser task off the event loop — `.remote()` serialises the ~1GB body into plasma in the calling thread; `main` already collects off-loop, this moves the submit too. Only affects the via-router path (with `--rollout-fetch-in-parser` the body never enters the manager); mechanism shared with the measured frame-selection fix, not individually ablated |
| `fix(router)` | drop only the worker's `date`/`server` headers (uvicorn stamps its own, so forwarding duplicates them). Everything else forwards verbatim: the relay is byte-transparent, so the worker's framing headers stay true for this hop — verified empirically for identity, chunked and `connection: close` downstreams |
| `perf(router)` | stream responses through the proxy instead of buffering them — buffering held every in-flight body twice in router memory and serialised the two hops (34 GiB -> 144 MiB router RSS at 16-way concurrency) |
| `perf(rollout)` | log rollout media off the train barrier — the every-10th-rollout mp4 encode + wandb upload took ~1 min inside the convert step; a daemon thread keeps it off the critical path (the media panels never honoured step alignment anyway) |
| `feat(rollout)` | `--rollout-fetch-in-parser`: parser actors ask the router `GET /pick_worker_for_request` for a least-loaded engine, fetch the rollout response straight from it, parse it in place, and ack `POST /worker_finish_request` in a `finally`. Bodies skip both the router's data plane and the manager's event loop; the router keeps registration, health and load counts. One flag, not two: fetching in the actor exists precisely to bypass the router, so a via-router actor fetch mode was dropped |
| `ci(scripts)` | run all five e2e recipes with `--rollout-fetch-in-parser`, parser pools sized to the concurrency slots (`server_concurrency x engines`, the arguments.py minimum) — the fetch path is exercised by every GPU e2e stage instead of none |

## Validation

- `pytest tests/fast`: 234 passed on the rebased branch; `python3 train_diffusion.py --help` parses.
- Writing the pick/ack test surfaced a pre-existing bug: `_use_url` on an empty pool raised a bare
  `ValueError` (a 500 through the pick endpoint); the selection paths are now unified and an empty
  pool is a 503.
- Header transparency verified with a local three-endpoint experiment (identity, chunked,
  `connection: close` downstreams through a byte-transparent streaming relay): bodies intact,
  framing regenerated per hop, the only artifact being duplicated `date`/`server` — hence the
  two-header drop.
- A 17-GPU H3 production run served by these five data-path commits (deployed together with the
  #198 fixes, since merged) held 502-508 s train_wait steady, `log_prob_mean_abs_diff` ~4e-05,
  zero pairing faults. First-step ablations attribute the gap of a #199-only stack (~730 s) to
  the missing #198 items — chiefly reward-side frame selection — not to these commits; with #198
  now in main, this branch carries the full measured stack.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour — `tests/fast/router/test_pick_worker.py` covers the pick/ack ledger (least-loaded pick, ack decrement, unknown ack 400, empty pool 503), registered to the stage-a-cpu runner
- [x] `pytest -x` is green — tests/fast, 234 passed
- [x] If launch flags changed, `python3 train_diffusion.py --help` still parses
- [ ] If a public flag was added, it appears in the CLI reference docs — **not updated**
- [ ] If an example was added, it has a real walkthrough — n/a
