### PR TITLE
feat(sft): media-clip dict reads and encoder host-RAM offload

### DIFF
--- a/miles/rollout/encoder_hub/__init__.py
+++ b/miles/rollout/encoder_hub/__init__.py
@@ -3,8 +3,9 @@
 Each family module provides:
 - ``load_encoder(args, device)``: load the frozen encode components (tokenizer/text
   encoder/VAE) from the ``--sft-encoder-checkpoint`` HF name or path;
-- ``encode_sample(encoder, pixels, prompt, generator)``: encode one media/prompt pair
-  into a cached train sample (clean latent + cond kwargs);
+- ``encode_sample(encoder, media_clip, prompt, generator)``: encode one decoded media dict
+  ``{"video": [C, T, H, W] in [-1, 1], "fps": float | None}`` into a cached train
+  sample (clean latent + cond kwargs);
 - ``validate_args(args)``: family-specific encode constraints.
 """
 

--- a/miles/rollout/encoder_hub/wan2_2.py
+++ b/miles/rollout/encoder_hub/wan2_2.py
@@ -32,11 +32,13 @@ def load_encoder(args, device: torch.device) -> dict:
 
 
 @torch.no_grad()
-def encode_sample(encoder: dict, pixels: torch.Tensor, prompt: str, generator: torch.Generator) -> dict:
+def encode_sample(encoder: dict, media_clip: dict, prompt: str, generator: torch.Generator) -> dict:
     from diffusers.pipelines.wan.pipeline_wan import prompt_clean
 
     device = encoder["device"]
-    latent = encoder["vae"].encode(pixels.unsqueeze(0).to(device, torch.float32)).latent_dist.sample(generator)
+    latent = (
+        encoder["vae"].encode(media_clip["video"].unsqueeze(0).to(device, torch.float32)).latent_dist.sample(generator)
+    )
     latent = (latent - encoder["latents_mean"]) / encoder["latents_std"]
 
     inputs = encoder["tokenizer"](

--- a/miles/rollout/sft_rollout.py
+++ b/miles/rollout/sft_rollout.py
@@ -34,7 +34,8 @@ def sft_sample_key(args, item: dict) -> tuple[str, int]:
     """Content-addressed cache filename and latent-sampling seed for one (media, prompt) item."""
     stat = Path(item["media"]).stat()
     digest = hashlib.sha256(
-        f"{args.sft_encoder_checkpoint}|{args.diffusion_height}x{args.diffusion_width}"
+        f"{args.diffusion_model_family}|{args.sft_encoder_checkpoint}"
+        f"|{args.diffusion_height}x{args.diffusion_width}"
         f"|{args.diffusion_output_num_frames}s{args.sft_frame_stride}"
         f"|{item['media']}|{stat.st_size}|{stat.st_mtime_ns}|{item['prompt']}".encode()
     ).digest()
@@ -98,7 +99,7 @@ def _decode_video(path: str) -> tuple[torch.Tensor, float]:
     return torch.from_numpy(frames.copy()).permute(0, 3, 1, 2), fps
 
 
-def read_media_clip(path: str, *, height: int, width: int, num_frames: int, frame_stride: int) -> torch.Tensor:
+def read_media_clip(path: str, *, height: int, width: int, num_frames: int, frame_stride: int) -> dict:
     if Path(path).suffix.lower() in IMAGE_EXTENSIONS:
         if num_frames != 1:
             raise ValueError(f"{path} is an image, which requires --diffusion-output-num-frames 1")
@@ -106,8 +107,9 @@ def read_media_clip(path: str, *, height: int, width: int, num_frames: int, fram
         from PIL import Image
 
         frames = torch.from_numpy(np.asarray(Image.open(path).convert("RGB"))).permute(2, 0, 1)[None].float()
+        fps = None
     else:
-        video, _ = _decode_video(path)
+        video, fps = _decode_video(path)
         span = (num_frames - 1) * frame_stride + 1
         if video.shape[0] < span:
             raise ValueError(f"{path} has {video.shape[0]} frames, need {span}")
@@ -121,22 +123,42 @@ def read_media_clip(path: str, *, height: int, width: int, num_frames: int, fram
     frames = torch.nn.functional.interpolate(frames, size=(new_h, new_w), mode="bilinear", antialias=True)
     top = (new_h - height) // 2
     left = (new_w - width) // 2
-    return frames[:, :, top : top + height, left : left + width].permute(1, 0, 2, 3)
+    return {"video": frames[:, :, top : top + height, left : left + width].permute(1, 0, 2, 3), "fps": fps}
+
+
+def _relocate(obj, device: torch.device):
+    """Move every module/tensor found in a family's encoder structure."""
+    if isinstance(obj, (torch.nn.Module, torch.Tensor)):
+        return obj.to(device)
+    if isinstance(obj, dict):
+        return {key: _relocate(value, device) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_relocate(value, device) for value in obj)
+    return obj
 
 
 @ray.remote
 class SftEncodeActor:
+    """Loads the family encoder once; with --sft-offload-encoder it sleeps in
+    host RAM between encode bursts instead of holding the GPU for the whole run."""
+
     def __init__(self, args):
         from miles.rollout.encoder_hub import get_encoder
 
         self.args = args
         self.encoder_module = get_encoder(args.diffusion_model_family)
         self.encoder = self.encoder_module.load_encoder(args, torch.device("cuda"))
+        if args.sft_offload_encoder:
+            self.encoder = _relocate(self.encoder, torch.device("cpu"))
+            torch.cuda.empty_cache()
 
     def encode(self, items: list[dict], cache_dir: str) -> int:
         args = self.args
+        encoder = self.encoder
+        if args.sft_offload_encoder:
+            encoder = _relocate(encoder, torch.device("cuda"))
         for item in items:
-            pixels = read_media_clip(
+            media_clip = read_media_clip(
                 item["media"],
                 height=args.diffusion_height,
                 width=args.diffusion_width,
@@ -144,12 +166,15 @@ class SftEncodeActor:
                 frame_stride=args.sft_frame_stride,
             )
             generator = torch.Generator().manual_seed(item["latent_seed"])
-            pair = self.encoder_module.encode_sample(self.encoder, pixels, item["prompt"], generator)
+            pair = self.encoder_module.encode_sample(encoder, media_clip, item["prompt"], generator)
             out_path = Path(cache_dir) / item["cache_name"]
             # Temp-then-rename so an interrupted write never leaves a loadable-looking cache entry.
             tmp_path = out_path.with_name(out_path.name + ".tmp")
             torch.save(pair, tmp_path)
             os.replace(tmp_path, out_path)
+        if args.sft_offload_encoder:
+            self.encoder = _relocate(encoder, torch.device("cpu"))
+            torch.cuda.empty_cache()
         return len(items)
 
 

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -608,6 +608,11 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             # cached next to the jsonl under .sft_cache/, one content-addressed file per sample.
             parser.add_argument("--sft-frame-stride", type=int, default=1, help="SFT encode temporal stride")
             parser.add_argument(
+                "--sft-offload-encoder",
+                action="store_true",
+                help="keep the frozen encoder in host RAM, on the GPU only during encode bursts",
+            )
+            parser.add_argument(
                 "--sft-encoder-checkpoint",
                 type=str,
                 default=None,

--- a/tests/fast/rollout/test_sft_read_media.py
+++ b/tests/fast/rollout/test_sft_read_media.py
@@ -1,4 +1,14 @@
-"""Image and video branches of the SFT media reader."""
+"""read_media_clip: file -> media dict.
+
+    image  --PIL-------------------.
+                                    >-- [-1,1] float -- scale/crop -- {"video", "fps"}
+    video  --ffmpeg rgb24 (+fps)---'
+
+What each test pins:
+  image branch      single frame, exact passthrough, fps None, multi-frame rejected
+  window selection  which source frames survive num_frames x frame_stride (mocked decode)
+  decoder           bit-exact rgb24 round trip through real ffmpeg, probed fps
+"""
 
 from tests.ci.ci_register import register_cpu_ci
 
@@ -39,9 +49,9 @@ def _write_png(path, height, width):
 def test_image_reads_as_single_frame(tmp_path):
     path = tmp_path / "a.png"
     _write_png(path, 120, 200)
-    clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
-    assert clip.shape == (3, 1, 64, 64)
-    assert clip.min() >= -1.0 and clip.max() <= 1.0
+    media_clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
+    assert media_clip["video"].shape == (3, 1, 64, 64)
+    assert media_clip["video"].min() >= -1.0 and media_clip["video"].max() <= 1.0
 
 
 def test_image_rejects_multi_frame(tmp_path):
@@ -54,9 +64,9 @@ def test_image_rejects_multi_frame(tmp_path):
 def test_image_no_resize_when_exact(tmp_path):
     path = tmp_path / "a.png"
     _write_png(path, 64, 64)
-    clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
+    media_clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
     original = torch.from_numpy(np.asarray(Image.open(path))).permute(2, 0, 1).float() / 127.5 - 1.0
-    assert torch.allclose(clip[:, 0], original)
+    assert torch.allclose(media_clip["video"][:, 0], original)
 
 
 def _patch_decoder(monkeypatch, num_frames=100):
@@ -70,10 +80,11 @@ def _patch_decoder(monkeypatch, num_frames=100):
 def test_video_window_is_centered_and_strided(tmp_path, monkeypatch):
     _patch_decoder(monkeypatch)
     # span = (21-1)*2+1 = 41 frames, centered in 100 -> starts at 29
-    clip = read_media_clip(str(tmp_path / "a.mp4"), height=8, width=8, num_frames=21, frame_stride=2)
-    assert clip.shape == (3, 21, 8, 8)
+    media_clip = read_media_clip(str(tmp_path / "a.mp4"), height=8, width=8, num_frames=21, frame_stride=2)
+    assert media_clip["video"].shape == (3, 21, 8, 8)
+    assert media_clip["fps"] == 24.0
     # frame values encode their source index, so the window is verifiable
-    kept = [int(round(float(v) * 127.5 + 127.5)) for v in clip[0, :, 0, 0]]
+    kept = [int(round(float(v) * 127.5 + 127.5)) for v in media_clip["video"][0, :, 0, 0]]
     assert kept == list(range(29, 70, 2))
 
 
@@ -153,11 +164,11 @@ def test_read_media_clip_on_a_real_file(tmp_path):
         ],
         check=True,
     )
-    clip = read_media_clip(str(path), height=32, width=32, num_frames=9, frame_stride=2)
-    assert clip.shape == (3, 9, 32, 32)
-    assert clip.min() >= -1.0 and clip.max() <= 1.0
+    media_clip = read_media_clip(str(path), height=32, width=32, num_frames=9, frame_stride=2)
+    assert media_clip["video"].shape == (3, 9, 32, 32)
+    assert media_clip["video"].min() >= -1.0 and media_clip["video"].max() <= 1.0
     # testsrc animates, so the kept frames must differ from one another
-    assert not torch.equal(clip[:, 0], clip[:, -1])
+    assert not torch.equal(media_clip["video"][:, 0], media_clip["video"][:, -1])
 
 
 def test_ffmpeg_failure_is_reported(tmp_path):

--- a/tests/fast/rollout/test_sft_sample_key.py
+++ b/tests/fast/rollout/test_sft_sample_key.py
@@ -12,6 +12,7 @@ from miles.rollout.sft_rollout import sft_sample_key
 
 def _args(**overrides):
     base = dict(
+        diffusion_model_family="wan2_2",
         sft_encoder_checkpoint="ckpt",
         diffusion_height=480,
         diffusion_width=832,
@@ -61,3 +62,12 @@ def test_key_is_per_sample(tmp_path):
     name_a, _ = sft_sample_key(_args(), {"media": str(a), "prompt": "p"})
     name_b, _ = sft_sample_key(_args(), {"media": str(b), "prompt": "p"})
     assert name_a != name_b
+
+
+def test_key_changes_with_model_family(tmp_path):
+    video = tmp_path / "a.mp4"
+    video.write_bytes(b"x" * 100)
+    item = {"media": str(video), "prompt": "p"}
+    name_wan, _ = sft_sample_key(_args(), item)
+    name_other, _ = sft_sample_key(_args(diffusion_model_family="other"), item)
+    assert name_wan != name_other


### PR DESCRIPTION
Stacked on #200 (`sft/ffmpeg-decode`) — review that one first.

## What

- `read_media_clip` returns `{"video": tensor, "fps": float | None}` instead of a bare tensor.
- New `--sft-offload-encoder` flag: the frozen encoder is loaded from disk once, then sleeps in host RAM and only occupies the GPU inside an encode burst (a generic module/tensor walk moves any family encoder structure).
- The cache key includes the model family.

## Why

Three generalizations the wan2.2-shaped SFT plugin hardcodes, each needed by an upcoming family whose encoder differs:

- **fps**: a family whose model consumes a fixed frame rate must reject mismatched sources at encode time; the reader already probes fps for free, so hand it over.
- **offload**: an encoder much larger than wan's UMT5 cannot sit on the GPU for the whole run beside the trainer. Host RAM round trips cost seconds per burst instead of a from-disk reload, and nothing when the cache is warm.
- **cache key**: two families given the same geometry args would otherwise collide in the cache.

Offload is a deployment decision, not a family property, so it is a launch flag rather than per-family configuration.

## Validation

`pytest tests/fast/rollout tests/fast/backends/fsdp_utils/test_loss_hub_sft.py` — 24 passed locally (3 ffmpeg-backed tests skip without the binary); 12 passed with `CI=true` on a devbox with real ffmpeg.

## Checklist

- [x] `pre-commit run --all-files` passes — ruff, black, isort on the touched files
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green
- [x] If launch flags changed, `python3 train.py --help` still parses
- [ ] If a public flag was added, it appears in the CLI reference docs — **not yet: repo has no CLI reference page for SFT flags; help text added inline**
- [ ] If an example was added, it has a real walkthrough — **no example added**

---

Second of a 4-PR stack. Next: per-sigma-decile loss metrics, then the H3 family itself.
