### PR TITLE
feat(sft): per-sigma-bucket loss metrics

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -416,7 +416,12 @@ class FSDPTrainRayActor(TrainRayActor):
         if self.args.diffusion_recompute_old_log_prob:
             with timer("recompute_old_log_prob"), torch.no_grad():
                 # write_old_log_prob returns before recording; this is never reduced.
-                unused_metrics = new_metric_buffer(self.parallel_state.dp_group, device, self.models)
+                unused_metrics = new_metric_buffer(
+                    self.parallel_state.dp_group,
+                    device,
+                    self.models,
+                    sigma_buckets=self.args.log_loss_sigma_bucket,
+                )
                 # Skip window 0: its training forward runs on the same pre-update weights and doubles as the recompute.
                 # Start the id after window 0's micro-batches to stay aligned with the training loop.
                 microbatch_id = len(microbatch_schedule[0])
@@ -446,7 +451,12 @@ class FSDPTrainRayActor(TrainRayActor):
                 # LEGACY 2D parity: pad cond to the whole-window width. TODO: remove with legacy 2D path.
                 legacy_pad_to_len = self._maybe_legacy_window_pad_len(train_pairs, microbatch_ranges)
 
-                metrics = new_metric_buffer(self.parallel_state.dp_group, device, self.models)
+                metrics = new_metric_buffer(
+                    self.parallel_state.dp_group,
+                    device,
+                    self.models,
+                    sigma_buckets=self.args.log_loss_sigma_bucket,
+                )
 
                 for pair_lo, pair_hi in microbatch_ranges:
                     chunk = train_pairs[pair_lo:pair_hi]

--- a/miles/backends/fsdp_utils/loss_hub/sft.py
+++ b/miles/backends/fsdp_utils/loss_hub/sft.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 from miles.backends.fsdp_utils.loss_hub.types import DiffusionLossContext, PreparedBatch
+from miles.backends.fsdp_utils.metrics import sigma_bucket_key
 from miles.utils.hash_utils import stable_hash
 from miles.utils.metric_buffer import MetricBuffer
 
@@ -91,7 +92,7 @@ def prepare_sft_batch(
         neg_cond=None,
         joint_cond=None,
         advantage=torch.ones(bsz, device=device, dtype=torch.float32),
-        extras={"target": noise - x0},
+        extras={"target": noise - x0, "sigmas": sigmas},
     )
 
 
@@ -113,4 +114,8 @@ def sft_loss_formula(
 
     with torch.no_grad():
         metrics.emit_mean("loss", total=loss_sum, count=len(batch))
+        num_buckets = ctx.args.log_loss_sigma_bucket
+        for pair_loss, sigma in zip(per_pair, prepared.extras["sigmas"], strict=True):
+            bucket = min(int(float(sigma) * num_buckets), num_buckets - 1)
+            metrics.emit_mean(sigma_bucket_key(bucket, num_buckets), total=pair_loss, count=1)
     return loss_sum

--- a/miles/backends/fsdp_utils/metrics.py
+++ b/miles/backends/fsdp_utils/metrics.py
@@ -34,9 +34,19 @@ SCHEMA = {
 }
 
 
-def new_metric_buffer(group, device: torch.device, components: Collection[str]) -> MetricBuffer:
+def sigma_bucket_key(bucket: int, num_buckets: int) -> str:
+    return f"loss_sigma_{bucket / num_buckets:g}_{(bucket + 1) / num_buckets:g}"
+
+
+def new_metric_buffer(
+    group, device: torch.device, components: Collection[str], sigma_buckets: int = 0
+) -> MetricBuffer:
     """Buffer for one optimizer step, reducing over the DP group."""
     schema = dict(SCHEMA)
+    # SFT loss by sigma bucket: velocity-MSE magnitude varies strongly with the
+    # corruption level, so only bucketed curves are comparable across steps.
+    for bucket in range(sigma_buckets):
+        schema[sigma_bucket_key(bucket, sigma_buckets)] = MetricReduce.MEAN
     for component in components if len(components) > 1 else ():
         schema[f"log_prob_mean_abs_diff_{component}"] = MetricReduce.MEAN
         schema[f"model_output_mean_abs_diff_{component}"] = MetricReduce.MEAN

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -608,6 +608,12 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
             # cached next to the jsonl under .sft_cache/, one content-addressed file per sample.
             parser.add_argument("--sft-frame-stride", type=int, default=1, help="SFT encode temporal stride")
             parser.add_argument(
+                "--log-loss-sigma-bucket",
+                type=int,
+                default=10,
+                help="number of sigma buckets for per-bucket loss curves (0 disables; emitted by the SFT loss today)",
+            )
+            parser.add_argument(
                 "--sft-offload-encoder",
                 action="store_true",
                 help="keep the frozen encoder in host RAM, on the GPU only during encode bursts",

--- a/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
+++ b/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
@@ -47,7 +47,7 @@ def _ctx(models, rollout_id=3, microbatch_id=0, dp_rank=0, config=None):
         train_pipeline_config=config if config is not None else _Config(),
         sde_backend=None,
         scheduler=_scheduler(),
-        args=Namespace(seed=42),
+        args=Namespace(seed=42, log_loss_sigma_bucket=5),
         forward_dtype=torch.float32,
         device=torch.device("cpu"),
         rollout_id=rollout_id,
@@ -68,7 +68,8 @@ class _Metrics:
         self.seen = {}
 
     def emit_mean(self, key, *, total, count):
-        self.seen[key] = (float(total), count)
+        prev_total, prev_count = self.seen.get(key, (0.0, 0))
+        self.seen[key] = (prev_total + float(total), prev_count + count)
 
 
 class TestPrepareSftBatch:
@@ -203,3 +204,27 @@ class TestSftLossFormula:
         )
         assert torch.allclose(loss, torch.tensor(float(len(batch))))
         assert metrics.seen["loss"] == (float(len(batch)), len(batch))
+
+    def test_sigma_buckets_partition_the_loss(self):
+        torch.manual_seed(0)
+        ctx = _ctx({"transformer": nn.Identity()})
+        batch = _batch()
+        prepared = prepare_sft_batch(ctx, batch)
+        metrics = _Metrics()
+        loss = sft_loss_formula(
+            ctx,
+            batch,
+            prepared,
+            new_pred=prepared.extras["target"] + 1.0,
+            ref_pred=None,
+            metrics=metrics,
+        )
+        from miles.backends.fsdp_utils.metrics import new_metric_buffer, sigma_bucket_key
+
+        bucket_keys = [key for key in metrics.seen if key.startswith("loss_sigma_")]
+        declared = new_metric_buffer(None, torch.device("cpu"), ["transformer"], sigma_buckets=5)._schema
+        assert set(bucket_keys) <= set(declared), "emitted buckets must be pre-declared for the DP reduce layout"
+        expected = {sigma_bucket_key(min(int(float(s) * 5), 4), 5) for s in prepared.extras["sigmas"]}
+        assert set(bucket_keys) == expected
+        total = sum(metrics.seen[key][0] for key in bucket_keys)
+        assert torch.allclose(torch.tensor(total), loss)


### PR DESCRIPTION
Stacked on #201 (`sft/encoder-contract`) — review that one first.

## What

- `train/loss_sigma_{lo}_{hi}` bucket metrics alongside the aggregate SFT loss; bucket count set by the new `--log-loss-sigma-bucket` flag (default 10, 0 disables). The flag is not SFT-scoped: RL losses are per-timestep too and can emit into the same buckets later.

## Why

The velocity-MSE magnitude varies strongly with the corruption level (a sigma≈1 pair costs several times a sigma≈0.6 pair), so with a handful of samples per step the aggregate curve is dominated by which sigmas the step happened to draw and looks like noise. Curves bucketed by sigma decile are comparable across steps; in practice they are the only readable convergence signal for small-batch SFT.

Bucket keys enter the `MetricBuffer` schema at construction, derived from the same `sigma_bucket_key` helper the emitter uses: `MetricBuffer` packs the cross-rank reduce layout from its schema, so declaration and emission must never drift. All ranks share args, so the layout stays rank-consistent. Empty buckets in a step simply emit nothing.

## Files

| File | Role |
|---|---|
| `miles/backends/fsdp_utils/metrics.py` | `sigma_bucket_key` helper; buckets added to the buffer schema |
| `miles/backends/fsdp_utils/actor.py` | Pass the flag into `new_metric_buffer` |
| `miles/utils/arguments.py` | `--log-loss-sigma-bucket` |
| `miles/backends/fsdp_utils/loss_hub/sft.py` | `sigmas` carried in extras; per-pair bucket emission |
| `tests/fast/backends/fsdp_utils/test_loss_hub_sft.py` | With a non-default bucket count (5): buckets partition the loss exactly and match the declared schema; the metrics fake now accumulates like the real buffer |

## Validation

`pytest tests/fast/backends/fsdp_utils/test_loss_hub_sft.py` — 11 passed; `train_diffusion.py --help` parses with the new flag (verified on a devbox with full deps). Production evidence: the H3 SFT runs trained with these curves (wandb project `miles-diffusion-sft`); the aggregate loss oscillates 0.15–0.31 while per-decile curves show clean convergence.

## Checklist

- [x] `pre-commit run --all-files` passes — ruff, black on the touched files
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green
- [x] If launch flags changed, `python3 train.py --help` still parses — `train_diffusion.py --help`, exit 0
- [ ] If a public flag was added, it appears in the CLI reference docs — **repo has no CLI reference page for SFT flags; help text added inline**
- [ ] If an example was added, it has a real walkthrough — **no example added**

---

Third of a 4-PR stack; the H3 family PR follows.
