### PR TITLE
refactor(sft): hand raw uint8 clips to encode_sample

### DIFF
--- a/miles/rollout/encoder_hub/__init__.py
+++ b/miles/rollout/encoder_hub/__init__.py
@@ -4,7 +4,7 @@ Each family module provides:
 - ``load_encoder(args, device)``: load the frozen encode components (tokenizer/text
   encoder/VAE) from the ``--sft-encoder-checkpoint`` HF name or path;
 - ``encode_sample(encoder, media_clip, prompt, generator)``: encode one decoded media dict
-  ``{"video": [C, T, H, W] in [-1, 1], "fps": float | None}`` into a cached train
+  ``{"video": [C, T, H, W] uint8, "fps": float | None}`` into a cached train
   sample (clean latent + cond kwargs);
 - ``validate_args(args)``: family-specific encode constraints.
 """

--- a/miles/rollout/encoder_hub/h3.py
+++ b/miles/rollout/encoder_hub/h3.py
@@ -150,8 +150,7 @@ def encode_sample(encoder: dict, media_clip: dict, prompt: str, generator: torch
     if media_clip["fps"] is not None and abs(media_clip["fps"] - H3_FPS) > 0.01:
         raise ValueError(f'H3 encode requires {H3_FPS:g} fps clips, got {media_clip["fps"]:g}')
 
-    # Engine input is uint8 frames: invert the reader's [-1, 1] normalization (exact roundtrip).
-    frames = ((media_clip["video"].permute(1, 2, 3, 0) + 1.0) * 127.5).round().clamp(0, 255).to(torch.uint8).numpy()
+    frames = media_clip["video"].permute(1, 2, 3, 0).numpy()
 
     rows, latent_t, latent_h, latent_w = minimax_h3_encode_reference_video_rows(
         encoder["vae"], frames, encoder["vae_arch"]

--- a/miles/rollout/encoder_hub/wan2_2.py
+++ b/miles/rollout/encoder_hub/wan2_2.py
@@ -36,9 +36,8 @@ def encode_sample(encoder: dict, media_clip: dict, prompt: str, generator: torch
     from diffusers.pipelines.wan.pipeline_wan import prompt_clean
 
     device = encoder["device"]
-    latent = (
-        encoder["vae"].encode(media_clip["video"].unsqueeze(0).to(device, torch.float32)).latent_dist.sample(generator)
-    )
+    pixels = media_clip["video"].unsqueeze(0).to(device, torch.float32) / 127.5 - 1.0
+    latent = encoder["vae"].encode(pixels).latent_dist.sample(generator)
     latent = (latent - encoder["latents_mean"]) / encoder["latents_std"]
 
     inputs = encoder["tokenizer"](

--- a/miles/rollout/sft_rollout.py
+++ b/miles/rollout/sft_rollout.py
@@ -106,7 +106,7 @@ def read_media_clip(path: str, *, height: int, width: int, num_frames: int, fram
         import numpy as np
         from PIL import Image
 
-        frames = torch.from_numpy(np.asarray(Image.open(path).convert("RGB"))).permute(2, 0, 1)[None].float()
+        frames = torch.from_numpy(np.asarray(Image.open(path).convert("RGB"))).permute(2, 0, 1)[None]
         fps = None
     else:
         video, fps = _decode_video(path)
@@ -114,16 +114,18 @@ def read_media_clip(path: str, *, height: int, width: int, num_frames: int, fram
         if video.shape[0] < span:
             raise ValueError(f"{path} has {video.shape[0]} frames, need {span}")
         start = (video.shape[0] - span) // 2
-        frames = video[start : start + span : frame_stride].float()
-    frames = frames / 127.5 - 1.0
+        frames = video[start : start + span : frame_stride]
 
-    scale = max(height / frames.shape[2], width / frames.shape[3])
-    new_h = max(height, round(frames.shape[2] * scale))
-    new_w = max(width, round(frames.shape[3] * scale))
-    frames = torch.nn.functional.interpolate(frames, size=(new_h, new_w), mode="bilinear", antialias=True)
-    top = (new_h - height) // 2
-    left = (new_w - width) // 2
-    return {"video": frames[:, :, top : top + height, left : left + width].permute(1, 0, 2, 3), "fps": fps}
+    # Always emit uint8; each family owns its preprocessing.
+    if frames.shape[2:] != (height, width):
+        scale = max(height / frames.shape[2], width / frames.shape[3])
+        new_h = max(height, round(frames.shape[2] * scale))
+        new_w = max(width, round(frames.shape[3] * scale))
+        resized = torch.nn.functional.interpolate(frames.float(), size=(new_h, new_w), mode="bilinear", antialias=True)
+        top = (new_h - height) // 2
+        left = (new_w - width) // 2
+        frames = resized[:, :, top : top + height, left : left + width].round().clamp(0, 255).to(torch.uint8)
+    return {"video": frames.permute(1, 0, 2, 3), "fps": fps}
 
 
 def _relocate(obj, device: torch.device):

--- a/tests/fast/rollout/test_sft_read_media.py
+++ b/tests/fast/rollout/test_sft_read_media.py
@@ -1,13 +1,14 @@
 """read_media_clip: file -> media dict.
 
     image  --PIL-------------------.
-                                    >-- [-1,1] float -- scale/crop -- {"video", "fps"}
+                                    >-- uint8 [C,T,H,W] -- scale/crop -- {"video", "fps"}
     video  --ffmpeg rgb24 (+fps)---'
 
 What each test pins:
-  image branch      single frame, exact passthrough, fps None, multi-frame rejected
+  image branch      single frame, byte-exact passthrough, fps None, multi-frame rejected
   window selection  which source frames survive num_frames x frame_stride (mocked decode)
   decoder           bit-exact rgb24 round trip through real ffmpeg, probed fps
+  canvas rule       exact-size clips pass through uint8-untouched; others resize+requantize
 """
 
 from tests.ci.ci_register import register_cpu_ci
@@ -51,7 +52,7 @@ def test_image_reads_as_single_frame(tmp_path):
     _write_png(path, 120, 200)
     media_clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
     assert media_clip["video"].shape == (3, 1, 64, 64)
-    assert media_clip["video"].min() >= -1.0 and media_clip["video"].max() <= 1.0
+    assert media_clip["video"].dtype == torch.uint8
 
 
 def test_image_rejects_multi_frame(tmp_path):
@@ -65,8 +66,8 @@ def test_image_no_resize_when_exact(tmp_path):
     path = tmp_path / "a.png"
     _write_png(path, 64, 64)
     media_clip = read_media_clip(str(path), height=64, width=64, num_frames=1, frame_stride=1)
-    original = torch.from_numpy(np.asarray(Image.open(path))).permute(2, 0, 1).float() / 127.5 - 1.0
-    assert torch.allclose(media_clip["video"][:, 0], original)
+    original = torch.from_numpy(np.asarray(Image.open(path))).permute(2, 0, 1)
+    assert torch.equal(media_clip["video"][:, 0], original)
 
 
 def _patch_decoder(monkeypatch, num_frames=100):
@@ -84,7 +85,7 @@ def test_video_window_is_centered_and_strided(tmp_path, monkeypatch):
     assert media_clip["video"].shape == (3, 21, 8, 8)
     assert media_clip["fps"] == 24.0
     # frame values encode their source index, so the window is verifiable
-    kept = [int(round(float(v) * 127.5 + 127.5)) for v in media_clip["video"][0, :, 0, 0]]
+    kept = [int(v) for v in media_clip["video"][0, :, 0, 0]]
     assert kept == list(range(29, 70, 2))
 
 
@@ -166,7 +167,7 @@ def test_read_media_clip_on_a_real_file(tmp_path):
     )
     media_clip = read_media_clip(str(path), height=32, width=32, num_frames=9, frame_stride=2)
     assert media_clip["video"].shape == (3, 9, 32, 32)
-    assert media_clip["video"].min() >= -1.0 and media_clip["video"].max() <= 1.0
+    assert media_clip["video"].dtype == torch.uint8
     # testsrc animates, so the kept frames must differ from one another
     assert not torch.equal(media_clip["video"][:, 0], media_clip["video"][:, -1])
 


### PR DESCRIPTION
Stacked on #203 (`sft/h3-family`) — review that one first.

## What

- `read_media_clip` emits raw uint8 `[C, T, H, W]`; normalization moves into each family's `encode_sample` (wan2.2 does its own `/127.5 - 1`, H3 hands the bytes straight to the engine recipe).

## Why

The reader used to normalize to [-1, 1] for everyone, which fit wan2.2 but forced H3 to invert the normalization back to uint8 because the engine recipe validates uint8 input and normalizes internally. Making the reader purely mechanical (decode, window, geometry) removes that normalize-then-invert round trip and puts preprocessing where each model family already defines it.

Canvas-sized clips now pass through byte-exact end to end; only off-canvas sources are resized in float and re-quantized.

## Validation

`pytest tests/fast/rollout` — 14 passed locally; 16 passed on a devbox with sglang and ffmpeg (image passthrough is now asserted byte-exact with `torch.equal`, strictly stronger than the previous `allclose`).

## Checklist

- [x] `pre-commit run --all-files` passes — ruff, black on the touched files
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green
- [ ] If launch flags changed, `python3 train.py --help` still parses — **no flags changed**
- [ ] If a public flag was added, it appears in the CLI reference docs — **no flags added**
- [ ] If an example was added, it has a real walkthrough — **no example added**
