### PR TITLE
feat(sft): export LoRA checkpoints to loader-ready safetensors

### DIFF
--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -67,6 +67,8 @@ SFT: the encode pool (`miles/rollout/encoder_hub/h3.py`) imports the engine's ow
 rollout conditioning. Dataset clips must already sit on the serving grid (short_edge=768
 canvas, 24 fps, 17n+5 frames); `--sft-offload-encoder` keeps the ~70GB encoder pair in host
 RAM outside encode bursts, and `--train-only` lifts the LoRA-IPC weight-sync requirement.
+`scripts/export_lora.py` converts any saved checkpoint into one safetensors file (+
+`adapter_config.json` sidecar) directly loadable by sgl-diffusion's `--lora-path`.
 
 H3 solves `x0 = x + sigma * v`, the opposite sign from the flow-matching convention the shared
 train and rollout steps assume, so `compute_noise_pred` returns the negated velocity. Both halves

--- a/miles/backends/fsdp_utils/lora_export.py
+++ b/miles/backends/fsdp_utils/lora_export.py
@@ -1,0 +1,65 @@
+"""Convert a PEFT LoRA DCP checkpoint into one loader-ready safetensors file.
+
+Renames ``model_state.model.base_model.model.<m>.lora_{A,B}.default.weight`` (the
+PEFT DCP layout every miles LoRA run saves) to ``transformer.<m>.lora_{A,B}.weight``,
+plus an ``adapter_config.json`` sidecar so loaders pick up lora_alpha. Multi-DiT
+families are not handled yet and fail the layout check loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+DCP_PREFIX = "model_state.model.base_model.model."
+
+
+def flatten_state(tree, prefix=""):
+    if isinstance(tree, torch.Tensor):
+        yield prefix, tree
+        return
+    for key, value in tree.items():
+        yield from flatten_state(value, f"{prefix}.{key}" if prefix else key)
+
+
+def convert_lora_state(flat) -> dict:
+    """PEFT DCP names -> diffusers/sglang loader names."""
+    out = {}
+    for name, tensor in flatten_state(flat):
+        if "lora_" not in name:
+            continue
+        if not name.startswith(DCP_PREFIX):
+            raise ValueError(f"unexpected LoRA key layout: {name}")
+        out["transformer." + name.removeprefix(DCP_PREFIX).replace(".default.", ".")] = tensor.contiguous()
+    if not out:
+        raise ValueError("checkpoint holds no LoRA tensors")
+    return out
+
+
+def export_lora_safetensors(ckpt_dir: Path, out: Path, lora_rank: int, lora_alpha: int) -> Path:
+    """Gather the DCP model dir under ``ckpt_dir`` and write ``out`` plus its sidecar."""
+    from safetensors.torch import save_file
+    from torch.distributed.checkpoint.format_utils import dcp_to_torch_save
+
+    model_dir = Path(ckpt_dir) / "model"
+    if not model_dir.is_dir():
+        raise ValueError(f"{model_dir} is not a checkpoint model directory")
+
+    with tempfile.NamedTemporaryFile(suffix=".pt") as tmp:
+        dcp_to_torch_save(str(model_dir), tmp.name)
+        flat = torch.load(tmp.name, map_location="cpu", weights_only=False)
+
+    out_state = convert_lora_state(flat)
+    out = Path(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    save_file(out_state, str(out), metadata={"lora_rank": str(lora_rank), "lora_alpha": str(lora_alpha)})
+    sidecar = out.parent / "adapter_config.json"
+    sidecar.write_text(json.dumps({"lora_alpha": lora_alpha, "r": lora_rank}, indent=1) + "\n")
+    logger.info("exported %d LoRA tensors -> %s (+ %s)", len(out_state), out, sidecar.name)
+    return out

--- a/scripts/export_lora.py
+++ b/scripts/export_lora.py
@@ -1,0 +1,29 @@
+"""Export a miles LoRA checkpoint (torch.distributed.checkpoint) to safetensors.
+
+Thin CLI over :func:`miles.backends.fsdp_utils.lora_export.export_lora_safetensors`.
+
+Usage:
+    python3 scripts/export_lora.py --ckpt-dir <run>/ckpt/iter_0000070 \\
+        --out practical_dynamics_fx.safetensors --lora-rank 64 --lora-alpha 128
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from miles.backends.fsdp_utils.lora_export import export_lora_safetensors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt-dir", type=Path, required=True, help="iter_XXXXXXX checkpoint directory")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--lora-rank", type=int, required=True)
+    parser.add_argument("--lora-alpha", type=int, required=True)
+    args = parser.parse_args()
+    export_lora_safetensors(args.ckpt_dir, args.out, args.lora_rank, args.lora_alpha)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fast/backends/fsdp_utils/test_lora_export.py
+++ b/tests/fast/backends/fsdp_utils/test_lora_export.py
@@ -1,0 +1,46 @@
+"""DCP LoRA key mapping -> loader names.
+
+    model_state.model.base_model.model.<m>.lora_A.default.weight
+        -> transformer.<m>.lora_A.weight        (nested dicts flattened first)
+
+Pins: renaming, non-LoRA keys skipped, foreign layouts and LoRA-free states rejected.
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.backends.fsdp_utils.lora_export import convert_lora_state
+
+
+def test_maps_peft_dcp_names_to_loader_names():
+    flat = {
+        "model_state": {
+            "model": {
+                "base_model": {
+                    "model": {
+                        "blocks.0.attn.to_q": {
+                            "lora_A": {"default": {"weight": torch.zeros(4, 8)}},
+                            "lora_B": {"default": {"weight": torch.zeros(8, 4)}},
+                            "base_layer": {"weight": torch.zeros(8, 8)},
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out = convert_lora_state(flat)
+    assert set(out) == {
+        "transformer.blocks.0.attn.to_q.lora_A.weight",
+        "transformer.blocks.0.attn.to_q.lora_B.weight",
+    }
+
+
+def test_rejects_foreign_layout_and_empty_state():
+    with pytest.raises(ValueError, match="unexpected LoRA key layout"):
+        convert_lora_state({"oops": {"lora_A": {"weight": torch.zeros(1)}}})
+    with pytest.raises(ValueError, match="no LoRA tensors"):
+        convert_lora_state({"model_state": {"model": {"w": torch.zeros(1)}}})


### PR DESCRIPTION
Stacked on #204 (`sft/uint8-media`) — review that one first.

## What

- `miles/backends/fsdp_utils/lora_export.py`: convert the DCP model directory a LoRA run saves into one safetensors file that sgl-diffusion's `--lora-path` (and diffusers/ComfyUI peft loaders) accept, plus an `adapter_config.json` sidecar carrying `lora_alpha`/`r`.
- `scripts/export_lora.py`: thin CLI over the util.

## Why

A LoRA SFT/GRPO run leaves a `torch.distributed.checkpoint` directory keyed `model_state.model.base_model.model.<module>.lora_{A,B}.default.weight` — nothing downstream loads that. Without this the training recipe produces artifacts that cannot reach the engine.

The script is model-agnostic: miles applies LoRA through PEFT identically for every family, so the DCP layout it converts is the same everywhere; per-model name fusion (e.g. H3's stacked QKV) is the loader's job and already lives in sgl-diffusion's per-model `param_names_mapping`. Traced load path: `normalize_lora_state_dict` detects the `.lora_A/.lora_B` layout as STANDARD, per-model regexes strip the `transformer.` root and stack `to_{q,k,v}` into the fused `qkv_proj`. Alpha travels in the `adapter_config.json` sidecar because sgl-diffusion reads that file (not safetensors metadata) when `--lora-alpha` is absent.

The cache-precompute companion script stays out on purpose: with `--sft-offload-encoder` the first epoch builds the same content-addressed cache on the fly at identical per-clip cost, so precompute is an optimization, not a gap.

## Validation

`pytest tests/fast/backends/fsdp_utils/test_lora_export.py` — 2 passed. The same conversion produced every LoRA used in this project's H3 serving runs (sglang `--lora-path` round trips confirmed on 8×H200 and 2-GPU tp2 servers).

## Checklist

- [x] `pre-commit run --all-files` passes — ruff, black on the touched files
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green
- [ ] If launch flags changed, `python3 train.py --help` still parses — **no flags changed**
- [ ] If a public flag was added, it appears in the CLI reference docs — **no flags added**
- [ ] If an example was added, it has a real walkthrough — **no example added**
