### PR TITLE
feat(h3,SFT): dataset-bound one-click recipe with portable dataset paths

### DIFF
--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -38,7 +38,8 @@ Recipe: `scripts/run_diffusion_sft_h3_t2va.py`
 **Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
 
 ```bash
-MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_h3_t2va.py
+python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads the default dataset on first run
+# custom data: --extra-args "--prompt-data /abs/train.jsonl"
 ```
 
 ### 4.2 Flow-GRPO + PickScore (2 GPUs)

--- a/miles/backends/fsdp_utils/metrics.py
+++ b/miles/backends/fsdp_utils/metrics.py
@@ -35,7 +35,12 @@ SCHEMA = {
 
 
 def sigma_bucket_key(bucket: int, num_buckets: int) -> str:
-    return f"loss_sigma_{bucket / num_buckets:g}_{(bucket + 1) / num_buckets:g}"
+    # Keep integer edges as floats (0.0, 1.0) so key names stay stable across bucket counts.
+    def edge(value: float) -> str:
+        text = f"{value:g}"
+        return text if "." in text else f"{value:.1f}"
+
+    return f"loss_sigma_{edge(bucket / num_buckets)}_{edge((bucket + 1) / num_buckets)}"
 
 
 def new_metric_buffer(

--- a/miles/rollout/sft_rollout.py
+++ b/miles/rollout/sft_rollout.py
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 ENCODE_GPU_FRACTION = 0.3
 
 
+def resolve_media_path(media: str, prompt_data: str) -> str:
+    """Relative media paths are anchored at the dataset jsonl's directory (portable datasets)."""
+    if os.path.isabs(media):
+        return media
+    return str(Path(prompt_data).parent / media)
+
+
 def sft_sample_key(args, item: dict) -> tuple[str, int]:
     """Content-addressed cache filename and latent-sampling seed for one (media, prompt) item."""
     stat = Path(item["media"]).stat()
@@ -239,7 +246,7 @@ def generate_rollout(args, rollout_id, data_source, evaluation: bool = False) ->
         media = sample.metadata.get("video") or sample.metadata.get("image")
         if media is None:
             raise ValueError(f"sample {sample.index} metadata has neither 'video' nor 'image': {sample.metadata}")
-        item = {"media": media, "prompt": sample.prompt}
+        item = {"media": resolve_media_path(media, args.prompt_data), "prompt": sample.prompt}
         item["cache_name"], item["latent_seed"] = sft_sample_key(args, item)
         items.append(item)
 

--- a/scripts/run_diffusion_sft_h3_t2va.py
+++ b/scripts/run_diffusion_sft_h3_t2va.py
@@ -17,7 +17,8 @@ Per rollout step: 64 samples, num_steps_per_rollout=4, so 16 samples per optimiz
 step over 8 dp ranks is 2 samples per rank at mbs=1.
 
 Usage:
-    MILES_SCRIPT_DATA_JSONL=/abs/data.jsonl python3 scripts/run_diffusion_sft_h3_t2va.py
+    python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads DATASET on first run
+    # custom data: append --prompt-data /abs/train.jsonl via --extra-args (last flag wins)
 """
 
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ import typer
 import miles.utils.external_utils.command_utils as U
 
 MODEL = "MiniMaxAI/MiniMax-H3"
+DATASET = "rockdu/WISA-80K-Practical-Dynamics-254"
 WANDB_PROJECT = "miles-diffusion-sft"
 
 # H3 DiT LoRA targets: packed self-attn and FFN (miles-side diffusers module names).
@@ -35,16 +37,18 @@ LORA_TARGET_MODULES = "attn.to_q attn.to_k attn.to_v attn.to_out.0 ff.net.0.proj
 
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
-    data_jsonl: str = ""
+    data_dir: str = "/root/datasets"
     resume_ckpt: str = ""
     start_rollout: int = -1
     num_epoch: int = 3
     extra_args: str = ""
 
 
+def prepare(args: ScriptArgs):
+    U.hf_download_dataset(DATASET, data_dir=args.data_dir)
+
+
 def execute(args: ScriptArgs) -> None:
-    if not args.data_jsonl:
-        raise SystemExit("set --data-jsonl (or MILES_SCRIPT_DATA_JSONL) to a jsonl with prompt + metadata.video")
     run_name = f"diffusion_sft_h3_t2va_{U.create_run_id()}"
 
     ckpt_args = (
@@ -58,7 +62,7 @@ def execute(args: ScriptArgs) -> None:
 
     rollout_args = (
         "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
-        f"--prompt-data {args.data_jsonl} "
+        f"--prompt-data {args.data_dir}/{DATASET.split('/')[1]}/train.jsonl "
         "--input-key prompt "
         "--rollout-batch-size 64 "
         f"--num-epoch {args.num_epoch} "
@@ -120,6 +124,7 @@ def execute(args: ScriptArgs) -> None:
 
 @U.dataclass_cli
 def main(args: ScriptArgs) -> None:
+    prepare(args)
     execute(args)
 
 

--- a/scripts/run_diffusion_sft_h3_t2va.py
+++ b/scripts/run_diffusion_sft_h3_t2va.py
@@ -13,8 +13,9 @@ Videos must already sit on H3's serving grid: short_edge=768 canvas, 24 fps, and
 17n+5 frame count (the default spec is 1344x768 / 107 frames, ~4.46 s). See
 scripts/prepare_wisa_h3_lighting.py for a dataset pipeline that produces this format.
 
-Per rollout step: 64 samples, num_steps_per_rollout=4, so 16 samples per optimizer
-step over 8 dp ranks is 2 samples per rank at mbs=1.
+Per rollout step: 32 samples, num_steps_per_rollout=4, so 8 samples per optimizer
+step over 8 dp ranks is 1 sample per rank at mbs=1 (the batch size the reference
+lr/wd defaults were validated with).
 
 Usage:
     python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads DATASET on first run
@@ -64,7 +65,7 @@ def execute(args: ScriptArgs) -> None:
         "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
         f"--prompt-data {args.data_dir}/{DATASET.split('/')[1]}/train.jsonl "
         "--input-key prompt "
-        "--rollout-batch-size 64 "
+        "--rollout-batch-size 32 "
         f"--num-epoch {args.num_epoch} "
         "--num-steps-per-rollout 4 "
         # H3 serving grid: 16:9 canvas at short_edge=768, 24 fps, 17n+5 frames.

--- a/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
+++ b/tests/fast/backends/fsdp_utils/test_loss_hub_sft.py
@@ -228,3 +228,10 @@ class TestSftLossFormula:
         assert set(bucket_keys) == expected
         total = sum(metrics.seen[key][0] for key in bucket_keys)
         assert torch.allclose(torch.tensor(total), loss)
+
+
+def test_sigma_bucket_key_edges_are_floats():
+    from miles.backends.fsdp_utils.metrics import sigma_bucket_key
+
+    assert sigma_bucket_key(0, 10) == "loss_sigma_0.0_0.1"
+    assert sigma_bucket_key(9, 10) == "loss_sigma_0.9_1.0"

--- a/tests/fast/rollout/test_sft_resolve_media_path.py
+++ b/tests/fast/rollout/test_sft_resolve_media_path.py
@@ -1,0 +1,15 @@
+"""Relative media paths anchor at the dataset jsonl directory; absolute paths pass through."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+from miles.rollout.sft_rollout import resolve_media_path
+
+
+def test_absolute_path_passes_through():
+    assert resolve_media_path("/data/clips/a.mp4", "/elsewhere/train.jsonl") == "/data/clips/a.mp4"
+
+
+def test_relative_path_anchors_at_jsonl_dir():
+    assert resolve_media_path("clips/a.mp4", "/data/set/train.jsonl") == "/data/set/clips/a.mp4"


### PR DESCRIPTION
## What

- Relative `metadata.video`/`metadata.image` paths now resolve against the dataset jsonl's directory (`resolve_media_path`); absolute paths untouched.
- The H3 SFT recipe is dataset-bound in the core-recipe style: `prepare()` downloads `rockdu/WISA-80K-Practical-Dynamics-254` via `U.hf_download_dataset` and `execute()` points `--prompt-data` at it — `python3 scripts/run_diffusion_sft_h3_t2va.py` with no arguments is a complete run. Custom data via `--extra-args "--prompt-data /abs/train.jsonl"` (last flag wins).
- Sigma-bucket metric keys keep float edges (`loss_sigma_0.0_0.1`, `loss_sigma_0.9_1.0`), matching the pre-#202 names so wandb charts line up across runs.
- Rollout batch size restored to 32 — the batch the recipe's reference lr/wd defaults were validated with.

## Validation

- Unit: `tests/fast/rollout/test_sft_resolve_media_path.py` (new), sigma-key edge pins in `test_loss_hub_sft.py` — all fast rollout/loss tests pass.
- Cold start on a machine with no dataset: zero-arg launch downloaded the dataset, encoded rollout 0 (64 clips via relative paths, no errors), reached train step 1.
- Full run from this branch: batch 32, epoch-boundary checkpoints, float-edge bucket keys; curve matches the reference run.

## Checklist

- [x] `pre-commit run --all-files` passes (verified in CI after a formatting fixup)
- [x] Added/updated tests for new behaviour
- [x] `pytest tests/fast/rollout tests/fast/backends/fsdp_utils/test_loss_hub_sft.py` green
- [x] `python3 scripts/run_diffusion_sft_h3_t2va.py --help` parses (flag surface: `data_jsonl` removed, `data_dir` added)
- [x] Docs updated (`docs/models/h3/h3.md` usage)
