### PR TITLE
fix(sft): default save-interval to once per epoch in SFT recipes

### DIFF
--- a/scripts/run_diffusion_sft_h3_t2va.py
+++ b/scripts/run_diffusion_sft_h3_t2va.py
@@ -33,6 +33,9 @@ WANDB_PROJECT = "miles-diffusion-sft"
 LORA_TARGET_MODULES = "attn.to_q attn.to_k attn.to_v attn.to_out.0 ff.net.0.proj ff.net.2"
 
 
+ROLLOUT_BATCH_SIZE = 64
+
+
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
     data_jsonl: str = ""
@@ -45,11 +48,15 @@ class ScriptArgs(U.ExecuteTrainConfig):
 def execute(args: ScriptArgs) -> None:
     if not args.data_jsonl:
         raise SystemExit("set --data-jsonl (or MILES_SCRIPT_DATA_JSONL) to a jsonl with prompt + metadata.video")
+    # Default save cadence: once per epoch; override with --save-interval in extra_args.
+    with open(args.data_jsonl) as f:
+        num_samples = sum(1 for line in f if line.strip())
+    save_interval = max(1, num_samples // ROLLOUT_BATCH_SIZE)
     run_name = f"diffusion_sft_h3_t2va_{U.create_run_id()}"
 
     ckpt_args = (
         f"--hf-checkpoint {MODEL} --sft-encoder-checkpoint {MODEL} "
-        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval {save_interval} "
     )
     if args.resume_ckpt:
         ckpt_args += f"--load {args.resume_ckpt} "
@@ -60,7 +67,7 @@ def execute(args: ScriptArgs) -> None:
         "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
         f"--prompt-data {args.data_jsonl} "
         "--input-key prompt "
-        "--rollout-batch-size 64 "
+        f"--rollout-batch-size {ROLLOUT_BATCH_SIZE} "
         f"--num-epoch {args.num_epoch} "
         "--num-steps-per-rollout 4 "
         # H3 serving grid: 16:9 canvas at short_edge=768, 24 fps, 17n+5 frames.

--- a/scripts/run_diffusion_sft_wan22.py
+++ b/scripts/run_diffusion_sft_wan22.py
@@ -30,6 +30,9 @@ LORA_TARGET_MODULES = (
 )
 
 
+ROLLOUT_BATCH_SIZE = 64
+
+
 @dataclass
 class ScriptArgs(U.ExecuteTrainConfig):
     data_jsonl: str = ""
@@ -41,11 +44,15 @@ class ScriptArgs(U.ExecuteTrainConfig):
 def execute(args: ScriptArgs) -> None:
     if not args.data_jsonl:
         raise SystemExit("set --data-jsonl (or MILES_SCRIPT_DATA_JSONL) to a jsonl with prompt + metadata.video")
+    # Default save cadence: once per epoch; override with --save-interval in extra_args.
+    with open(args.data_jsonl) as f:
+        num_samples = sum(1 for line in f if line.strip())
+    save_interval = max(1, num_samples // ROLLOUT_BATCH_SIZE)
     run_name = f"diffusion_sft_wan22_{U.create_run_id()}"
 
     ckpt_args = (
         f"--hf-checkpoint {MODEL} --sft-encoder-checkpoint {MODEL} "
-        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval {save_interval} "
     )
     if args.resume_ckpt:
         ckpt_args += f"--load {args.resume_ckpt} "
@@ -56,7 +63,7 @@ def execute(args: ScriptArgs) -> None:
         "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
         f"--prompt-data {args.data_jsonl} "
         "--input-key prompt "
-        "--rollout-batch-size 64 "
+        f"--rollout-batch-size {ROLLOUT_BATCH_SIZE} "
         "--num-epoch 3 "
         "--num-steps-per-rollout 4 "
         "--diffusion-height 480 "


### PR DESCRIPTION
## What

- Both SFT recipes (`run_diffusion_sft_h3_t2va.py`, `run_diffusion_sft_wan22.py`) now default `--save-interval` to once per epoch (`max(1, dataset_size // rollout_batch_size)`) instead of a fixed 20; the batch size is hoisted to a `ROLLOUT_BATCH_SIZE` constant shared by both flags.

## Why

With the fixed interval of 20, any dataset smaller than 20×64 rollouts per run silently trains to completion and saves nothing (a 254-sample dataset yields 3 rollouts per epoch — the interval is never reached). Per-epoch saving is a sensible default at every dataset size and stays overridable: `extra_args` is appended last, so an explicit `--save-interval` in it wins.

## Validation

- `python3 scripts/run_diffusion_sft_h3_t2va.py --help` parses.
- Both scripts `py_compile` clean.

## Checklist

- [ ] `pre-commit run --all-files` passes — **not run** (developed on a remote box without the hook env)
- [x] No unit-testable behaviour added (launch-script default; validated via --help parse)
- [x] No launch flags changed (default value change only, still overridable)
- [x] No public flag added
- [x] No example added
