### PR TITLE
feat(sft): single-card equivalent of the 8-GPU H3 SFT recipe

### DIFF
--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -45,12 +45,16 @@ python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # the same run on one card
 # custom data: --extra-args "--prompt-data /abs/train.jsonl"
 ```
 
-Both train the same schedule — `global_batch_size` 8 at `--micro-batch-size 1` — the 1-GPU
-recipe just folds the 8 ranks' one micro-batch each into 8 gradient-accumulation
-micro-batches. It adds two flags: `--fsdp-cpu-offload`, without which H3's ~66 GB bf16
-master leaves no room for activations on one card, and `--fsdp-master-dtype bf16`, which
-costs nothing here because only the LoRA adapters train and PEFT keeps those in fp32
-whatever the base dtype. Measured against the 8-GPU run on the same dataset, warm cache:
+The 1-GPU recipe is the 8-GPU one's schedule on a single card, not a scaled-down variant:
+`global_batch_size` is 8 either way (derived from the rollout knobs, with no world-size
+term), so only the layout changes — 8 ranks × 1 micro-batch becomes 1 rank × 8
+gradient-accumulation micro-batches at `--micro-batch-size 1`, still 4 optimizer steps per
+rollout. Two flags differ, both forced by the single card: `--fsdp-cpu-offload`, without
+which H3's ~66 GB bf16 master leaves no room for activations, and `--fsdp-master-dtype bf16`,
+which changes no math here because only the LoRA adapters train and PEFT keeps those in fp32
+whatever the base dtype.
+
+Measured against the 8-GPU run on the same dataset, warm cache:
 
 | | 8 GPUs | 1 GPU |
 |---|---|---|
@@ -61,9 +65,15 @@ whatever the base dtype. Measured against the 8-GPU run on the same dataset, war
 
 The 9× gap is 8× rank count plus ~14% for the offload's PCIe round trip on every block. A
 cold `.sft_cache` costs more and only on one rank: one encode worker instead of eight
-(~13.5 s per clip, ~480 s per rollout through the first epoch), and while it runs the ~67 GB
-encoder — not the 39.5 GB train step — is the GPU peak. The recipe's docstring carries the
-full host-RAM breakdown.
+(~480–590 s per rollout through the first epoch), and while it runs the ~67 GB encoder — not
+the 39.5 GB train step — is the GPU peak. The recipe's docstring carries the full host-RAM
+breakdown.
+
+The two curves are comparable on trend and on the per-sigma buckets, not point by point:
+`prepare_sft_batch` seeds the sigma and noise draw on `(rollout_id, microbatch_id, dp_rank)`,
+so a change of topology moves every sample to a different sigma. Within one topology,
+`--extra-args "--deterministic-mode"` pins a run bit-for-bit at ~25% more time per step and
+~3.6 GB more GPU.
 
 ### 4.2 Flow-GRPO + PickScore (2 GPUs)
 

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -57,7 +57,9 @@ room for activations on a single 139.8 GB H200. The offload holds that shard and
 optimizer state in host RAM and all-gathers one block at a time as bf16, so the GPU carries
 activations only.
 
-Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset:
+Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset. Both
+runs report `sft_cache_miss: 0`, and the step figures are `perf/actor_train_time`, which
+covers the training loop only — encoding lands in `perf/train_wait_time` and is excluded:
 
 | | 8 GPUs | 1 GPU |
 |---|---|---|
@@ -71,10 +73,11 @@ The offload costs about **14% per micro-batch** — the PCIe round trip for ever
 both the forward and the gradient-checkpoint recompute. The rest of the 9× wall-clock gap
 is just having an eighth of the ranks.
 
-The encode pool also drops from 8 workers to 1 (~13.5 s per clip), so a cold `.sft_cache`
-adds ~7 min per rollout through the first epoch. The cache is content-addressed on the
-media and the encode settings, so a directory the 8-GPU recipe already filled is reused
-as-is and the encode disappears.
+End to end a cold cache costs more, and only on one rank: the encode pool drops from 8
+workers to 1 at ~13.5 s per clip, which measured ~480 s of `train_wait_time` per rollout
+(32 misses) through the first epoch and 1–16 s once warm. The cache is content-addressed on
+the media and the encode settings, so a directory the 8-GPU recipe already filled is reused
+as-is.
 
 ```bash
 python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads the default dataset on first run

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -70,7 +70,7 @@ covers the training loop only — encoding lands in `perf/train_wait_time` and i
 | | 8 GPUs | 1 GPU |
 |---|---|---|
 | GPU peak (train step) | ~57 GB/rank | **39.5 GB** |
-| host RAM | — | **~154 GB** during FSDP init, **~93 GB** steady (projected from the fp32 measurement) |
+| host RAM | — | **217 GB** peak during FSDP init, **99 GB** steady |
 | init | — | ~12 min |
 | per optimizer step | 30.5 s | **278 s** |
 | per micro-batch | 30.5 s | **34.8 s** |
@@ -86,6 +86,21 @@ peak rather than the 39.5 GB train step. A fully warm cache never constructs the
 all (`sft_cache_miss: 0`), so the card only ever holds activations. The cache is
 content-addressed on the media and the encode settings, so a directory the 8-GPU recipe
 already filled is reused as-is.
+
+Host RAM is the resource this recipe is actually expensive in, and it splits three ways
+(sampled from `/proc/<pid>/status` through init):
+
+- **99 GB steady, of which ~95 GB is CUDA pinned host memory** — the offloaded shard, one
+  `cudaHostAlloc` region per parameter group (1636 `/dev/zero` mappings). It is
+  shmem-accounted but does not consume `/dev/shm`, and being pinned it cannot be paged out.
+  This is the floor, 1.4× the 66 GB of weights.
+- **up to 62 GB of `RssFile`** — the mmap'd safetensors that `fully_shard` copies from,
+  released as soon as it finishes. Reclaimable page cache, not pressure.
+- **up to 66 GB of `RssAnon`** — `model.state_dict()` plus `set_model_state_dict`
+  materializing a full copy, freed by the `del full_state` right after.
+
+The 217 GB peak is the moment the last two briefly overlap inside `_broadcast_state_dict`.
+At fp32 master the same trace peaks at 313 GB and settles at 188 GB.
 
 Note what `--fsdp-master-dtype` does *not* move: the GPU number. Under `--fsdp-cpu-offload`
 no weights are resident and the gathered copy is bf16 at either setting, so the 39.5 GB is

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -31,89 +31,41 @@ From `miles/backends/fsdp_utils/configs/h3.py`:
 | Forced sampling params | `task=t2va`, `short_edge=768`, `conditions=[]` | sgl-d accepts only these for H3, so none of them is exposed as an argument |
 
 ## 4. Launch
-### 4.1 LoRA SFT on (video, prompt) pairs (8 GPUs, no rollout engines)
+### 4.1 LoRA SFT on (video, prompt) pairs (no rollout engines)
 
-Recipe: `scripts/run_diffusion_sft_h3_t2va.py`
-
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+| Recipe | Topology | Status |
+|---|---|---|
+| `scripts/run_diffusion_sft_h3_t2va.py` | 8 GPUs | [📈 V — Verified](../../user-guide/recipe-verification.md#v) |
+| `scripts/run_diffusion_sft_h3_t2va_1gpu.py` | 1 GPU | [○ NV — Not verified](../../user-guide/recipe-verification.md#nv) |
 
 ```bash
-python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads the default dataset on first run
+python3 scripts/run_diffusion_sft_h3_t2va.py        # 8 GPUs
+python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # the same run on one card
+# either one downloads the default dataset on first run
 # custom data: --extra-args "--prompt-data /abs/train.jsonl"
 ```
 
-### 4.2 The same SFT on 1 GPU
-
-Recipe: `scripts/run_diffusion_sft_h3_t2va_1gpu.py`
-
-**Status:** [○ NV — Not verified](../../user-guide/recipe-verification.md#nv)
-
-Same batch schedule as 4.1 — `global_batch_size` 8 at `--micro-batch-size 1` — with 8 ranks
-× 1 micro-batch re-laid out as 1 rank × 8 gradient-accumulation micro-batches.
-
-Two flags differ from 4.1, both forced by the single card. `--fsdp-cpu-offload` holds the
-master shard and the LoRA optimizer state in host RAM and all-gathers one block at a time as
-bf16, so the GPU carries activations only — without it even a bf16 master (~66 GB for 33.5B
-parameters) leaves no room on a 139.8 GB H200.
-
-`--fsdp-master-dtype bf16` replaces 4.1's fp32 because under that offload fp32 buys nothing:
-only the LoRA adapters train and PEFT keeps them in fp32 whatever the base dtype, while the
-frozen base is gathered as bf16 for the forward at either setting. It does cost 66 GB of
-host RAM. diffusers' `_keep_in_fp32_modules` (`proj_in`, `proj_out`, `audio_proj_in`,
-`audio_proj_out`, `time_embedder`, `rope`) keeps the tensors MiniMax shipped as fp32 in fp32
-regardless. `--fsdp-reduce-dtype` stays fp32 — that one governs the LoRA gradients.
-
-Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset. Both
-runs report `sft_cache_miss: 0`, and the step figures are `perf/actor_train_time`, which
-covers the training loop only — encoding lands in `perf/train_wait_time` and is excluded:
+Both train the same schedule — `global_batch_size` 8 at `--micro-batch-size 1` — the 1-GPU
+recipe just folds the 8 ranks' one micro-batch each into 8 gradient-accumulation
+micro-batches. It adds two flags: `--fsdp-cpu-offload`, without which H3's ~66 GB bf16
+master leaves no room for activations on one card, and `--fsdp-master-dtype bf16`, which
+costs nothing here because only the LoRA adapters train and PEFT keeps those in fp32
+whatever the base dtype. Measured against the 8-GPU run on the same dataset, warm cache:
 
 | | 8 GPUs | 1 GPU |
 |---|---|---|
 | GPU peak (train step) | ~57 GB/rank | **39.5 GB** |
-| host RAM | — | **217 GB** peak during FSDP init, **99 GB** steady |
-| init | — | ~12 min |
+| host RAM | — | **217 GB** peak at init, **99 GB** steady |
 | per optimizer step | 30.5 s | **278 s** |
-| per micro-batch | 30.5 s | **34.8 s** |
+| per rollout (4 steps) | 122 s | **17.3 min** |
 
-The offload costs about **14% per micro-batch** — the PCIe round trip for every block, on
-both the forward and the gradient-checkpoint recompute. The rest of the 9× wall-clock gap
-is just having an eighth of the ranks.
+The 9× gap is 8× rank count plus ~14% for the offload's PCIe round trip on every block. A
+cold `.sft_cache` costs more and only on one rank: one encode worker instead of eight
+(~13.5 s per clip, ~480 s per rollout through the first epoch), and while it runs the ~67 GB
+encoder — not the 39.5 GB train step — is the GPU peak. The recipe's docstring carries the
+full host-RAM breakdown.
 
-A cold cache costs both time and memory, and only on one rank. The encode pool drops from 8
-workers to 1 at ~13.5 s per clip — measured ~480 s of `train_wait_time` per rollout (32
-misses) against 1–16 s once warm — and while it runs, the ~67 GB encoder is the run's GPU
-peak rather than the 39.5 GB train step. A fully warm cache never constructs the pool at
-all (`sft_cache_miss: 0`), so the card only ever holds activations. The cache is
-content-addressed on the media and the encode settings, so a directory the 8-GPU recipe
-already filled is reused as-is.
-
-Host RAM is the resource this recipe is actually expensive in, and it splits three ways
-(sampled from `/proc/<pid>/status` through init):
-
-- **99 GB steady, of which ~95 GB is CUDA pinned host memory** — the offloaded shard, one
-  `cudaHostAlloc` region per parameter group (1636 `/dev/zero` mappings). It is
-  shmem-accounted but does not consume `/dev/shm`, and being pinned it cannot be paged out.
-  This is the floor, 1.4× the 66 GB of weights.
-- **up to 62 GB of `RssFile`** — the mmap'd safetensors that `fully_shard` copies from,
-  released as soon as it finishes. Reclaimable page cache, not pressure.
-- **up to 66 GB of `RssAnon`** — `model.state_dict()` plus `set_model_state_dict`
-  materializing a full copy, freed by the `del full_state` right after.
-
-The 217 GB peak is the moment the last two briefly overlap inside `_broadcast_state_dict`.
-At fp32 master the same trace peaks at 313 GB and settles at 188 GB.
-
-Note what `--fsdp-master-dtype` does *not* move: the GPU number. Under `--fsdp-cpu-offload`
-no weights are resident and the gathered copy is bf16 at either setting, so the 39.5 GB is
-activations plus one block (`allocated_GB` reads 0.06 between steps against a 37.7 GB
-reserved pool). It is purely a host-RAM lever. Pass `--extra-args "--fsdp-master-dtype
-fp32"` to match 4.1 flag for flag at twice the host cost.
-
-```bash
-python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads the default dataset on first run
-# custom data: --extra-args "--prompt-data /abs/train.jsonl"
-```
-
-### 4.3 Flow-GRPO + PickScore (2 GPUs)
+### 4.2 Flow-GRPO + PickScore (2 GPUs)
 
 Canonical recipe: `scripts/run_diffusion_grpo_h3_t2va_2gpu.py` — train, rollout, and PickScore
 colocated on 2 GPUs; 16:9 / 4 s (with `short_edge=768` the canvas is 1344×768 / 107 frames).

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -48,13 +48,14 @@ Recipe: `scripts/run_diffusion_sft_h3_t2va_1gpu.py`
 
 **Status:** [○ NV — Not verified](../../user-guide/recipe-verification.md#nv)
 
-Identical batch schedule to 4.1 — 32 samples per rollout, 4 optimizer steps, 8 samples per
-step at `--micro-batch-size 1` — with the 8 ranks' one micro-batch each folded into 8
-gradient-accumulation micro-batches on the one rank. The only added flag is
-`--fsdp-cpu-offload`, and it is what makes a single card enough: H3 is 33.5B parameters, so
-the fp32 master is ~134 GB and the per-rank ~16 GB the 8-GPU run reports has no single-GPU
-equivalent. With the offload the fp32 shard and the LoRA optimizer state sit in host RAM
-and FSDP all-gathers one block at a time as bf16, leaving the GPU to hold activations only.
+Same batch schedule as 4.1 — `global_batch_size` 8 at `--micro-batch-size 1` — with 8 ranks
+× 1 micro-batch re-laid out as 1 rank × 8 gradient-accumulation micro-batches.
+
+`--fsdp-cpu-offload` is the only added flag, and it is what fits H3 on one card: the fp32
+master is ~134 GB (33.5B parameters), which shards to ~16 GB/rank across 8 but leaves no
+room for activations on a single 139.8 GB H200. The offload holds that shard and the LoRA
+optimizer state in host RAM and all-gathers one block at a time as bf16, so the GPU carries
+activations only.
 
 Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset:
 

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -51,11 +51,17 @@ Recipe: `scripts/run_diffusion_sft_h3_t2va_1gpu.py`
 Same batch schedule as 4.1 — `global_batch_size` 8 at `--micro-batch-size 1` — with 8 ranks
 × 1 micro-batch re-laid out as 1 rank × 8 gradient-accumulation micro-batches.
 
-`--fsdp-cpu-offload` is the only added flag, and it is what fits H3 on one card: the fp32
-master is ~134 GB (33.5B parameters), which shards to ~16 GB/rank across 8 but leaves no
-room for activations on a single 139.8 GB H200. The offload holds that shard and the LoRA
-optimizer state in host RAM and all-gathers one block at a time as bf16, so the GPU carries
-activations only.
+Two flags differ from 4.1, both forced by the single card. `--fsdp-cpu-offload` holds the
+master shard and the LoRA optimizer state in host RAM and all-gathers one block at a time as
+bf16, so the GPU carries activations only — without it even a bf16 master (~66 GB for 33.5B
+parameters) leaves no room on a 139.8 GB H200.
+
+`--fsdp-master-dtype bf16` replaces 4.1's fp32 because under that offload fp32 buys nothing:
+only the LoRA adapters train and PEFT keeps them in fp32 whatever the base dtype, while the
+frozen base is gathered as bf16 for the forward at either setting. It does cost 66 GB of
+host RAM. diffusers' `_keep_in_fp32_modules` (`proj_in`, `proj_out`, `audio_proj_in`,
+`audio_proj_out`, `time_embedder`, `rope`) keeps the tensors MiniMax shipped as fp32 in fp32
+regardless. `--fsdp-reduce-dtype` stays fp32 — that one governs the LoRA gradients.
 
 Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset. Both
 runs report `sft_cache_miss: 0`, and the step figures are `perf/actor_train_time`, which
@@ -64,7 +70,7 @@ covers the training loop only — encoding lands in `perf/train_wait_time` and i
 | | 8 GPUs | 1 GPU |
 |---|---|---|
 | GPU peak (train step) | ~57 GB/rank | **39.5 GB** |
-| host RAM | — | **~313 GB** during FSDP init, **~188 GB** steady |
+| host RAM | — | **~154 GB** during FSDP init, **~93 GB** steady (projected from the fp32 measurement) |
 | init | — | ~12 min |
 | per optimizer step | 30.5 s | **278 s** |
 | per micro-batch | 30.5 s | **34.8 s** |
@@ -81,12 +87,11 @@ all (`sft_cache_miss: 0`), so the card only ever holds activations. The cache is
 content-addressed on the media and the encode settings, so a directory the 8-GPU recipe
 already filled is reused as-is.
 
-Note what does *not* move the GPU number: `--fsdp-master-dtype`. Under `--fsdp-cpu-offload`
-no weights are resident, and the gathered compute copy is bf16 at either setting, so the
-39.5 GB is activations plus one block (`allocated_GB` reads 0.06 between steps against a
-37.7 GB reserved pool). Dropping the master to bf16 halves *host* RAM — ~134 GB to ~67 GB
-for the frozen base, with the trainable LoRA left in fp32 by PEFT regardless — and is the
-knob for a low-RAM host, not a low-memory card.
+Note what `--fsdp-master-dtype` does *not* move: the GPU number. Under `--fsdp-cpu-offload`
+no weights are resident and the gathered copy is bf16 at either setting, so the 39.5 GB is
+activations plus one block (`allocated_GB` reads 0.06 between steps against a 37.7 GB
+reserved pool). It is purely a host-RAM lever. Pass `--extra-args "--fsdp-master-dtype
+fp32"` to match 4.1 flag for flag at twice the host cost.
 
 ```bash
 python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads the default dataset on first run

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -42,7 +42,45 @@ python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads the default dataset o
 # custom data: --extra-args "--prompt-data /abs/train.jsonl"
 ```
 
-### 4.2 Flow-GRPO + PickScore (2 GPUs)
+### 4.2 The same SFT on 1 GPU
+
+Recipe: `scripts/run_diffusion_sft_h3_t2va_1gpu.py`
+
+**Status:** [○ NV — Not verified](../../user-guide/recipe-verification.md#nv)
+
+Identical batch schedule to 4.1 — 32 samples per rollout, 4 optimizer steps, 8 samples per
+step at `--micro-batch-size 1` — with the 8 ranks' one micro-batch each folded into 8
+gradient-accumulation micro-batches on the one rank. The only added flag is
+`--fsdp-cpu-offload`, and it is what makes a single card enough: H3 is 33.5B parameters, so
+the fp32 master is ~134 GB and the per-rank ~16 GB the 8-GPU run reports has no single-GPU
+equivalent. With the offload the fp32 shard and the LoRA optimizer state sit in host RAM
+and FSDP all-gathers one block at a time as bf16, leaving the GPU to hold activations only.
+
+Measured on one H200 (139.8 GB) against the 8-GPU reference run on the same dataset:
+
+| | 8 GPUs | 1 GPU |
+|---|---|---|
+| GPU peak | ~57 GB/rank | **35.3 GB** |
+| host RAM | — | **~313 GB** during FSDP init, **~188 GB** steady |
+| init | — | ~12 min |
+| per optimizer step | 30.5 s | **278 s** |
+| per micro-batch | 30.5 s | **34.8 s** |
+
+The offload costs about **14% per micro-batch** — the PCIe round trip for every block, on
+both the forward and the gradient-checkpoint recompute. The rest of the 9× wall-clock gap
+is just having an eighth of the ranks.
+
+The encode pool also drops from 8 workers to 1 (~13.5 s per clip), so a cold `.sft_cache`
+adds ~7 min per rollout through the first epoch. The cache is content-addressed on the
+media and the encode settings, so a directory the 8-GPU recipe already filled is reused
+as-is and the encode disappears.
+
+```bash
+python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads the default dataset on first run
+# custom data: --extra-args "--prompt-data /abs/train.jsonl"
+```
+
+### 4.3 Flow-GRPO + PickScore (2 GPUs)
 
 Canonical recipe: `scripts/run_diffusion_grpo_h3_t2va_2gpu.py` — train, rollout, and PickScore
 colocated on 2 GPUs; 16:9 / 4 s (with `short_edge=768` the canvas is 1344×768 / 107 frames).

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -63,7 +63,7 @@ covers the training loop only — encoding lands in `perf/train_wait_time` and i
 
 | | 8 GPUs | 1 GPU |
 |---|---|---|
-| GPU peak | ~57 GB/rank | **35.3 GB** |
+| GPU peak (train step) | ~57 GB/rank | **39.5 GB** |
 | host RAM | — | **~313 GB** during FSDP init, **~188 GB** steady |
 | init | — | ~12 min |
 | per optimizer step | 30.5 s | **278 s** |
@@ -73,11 +73,20 @@ The offload costs about **14% per micro-batch** — the PCIe round trip for ever
 both the forward and the gradient-checkpoint recompute. The rest of the 9× wall-clock gap
 is just having an eighth of the ranks.
 
-End to end a cold cache costs more, and only on one rank: the encode pool drops from 8
-workers to 1 at ~13.5 s per clip, which measured ~480 s of `train_wait_time` per rollout
-(32 misses) through the first epoch and 1–16 s once warm. The cache is content-addressed on
-the media and the encode settings, so a directory the 8-GPU recipe already filled is reused
-as-is.
+A cold cache costs both time and memory, and only on one rank. The encode pool drops from 8
+workers to 1 at ~13.5 s per clip — measured ~480 s of `train_wait_time` per rollout (32
+misses) against 1–16 s once warm — and while it runs, the ~67 GB encoder is the run's GPU
+peak rather than the 39.5 GB train step. A fully warm cache never constructs the pool at
+all (`sft_cache_miss: 0`), so the card only ever holds activations. The cache is
+content-addressed on the media and the encode settings, so a directory the 8-GPU recipe
+already filled is reused as-is.
+
+Note what does *not* move the GPU number: `--fsdp-master-dtype`. Under `--fsdp-cpu-offload`
+no weights are resident, and the gathered compute copy is bf16 at either setting, so the
+39.5 GB is activations plus one block (`allocated_GB` reads 0.06 between steps against a
+37.7 GB reserved pool). Dropping the master to bf16 halves *host* RAM — ~134 GB to ~67 GB
+for the frozen base, with the trainable LoRA left in fp32 by PEFT regardless — and is the
+knob for a low-RAM host, not a low-memory card.
 
 ```bash
 python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads the default dataset on first run

--- a/docs/user-guide/recipe-verification.md
+++ b/docs/user-guide/recipe-verification.md
@@ -51,3 +51,4 @@ count as verification.
   - `run_diffusion_grpo_wan22_pickscore_5gpu.py` — Wan2.2 5-GPU LoRA
     Flow-GRPO + PickScore.
   - `run_diffusion_sft_wan22.py` — Wan2.2 4-GPU LoRA SFT.
+  - `run_diffusion_sft_h3_t2va_1gpu.py` — MiniMax H3 1-GPU LoRA SFT.

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -17,7 +17,7 @@ Measured against the 8-GPU reference run at these defaults, same dataset. Both r
 sft_cache_miss: 0, and the step figures are perf/actor_train_time -- the training loop only,
 with encoding excluded (it lands in perf/train_wait_time):
 
-    GPU peak      35.3 GB of 139.8 GB -- the rest of the card is headroom
+    GPU peak      39.5 GB of 139.8 GB, activations only -- see the note below
     host RAM      ~313 GB while FSDP materializes the shards, ~188 GB steady after
     init          ~12 min to load, shard, and broadcast the fp32 state
     optim step    278 s, against 30.5 s on 8 GPUs
@@ -29,9 +29,17 @@ simply having an eighth of the ranks.
 
 Encoding is the other single-worker cost, and it shows up outside those figures: one encode
 actor instead of eight at ~13.5 s per clip, measured as ~480 s of train_wait_time per
-rollout (32 misses) on a cold cache against 1-16 s once warm. Cache entries are
-content-addressed on the media and the encode settings and are identical to the ones the
-8-GPU recipe writes, so a directory that recipe already filled is reused as-is.
+rollout (32 misses) on a cold cache against 1-16 s once warm. It also owns the run's GPU
+peak while it runs -- the encoder is ~67 GB against the 39.5 GB train step -- and a fully
+warm cache never constructs the pool at all. Cache entries are content-addressed on the
+media and the encode settings and are identical to the ones the 8-GPU recipe writes, so a
+directory that recipe already filled is reused as-is.
+
+--fsdp-master-dtype is not a lever on the GPU number: under --fsdp-cpu-offload no weights
+are resident and the gathered copy is bf16 either way, so the 39.5 GB is activations plus
+one block. Setting it to bf16 halves host RAM instead (~134 GB to ~67 GB for the frozen
+base; PEFT keeps the trainable LoRA in fp32 regardless), which is the knob for a low-RAM
+host rather than a low-memory card.
 
 Usage:
     python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads DATASET on first run

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -1,0 +1,148 @@
+"""1-GPU MiniMax H3 t2va LoRA SFT — the 8-GPU recipe's batch schedule on a single card.
+
+Same training math as scripts/run_diffusion_sft_h3_t2va.py: 32 samples per rollout,
+num_steps_per_rollout=4, so global_batch_size stays 8 samples per optimizer step. What
+changes is only how those 8 samples are laid out: 8 dp ranks x 1 micro-batch becomes
+1 rank x 8 gradient-accumulation micro-batches, still at micro_batch_size=1. Optimizer,
+LoRA, sigma grid, dtypes, and the loss are the 8-GPU recipe's, flag for flag.
+
+Why --fsdp-cpu-offload is not optional here: H3 is a 33.5B-parameter model, so the fp32
+master copy the recipe trains against is ~134 GB. Sharded 8 ways that is the ~16 GB/rank
+the 8-GPU run reports; on one 139.8 GB H200 it leaves nothing for activations.
+CPUOffloadPolicy keeps the fp32 shard and the (LoRA-only) optimizer state in host RAM and
+all-gathers one transformer block at a time as bf16, so GPU residency is activations plus a
+single block. This preserves the master/forward dtypes rather than trading them away.
+
+Measured against the 8-GPU reference run at these defaults, same dataset:
+
+    GPU peak      35.3 GB of 139.8 GB -- the rest of the card is headroom
+    host RAM      ~313 GB while FSDP materializes the shards, ~188 GB steady after
+    init          ~12 min to load, shard, and broadcast the fp32 state
+    optim step    278 s, against 30.5 s on 8 GPUs
+    micro-batch   34.8 s, against 30.5 s on 8 GPUs
+
+So the offload costs ~14% per micro-batch -- the PCIe round trip for every block, on both
+the forward and the gradient-checkpoint recompute. The remaining 9x wall-clock gap is
+simply having an eighth of the ranks.
+
+Encoding is the other single-worker cost: one encode actor instead of eight, ~13.5 s per
+clip, which on a cold cache adds ~7 min per rollout through the first epoch. Cache entries
+are content-addressed on the media and the encode settings and are identical to the ones
+the 8-GPU recipe writes, so a directory that recipe already filled is reused as-is.
+
+Usage:
+    python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads DATASET on first run
+    # custom data: append --prompt-data /abs/train.jsonl via --extra-args (last flag wins)
+"""
+
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "MiniMaxAI/MiniMax-H3"
+DATASET = "rockdu/WISA-80K-Practical-Dynamics-254"
+WANDB_PROJECT = "miles-diffusion-sft"
+
+# H3 DiT LoRA targets: packed self-attn and FFN (miles-side diffusers module names).
+LORA_TARGET_MODULES = "attn.to_q attn.to_k attn.to_v attn.to_out.0 ff.net.0.proj ff.net.2"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    data_dir: str = "/root/datasets"
+    resume_ckpt: str = ""
+    start_rollout: int = -1
+    num_epoch: int = 3
+    extra_args: str = ""
+
+
+def prepare(args: ScriptArgs):
+    U.hf_download_dataset(DATASET, data_dir=args.data_dir)
+
+
+def execute(args: ScriptArgs) -> None:
+    run_name = f"diffusion_sft_h3_t2va_1gpu_{U.create_run_id()}"
+
+    ckpt_args = (
+        f"--hf-checkpoint {MODEL} --sft-encoder-checkpoint {MODEL} "
+        f"--save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+    )
+    if args.resume_ckpt:
+        ckpt_args += f"--load {args.resume_ckpt} "
+        if args.start_rollout >= 0:
+            ckpt_args += f"--start-rollout-id {args.start_rollout} "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sft_rollout.generate_rollout "
+        f"--prompt-data {args.data_dir}/{DATASET.split('/')[1]}/train.jsonl "
+        "--input-key prompt "
+        "--rollout-batch-size 32 "
+        f"--num-epoch {args.num_epoch} "
+        "--num-steps-per-rollout 4 "
+        # H3 serving grid: 16:9 canvas at short_edge=768, 24 fps, 17n+5 frames.
+        "--diffusion-height 768 "
+        "--diffusion-width 1344 "
+        "--diffusion-output-num-frames 107 "
+        # H3 distilled CFG into the checkpoint; the family rejects guided training.
+        "--diffusion-guidance-scale 1.0 "
+    )
+
+    sft_args = (
+        "--loss-type sft_loss "
+        "--train-only "
+        "--custom-convert-samples-to-train-data-path miles.rollout.sft_rollout.convert_samples_to_train_data "
+        "--custom-rollout-log-function-path miles.rollout.sft_rollout.log_rollout_data "
+        "--custom-prepare-train-batch-path miles.backends.fsdp_utils.loss_hub.sft.prepare_sft_batch "
+        "--custom-loss-function-path miles.backends.fsdp_utils.loss_hub.sft.sft_loss_formula "
+        "--sft-frame-stride 1 "
+        "--sft-offload-encoder "
+    )
+
+    optimizer_args = "--lr 3e-5 --adam-beta2 0.999 --weight-decay 0.01 --adam-eps 1e-15 "
+
+    lora_args = (
+        "--use-lora "
+        "--lora-rank 64 "
+        "--lora-alpha 128 "
+        f"--lora-target-modules {LORA_TARGET_MODULES} "
+        "--lora-init-weights gaussian "
+    )
+
+    wandb_args = U.get_default_wandb_args(__file__, run_id=run_name, project=WANDB_PROJECT)
+
+    train_backend_args = (
+        "--train-backend fsdp "
+        "--fsdp-master-dtype fp32 "
+        "--fsdp-reduce-dtype fp32 "
+        "--diffusion-forward-dtype bf16 "
+        # Match the engine's t2va serving schedule (video shift 12) so training
+        # sigmas cover the same grid inference will sample.
+        "--fsdp-flow-shift 12.0 "
+        # The 134GB fp32 master has nowhere to live on one card; see the module docstring.
+        "--fsdp-cpu-offload "
+    )
+
+    perf_args = "--micro-batch-size 1 --gradient-checkpointing "
+
+    misc_args = "--actor-num-gpus-per-node 1 --num-gpus-per-node 1 "
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {sft_args} {optimizer_args} {lora_args} "
+            f"{wandb_args} {train_backend_args} {perf_args} {misc_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=1,
+        config=args,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    prepare(args)
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -13,7 +13,9 @@ CPUOffloadPolicy keeps the fp32 shard and the (LoRA-only) optimizer state in hos
 all-gathers one transformer block at a time as bf16, so GPU residency is activations plus a
 single block. This preserves the master/forward dtypes rather than trading them away.
 
-Measured against the 8-GPU reference run at these defaults, same dataset:
+Measured against the 8-GPU reference run at these defaults, same dataset. Both runs report
+sft_cache_miss: 0, and the step figures are perf/actor_train_time -- the training loop only,
+with encoding excluded (it lands in perf/train_wait_time):
 
     GPU peak      35.3 GB of 139.8 GB -- the rest of the card is headroom
     host RAM      ~313 GB while FSDP materializes the shards, ~188 GB steady after
@@ -25,10 +27,11 @@ So the offload costs ~14% per micro-batch -- the PCIe round trip for every block
 the forward and the gradient-checkpoint recompute. The remaining 9x wall-clock gap is
 simply having an eighth of the ranks.
 
-Encoding is the other single-worker cost: one encode actor instead of eight, ~13.5 s per
-clip, which on a cold cache adds ~7 min per rollout through the first epoch. Cache entries
-are content-addressed on the media and the encode settings and are identical to the ones
-the 8-GPU recipe writes, so a directory that recipe already filled is reused as-is.
+Encoding is the other single-worker cost, and it shows up outside those figures: one encode
+actor instead of eight at ~13.5 s per clip, measured as ~480 s of train_wait_time per
+rollout (32 misses) on a cold cache against 1-16 s once warm. Cache entries are
+content-addressed on the media and the encode settings and are identical to the ones the
+8-GPU recipe writes, so a directory that recipe already filled is reused as-is.
 
 Usage:
     python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads DATASET on first run

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -152,12 +152,19 @@ def execute(args: ScriptArgs) -> None:
 
     perf_args = "--micro-batch-size 1 --gradient-checkpointing "
 
+    # One rank has no cross-rank reduction order to vary, so determinism here is
+    # reachable and cheap to keep: it makes this recipe a reproducible reference for
+    # the 8-GPU one, whose curve is not bit-reproducible across topologies anyway.
+    # No --fsdp-attention-backend is set, so validate_attention_args takes the
+    # torch-native path rather than rejecting an opaque kernel.
+    determinism_args = "--deterministic-mode "
+
     misc_args = "--actor-num-gpus-per-node 1 --num-gpus-per-node 1 "
 
     U.execute_train(
         train_args=(
             f"{ckpt_args} {rollout_args} {sft_args} {optimizer_args} {lora_args} "
-            f"{wandb_args} {train_backend_args} {perf_args} {misc_args} {args.extra_args}"
+            f"{wandb_args} {train_backend_args} {perf_args} {determinism_args} {misc_args} {args.extra_args}"
         ),
         num_gpus_per_node=1,
         config=args,

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -6,12 +6,21 @@ changes is only how those 8 samples are laid out: 8 dp ranks x 1 micro-batch bec
 1 rank x 8 gradient-accumulation micro-batches, still at micro_batch_size=1. Optimizer,
 LoRA, sigma grid, dtypes, and the loss are the 8-GPU recipe's, flag for flag.
 
-Why --fsdp-cpu-offload is not optional here: H3 is a 33.5B-parameter model, so the fp32
-master copy the recipe trains against is ~134 GB. Sharded 8 ways that is the ~16 GB/rank
-the 8-GPU run reports; on one 139.8 GB H200 it leaves nothing for activations.
-CPUOffloadPolicy keeps the fp32 shard and the (LoRA-only) optimizer state in host RAM and
-all-gathers one transformer block at a time as bf16, so GPU residency is activations plus a
-single block. This preserves the master/forward dtypes rather than trading them away.
+Two flags differ from the 8-GPU recipe, both forced by having one card.
+
+--fsdp-cpu-offload is not optional: H3 is a 33.5B-parameter model, so even a bf16 master is
+~66 GB, and CPUOffloadPolicy is what keeps it (and the LoRA-only optimizer state) off a
+139.8 GB card that also has to hold activations. FSDP all-gathers one transformer block at a
+time as bf16, so GPU residency is activations plus a single block.
+
+--fsdp-master-dtype bf16 rather than fp32, because under this configuration fp32 buys
+nothing. Only the LoRA adapters train, and PEFT keeps those in fp32 whatever the base dtype
+(measured: base bf16 -> lora_A/lora_B float32, requires_grad=True). The frozen base is
+gathered as bf16 for the forward at either setting, since MixedPrecisionPolicy uses
+param_dtype=bf16 on every wrap and H3 declares no param_dtype_patterns. What fp32 does cost
+is 66 GB of host RAM. diffusers' _keep_in_fp32_modules -- proj_in, proj_out, audio_proj_in,
+audio_proj_out, time_embedder, rope -- keeps the tensors MiniMax shipped as fp32 in fp32
+regardless. --fsdp-reduce-dtype stays fp32: that one governs the LoRA gradients.
 
 Measured against the 8-GPU reference run at these defaults, same dataset. Both runs report
 sft_cache_miss: 0, and the step figures are perf/actor_train_time -- the training loop only,
@@ -37,9 +46,9 @@ directory that recipe already filled is reused as-is.
 
 --fsdp-master-dtype is not a lever on the GPU number: under --fsdp-cpu-offload no weights
 are resident and the gathered copy is bf16 either way, so the 39.5 GB is activations plus
-one block. Setting it to bf16 halves host RAM instead (~134 GB to ~67 GB for the frozen
-base; PEFT keeps the trainable LoRA in fp32 regardless), which is the knob for a low-RAM
-host rather than a low-memory card.
+one block. It is a host-RAM lever, which is why this recipe sets bf16; pass
+--fsdp-master-dtype fp32 via --extra-args to match the 8-GPU recipe byte for byte at twice
+the host cost.
 
 Usage:
     python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads DATASET on first run
@@ -125,13 +134,19 @@ def execute(args: ScriptArgs) -> None:
 
     train_backend_args = (
         "--train-backend fsdp "
-        "--fsdp-master-dtype fp32 "
+        # bf16 master, unlike the 8-GPU recipe: only the LoRA adapters train, PEFT keeps
+        # those in fp32 whatever the base dtype, and the frozen base is gathered as bf16
+        # for the forward at either setting -- so fp32 buys nothing here and costs 66GB of
+        # host RAM. diffusers' _keep_in_fp32_modules still protects proj_in/proj_out/
+        # audio_proj_in/audio_proj_out/time_embedder/rope. Reduce stays fp32: that one
+        # governs the LoRA gradients.
+        "--fsdp-master-dtype bf16 "
         "--fsdp-reduce-dtype fp32 "
         "--diffusion-forward-dtype bf16 "
         # Match the engine's t2va serving schedule (video shift 12) so training
         # sigmas cover the same grid inference will sample.
         "--fsdp-flow-shift 12.0 "
-        # The 134GB fp32 master has nowhere to live on one card; see the module docstring.
+        # Even a bf16 master has nowhere to live on one card; see the module docstring.
         "--fsdp-cpu-offload "
     )
 

--- a/scripts/run_diffusion_sft_h3_t2va_1gpu.py
+++ b/scripts/run_diffusion_sft_h3_t2va_1gpu.py
@@ -1,54 +1,51 @@
-"""1-GPU MiniMax H3 t2va LoRA SFT — the 8-GPU recipe's batch schedule on a single card.
+"""scripts/run_diffusion_sft_h3_t2va.py on one card, with the same training math.
 
-Same training math as scripts/run_diffusion_sft_h3_t2va.py: 32 samples per rollout,
-num_steps_per_rollout=4, so global_batch_size stays 8 samples per optimizer step. What
-changes is only how those 8 samples are laid out: 8 dp ranks x 1 micro-batch becomes
-1 rank x 8 gradient-accumulation micro-batches, still at micro_batch_size=1. Optimizer,
-LoRA, sigma grid, dtypes, and the loss are the 8-GPU recipe's, flag for flag.
+The 8-GPU recipe's schedule is preserved exactly, not approximated. global_batch_size is 8
+either way -- arguments.py derives it as rollout_batch_size x n_samples_per_prompt /
+num_steps_per_rollout, with no world-size term -- so the only thing one card changes is the
+layout: 8 dp ranks x 1 micro-batch becomes 1 rank x 8 gradient-accumulation micro-batches,
+still at micro_batch_size=1, still 4 optimizer steps per rollout. The gradient scale follows:
+actor.py divides by num_local_pairs, which is 8 on the single rank and 1 on each of eight
+ranks before FSDP2's mesh-mean divides by 8 again. Optimizer, LoRA, sigma grid, and loss are
+the 8-GPU recipe's flag for flag.
 
-Two flags differ from the 8-GPU recipe, both forced by having one card.
+Two flags do differ, both forced by having one card:
 
---fsdp-cpu-offload is not optional: H3 is a 33.5B-parameter model, so even a bf16 master is
-~66 GB, and CPUOffloadPolicy is what keeps it (and the LoRA-only optimizer state) off a
-139.8 GB card that also has to hold activations. FSDP all-gathers one transformer block at a
-time as bf16, so GPU residency is activations plus a single block.
+--fsdp-cpu-offload. H3 is 33.5B parameters, so even a bf16 master is ~66 GB and leaves no
+room for activations on a 139.8 GB H200. CPUOffloadPolicy keeps the master shard and the
+LoRA-only optimizer state in host RAM and all-gathers one transformer block at a time as
+bf16, so GPU residency is activations plus a single block.
 
---fsdp-master-dtype bf16 rather than fp32, because under this configuration fp32 buys
-nothing. Only the LoRA adapters train, and PEFT keeps those in fp32 whatever the base dtype
-(measured: base bf16 -> lora_A/lora_B float32, requires_grad=True). The frozen base is
-gathered as bf16 for the forward at either setting, since MixedPrecisionPolicy uses
-param_dtype=bf16 on every wrap and H3 declares no param_dtype_patterns. What fp32 does cost
-is 66 GB of host RAM. diffusers' _keep_in_fp32_modules -- proj_in, proj_out, audio_proj_in,
-audio_proj_out, time_embedder, rope -- keeps the tensors MiniMax shipped as fp32 in fp32
-regardless. --fsdp-reduce-dtype stays fp32: that one governs the LoRA gradients.
+--fsdp-master-dtype bf16 instead of fp32, which under that offload changes no math. Only the
+LoRA adapters train, and PEFT keeps those in fp32 whatever the base dtype; the frozen base is
+gathered as bf16 for the forward at either setting, because MixedPrecisionPolicy applies
+param_dtype=bf16 to every wrap and H3 declares no param_dtype_patterns. Measured: step 1 of
+an otherwise identical run reproduces the fp32 loss to every digit logged (3.276656e-01).
+diffusers' _keep_in_fp32_modules still holds proj_in, proj_out, audio_proj_in,
+audio_proj_out, time_embedder and rope in fp32. --fsdp-reduce-dtype stays fp32 -- that one
+governs the LoRA gradients, which do train.
 
-Measured against the 8-GPU reference run at these defaults, same dataset. Both runs report
-sft_cache_miss: 0, and the step figures are perf/actor_train_time -- the training loop only,
-with encoding excluded (it lands in perf/train_wait_time):
+What one card costs, measured against the 8-GPU reference run on the same dataset with a
+warm cache (per-step figures are perf/actor_train_time, so encoding is excluded):
 
-    GPU peak      39.5 GB of 139.8 GB, activations only -- see the note below
-    host RAM      ~313 GB while FSDP materializes the shards, ~188 GB steady after
-    init          ~12 min to load, shard, and broadcast the fp32 state
-    optim step    278 s, against 30.5 s on 8 GPUs
-    micro-batch   34.8 s, against 30.5 s on 8 GPUs
+    GPU peak         39.5 GB, activations plus one block -- no weights are resident
+    host RAM         217 GB peak through FSDP init, 99 GB steady (~95 GB of it pinned)
+    init             ~6 min
+    optimizer step   278 s against 30.5 s
+    rollout          17.3 min against 122 s
 
-So the offload costs ~14% per micro-batch -- the PCIe round trip for every block, on both
-the forward and the gradient-checkpoint recompute. The remaining 9x wall-clock gap is
-simply having an eighth of the ranks.
+The 9x wall-clock gap is 8x rank count and ~14% for the PCIe round trip the offload adds to
+every block, on both the forward and the gradient-checkpoint recompute. A cold .sft_cache
+adds more, and only here: one encode worker instead of eight, ~480-590 s per rollout through
+the first epoch, during which the ~67 GB encoder rather than the train step owns the GPU
+peak. Cache entries are content-addressed on the media and the encode settings and are
+identical to the 8-GPU recipe's, so a directory it already filled is reused as-is.
 
-Encoding is the other single-worker cost, and it shows up outside those figures: one encode
-actor instead of eight at ~13.5 s per clip, measured as ~480 s of train_wait_time per
-rollout (32 misses) on a cold cache against 1-16 s once warm. It also owns the run's GPU
-peak while it runs -- the encoder is ~67 GB against the 39.5 GB train step -- and a fully
-warm cache never constructs the pool at all. Cache entries are content-addressed on the
-media and the encode settings and are identical to the ones the 8-GPU recipe writes, so a
-directory that recipe already filled is reused as-is.
-
---fsdp-master-dtype is not a lever on the GPU number: under --fsdp-cpu-offload no weights
-are resident and the gathered copy is bf16 either way, so the 39.5 GB is activations plus
-one block. It is a host-RAM lever, which is why this recipe sets bf16; pass
---fsdp-master-dtype fp32 via --extra-args to match the 8-GPU recipe byte for byte at twice
-the host cost.
+What is not reproducible across the two, and cannot be: prepare_sft_batch seeds the sigma and
+noise draw on (rollout_id, microbatch_id, dp_rank), so every sample lands on a different sigma
+when the topology changes. Compare the two runs on trend and on the per-sigma buckets, never
+point by point. Within one topology, --extra-args "--deterministic-mode" does pin the run
+bit-for-bit; it costs ~25% per step and ~3.6 GB of GPU.
 
 Usage:
     python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py   # downloads DATASET on first run
@@ -152,19 +149,12 @@ def execute(args: ScriptArgs) -> None:
 
     perf_args = "--micro-batch-size 1 --gradient-checkpointing "
 
-    # One rank has no cross-rank reduction order to vary, so determinism here is
-    # reachable and cheap to keep: it makes this recipe a reproducible reference for
-    # the 8-GPU one, whose curve is not bit-reproducible across topologies anyway.
-    # No --fsdp-attention-backend is set, so validate_attention_args takes the
-    # torch-native path rather than rejecting an opaque kernel.
-    determinism_args = "--deterministic-mode "
-
     misc_args = "--actor-num-gpus-per-node 1 --num-gpus-per-node 1 "
 
     U.execute_train(
         train_args=(
             f"{ckpt_args} {rollout_args} {sft_args} {optimizer_args} {lora_args} "
-            f"{wandb_args} {train_backend_args} {perf_args} {determinism_args} {misc_args} {args.extra_args}"
+            f"{wandb_args} {train_backend_args} {perf_args} {misc_args} {args.extra_args}"
         ),
         num_gpus_per_node=1,
         config=args,


### PR DESCRIPTION
## What

`scripts/run_diffusion_sft_h3_t2va_1gpu.py` — `run_diffusion_sft_h3_t2va.py` on one card, training the same thing rather than a scaled-down approximation. Same automation level as the 8-GPU recipe: `prepare()` fetches `rockdu/WISA-80K-Practical-Dynamics-254`, so a zero-argument launch is a complete run and `--data-dir` is the only data knob.

Below the docstring the two scripts differ in four lines: the run-name prefix, `--fsdp-cpu-offload`, `--fsdp-master-dtype bf16`, and 8 → 1 GPUs. Every `*_args` block — optimizer, LoRA, batch, sigma grid, reduce dtype — is byte-identical.

## Why the two are equivalent

- **Batch schedule.** `global_batch_size` is 8 in both. `arguments.py` derives it as `rollout_batch_size × n_samples_per_prompt ÷ num_steps_per_rollout` — no world-size term — so one card only changes the layout: 8 dp ranks × 1 micro-batch becomes 1 rank × 8 gradient-accumulation micro-batches at `micro_batch_size=1`, still 4 optimizer steps per rollout.
- **Gradient scale.** `actor.py` backwards `loss_sum / num_local_pairs`: `/8` on the single rank, `/1` on each of eight before FSDP2's mesh-mean divides by 8 again.
- **Precision.** `--fsdp-master-dtype bf16` changes no math under `--fsdp-cpu-offload`. Only the LoRA adapters train and PEFT keeps those in fp32 whatever the base dtype (measured: base bf16 → `lora_A`/`lora_B` float32, requires_grad=True); the frozen base is gathered as bf16 for the forward at either setting, since `MixedPrecisionPolicy` applies `param_dtype=bf16` to every wrap and H3 declares no `param_dtype_patterns`. Step 1 of an otherwise identical run reproduces the fp32 loss to every digit logged, `3.276656e-01`. `_keep_in_fp32_modules` still holds `proj_in`/`proj_out`/`audio_proj_*`/`time_embedder`/`rope` in fp32; `--fsdp-reduce-dtype` stays fp32 because the LoRA gradients do train.

`--fsdp-cpu-offload` is the one flag that is a requirement rather than a free choice: H3 is 33.5B parameters, so even a bf16 master is ~66 GB and leaves no room for activations on a 139.8 GB H200.

## What it costs

Against the 8-GPU reference run on the same dataset, warm cache. Per-step figures are `perf/actor_train_time`, so encoding is excluded.

| | 8 GPUs | 1 GPU |
|---|---|---|
| GPU peak (train step) | ~57 GB/rank | **39.5 GB** — activations plus one block; no weights resident |
| host RAM | — | **217 GB** peak at init, **99 GB** steady (~95 GB pinned) |
| init | — | ~6 min |
| per optimizer step | 30.5 s | **278 s** |
| per rollout (4 steps) | 122 s | **17.3 min** |

The 9× gap is 8× rank count plus ~14% for the PCIe round trip the offload adds to every block, on the forward and the gradient-checkpoint recompute alike. A cold `.sft_cache` costs more and only here — one encode worker instead of eight, ~480–590 s per rollout through the first epoch, during which the ~67 GB encoder rather than the train step owns the GPU peak.

## Validation

A zero-argument run on a clean box, end to end:

- `prepare()` downloaded the dataset (1.1 GB, 254 rows, `clips/`), and its **relative** media paths resolved — the path this recipe would otherwise never exercise, since every earlier run of mine used absolute paths.
- FSDP init 6 min; encode 32/32 clips (583.7 s); 4 optimizer steps with per-sigma-bucket metrics; clean exit.
- Separately, an 11-rollout run to `iter_0000011` → `scripts/export_lora.py` → a 624-tensor rank-64/alpha-128 adapter structurally identical to the 8-GPU one, which then served under `sglang serve --lora-path` and reproduced the `lora_sft_guide` figure prompts.
- `--deterministic-mode` was exercised and passes (no op lacks a deterministic implementation), but is **not** on by default: it costs ~25% per step and ~3.6 GB of GPU, enough to push the peak past a 40 GB card. Documented as `--extra-args "--deterministic-mode"`.

## Limits

The two curves are comparable on trend and on the per-sigma buckets, **not** point by point. `prepare_sft_batch` seeds the sigma and noise draw on `(rollout_id, microbatch_id, dp_rank)`, so changing topology moves every sample to a different sigma by construction. A long-run trend comparison against the 8-GPU reference is not included here. The run that would have provided it reached 78 steps (19 rollouts) at fp32 master before I stopped it to switch the recipe to bf16; at that length both series still sit inside the 8-GPU run's own warm-up spread, so it would not have supported a conclusion either way.

Status is registered **NV**: no complete training curve has been run at this topology.

## Checklist

- [x] `pre-commit run --files <touched>` passes
- [ ] Added/updated tests — **none**; the script carries no library code, and its four differing lines are launch flags
- [x] `python3 scripts/run_diffusion_sft_h3_t2va_1gpu.py --help` parses
- [x] Zero-argument run validated end to end (see above)
- [ ] New public flags — **none**; `--fsdp-cpu-offload`, `--fsdp-master-dtype` and `--deterministic-mode` all already exist and are documented
- [x] Docs updated (`docs/models/h3/h3.md` §4.1, `recipe-verification.md`)
