### PR TITLE
fix(scripts): correct the PYTHONBUFFERED typo and unbuffer ray workers

### DIFF
--- a/miles/utils/external_utils/command_utils.py
+++ b/miles/utils/external_utils/command_utils.py
@@ -89,7 +89,7 @@ def execute_train(
             # it never reaches the scheduler, which then places work on excluded GPUs.
             f"{_cvd_export(config, num_gpus_per_node)}"
             # keeps ray from buffering stdout/stderr
-            "export PYTHONBUFFERED=16 && "
+            "export PYTHONUNBUFFERED=1 && "
             f"ray start --head --node-ip-address {master_addr} "
             f"--num-gpus {num_gpus_per_node} --disable-usage-stats"
         )
@@ -103,6 +103,8 @@ def execute_train(
         f()
 
     runtime_env_vars = {
+        # exported for the submitting client too, but only the runtime env reaches the ray workers
+        "PYTHONUNBUFFERED": "1",
         "NCCL_NVLS_ENABLE": os.environ.get("NCCL_NVLS_ENABLE", str(int(check_has_nvlink()))),
         **{
             k: os.environ[k]
@@ -132,7 +134,7 @@ def execute_train(
         return
 
     exec_command(
-        "export no_proxy=127.0.0.1 && export PYTHONBUFFERED=16 && "
+        "export no_proxy=127.0.0.1 && export PYTHONUNBUFFERED=1 && "
         f"""ray job submit {'' if 'RAY_ADDRESS' in os.environ else '--address="http://127.0.0.1:8265" '}"""
         f"--runtime-env-json={shlex.quote(runtime_env_json)} "
         f"-- python3 {shlex.quote(train_script)} {train_args}"


### PR DESCRIPTION
## What

`command_utils.py` sets `PYTHONBUFFERED=16` in three places. That variable does not exist —
the one Python reads is `PYTHONUNBUFFERED` — so the intent stated in the comment ("keeps ray
from buffering stdout/stderr") has never taken effect. This syncs the fix miles core already
shipped in radixark/miles#1895 (`5ed3fd170`, 2026-08-09):

- `export PYTHONBUFFERED=16` → `export PYTHONUNBUFFERED=1`, at the `ray start` and the
  `ray job submit` call sites
- `"PYTHONUNBUFFERED": "1"` added to `runtime_env_vars`, so the ray **workers** are unbuffered
  too, not just the submitting shell

## Why

With the typo, `ray job submit`'s stdout is block-buffered when it goes to a file, so a
`nohup … > train.log` redirect only lands every ~8 KB. On the H3 SFT recipe that is one write
per ~5 min (the log produces ~1.7 KB/min), which makes `tail -f` and the file's mtime look
frozen for minutes at a time while the job is perfectly healthy. Seen while verifying #211:
the redirect appeared stuck at "train step 20" for several minutes with the run still
progressing; the ray driver log was the only live view.

Note the tests in this repo already use the correct spelling (e.g.
`tests/fast/utils/test_metric_buffer_dist.py:19`), so this only ever affected the launch path.

## Notes

- Behaviour change is limited to output buffering; no flags, defaults or training semantics move.
- `grep -rn PYTHONBUFFERED` now returns nothing.

## Checklist

- [ ] `pre-commit run --all-files` — not run locally; CI will verify
- [x] No test changes needed (launch-path only, no new behaviour to assert)
- [x] Matches the upstream fix in radixark/miles#1895 line for line
