### PR TITLE
feat(krea2): add Krea 2 model family for DiffusionNFT training

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed.tensor import DTensor
 
+import miles.backends.fsdp_utils.configs.krea2  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.qwen_image  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.sd3  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.wan2_2  # noqa: F401 — register pipeline config

--- a/miles/backends/fsdp_utils/configs/krea2.py
+++ b/miles/backends/fsdp_utils/configs/krea2.py
@@ -1,0 +1,86 @@
+"""Krea2 training pipeline config."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from miles.utils.types import CondKwargs
+
+from .train_pipeline_config import TrainPipelineConfig, register_train_pipeline_config
+
+
+@register_train_pipeline_config("krea2")
+class Krea2TrainPipelineConfig(TrainPipelineConfig):
+    hf_ckpt_name_patterns = ("krea-2",)
+
+    @classmethod
+    def validate_args(cls, args) -> None:
+        # The engine's krea2 pipeline has no per-request output expansion yet.
+        if args.rollout_microgroup_size != 1:
+            raise ValueError("krea2 rollout serves one sample per request; use --rollout-microgroup-size 1")
+
+    def process_sigma_as_timesteps_input(self, sigmas: torch.Tensor, *, num_train_timesteps: int) -> torch.Tensor:
+        # The DiT takes flow time in [0, 1]; its sinusoidal embed applies the x1000 itself.
+        return sigmas
+
+    def prepare_cond_kwargs(self, cond: CondKwargs | None, device: torch.device) -> dict:
+        if cond is None:
+            return {}
+        kwargs = {}
+        if cond.encoder_hidden_states:
+            # (seq_len, num_text_layers, dim) -> (1, seq_len, num_text_layers, dim)
+            kwargs["encoder_hidden_states"] = cond.encoder_hidden_states[0].to(device).unsqueeze(0)
+        if cond.pos is not None:
+            kwargs["position_ids"] = cond.pos.to(device)
+        if cond.encoder_attention_mask:
+            kwargs["encoder_attention_mask"] = (
+                cond.encoder_attention_mask[0].to(device=device, dtype=torch.bool).unsqueeze(0)
+            )
+        return kwargs
+
+    def collate_cond_for_sample_batch(
+        self,
+        per_sample_cond_kwargs: list[dict],
+        device: torch.device,
+        pad_to_len: int | None = None,
+    ) -> dict:
+        img_pos = None
+        for kw in per_sample_cond_kwargs:
+            # position_ids = zero rows for text, then the latent-grid rows; the grid is
+            # resolution-only, so one batch shares it and text rows pad with more zeros.
+            rows = kw["position_ids"][kw["encoder_hidden_states"].shape[1] :]
+            if img_pos is None:
+                img_pos = rows
+            elif rows.shape != img_pos.shape:
+                raise ValueError(
+                    f"collate expects one image resolution per batch, "
+                    f"got grids {tuple(rows.shape)} vs {tuple(img_pos.shape)}"
+                )
+
+        max_len = max(kw["encoder_hidden_states"].shape[1] for kw in per_sample_cond_kwargs)
+        if pad_to_len is not None:
+            max_len = max(max_len, int(pad_to_len))
+        encs = []
+        masks = []
+        for kw in per_sample_cond_kwargs:
+            enc = kw["encoder_hidden_states"]
+            mask = kw["encoder_attention_mask"]
+            pad = max_len - enc.shape[1]
+            encs.append(F.pad(enc, (0, 0, 0, 0, 0, pad)) if pad else enc)
+            masks.append(F.pad(mask, (0, pad)) if pad else mask)
+        mask = torch.cat(masks, dim=0).to(device)
+        return {
+            "encoder_hidden_states": torch.cat(encs, dim=0).to(device),
+            # All-valid text runs maskless, matching the rollout DiT's fast path.
+            "encoder_attention_mask": None if bool(mask.all()) else mask,
+            "position_ids": torch.cat([img_pos.new_zeros(max_len, 3), img_pos], dim=0).to(device),
+        }
+
+    def cfg_combine(
+        self,
+        noise_pred_pos: torch.Tensor,
+        noise_pred_neg: torch.Tensor,
+        guidance_scale: float,
+        true_cfg_scale: float | None = None,
+    ) -> torch.Tensor:
+        return noise_pred_neg + guidance_scale * (noise_pred_pos - noise_pred_neg)

--- a/miles/backends/fsdp_utils/loss_hub/nft.py
+++ b/miles/backends/fsdp_utils/loss_hub/nft.py
@@ -28,7 +28,7 @@ def prepare_nft_batch(
 ) -> PreparedBatch:
     """Corrupt clean x0 at each pair's sigma; CFG-free cond."""
     if len(ctx.models) != 1:
-        raise ValueError("DiffusionNFT currently supports a single DiT component (SD3)")
+        raise ValueError("DiffusionNFT currently supports a single DiT component")
     device = ctx.device
     config = ctx.train_pipeline_config
     bsz = len(batch)

--- a/miles/backends/fsdp_utils/models/diffusers/krea2/parallel_plan.py
+++ b/miles/backends/fsdp_utils/models/diffusers/krea2/parallel_plan.py
@@ -1,0 +1,4 @@
+from miles.backends.fsdp_utils.models.parallel_plan import FSDPParallelPlan
+
+
+FSDP_PARALLEL_PLAN = FSDPParallelPlan()

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -101,8 +101,10 @@ def _parse_cond_kwargs(
             data.get("audio_encoder_hidden_states"),
             deserialize_func=deserialize_func,
         ),
+        # Krea2 emits the text key-padding mask under the generic encoder_hidden_states_mask key.
         encoder_attention_mask=_parse_tensor_or_list(
-            data.get("encoder_attention_mask"), deserialize_func=deserialize_func
+            data.get("encoder_attention_mask") or data.get("encoder_hidden_states_mask"),
+            deserialize_func=deserialize_func,
         ),
         audio_encoder_attention_mask=_parse_tensor_or_list(
             data.get("audio_encoder_attention_mask"), deserialize_func=deserialize_func
@@ -110,6 +112,7 @@ def _parse_cond_kwargs(
         pooled_projections=_parse_tensor_or_list(data.get("pooled_projections"), deserialize_func=deserialize_func),
         h3_packed_layout=_parse_h3_packed_layout(data.get("h3_packed_layout"), deserialize_func=deserialize_func),
         h3_token_tags=_deserialize_optional_tensor(data.get("h3_token_tags"), deserialize_func=deserialize_func),
+        pos=deserialize_func(data.get("pos")),
         text_ids=deserialize_func(data.get("text_ids")),
         text_mask=deserialize_func(data.get("text_mask")),
         fps=data.get("fps"),

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -36,6 +36,8 @@ class CondKwargs:
     # MiniMax H3 packed-sequence replay metadata (from rollout denoising_env).
     h3_packed_layout: dict | None = None
     h3_token_tags: torch.Tensor | None = None
+    # Krea2: joint text+image 3-axis RoPE coordinates (seq_len, 3).
+    pos: torch.Tensor | None = None
     # Cosmos3: token-level conditioning (no separate text encoder).
     text_ids: torch.Tensor | None = None
     text_mask: torch.Tensor | None = None

--- a/scripts/run_diffusion_nft_krea2.py
+++ b/scripts/run_diffusion_nft_krea2.py
@@ -1,17 +1,21 @@
-"""Krea-2-Raw DiffusionNFT training with PickScore.
+"""Krea-2-Raw DiffusionNFT training (OCR by default, PickScore via --reward).
 
 Same NFT shape as run_diffusion_nft_sd3_pickscore.py: EMA reference (--ref-mode ema),
 rollout under pi_old (--ema-rollout-policy ema), deterministic ODE rollout
 (noise_level=0, sde_type=ode) with no CFG. Krea-2 specifics: bf16, 1024px, and one
 sample per rollout request (the engine's krea2 pipeline has no per-request output
-expansion).
+expansion). Rollout debug tensors are collected (--diffusion-debug-mode).
 
-Smoke mode swaps in the small OCR dataset and a tiny batch, for checking the pipeline
-end to end without a real run.
+OCR is the default reward: text rendering improves visibly and its accuracy curve is
+steep, so both the metric and the wandb images validate the run. It needs no reward
+GPU. --reward pickscore switches to the aesthetic direction on one extra GPU.
+
+Smoke mode shrinks the batch for checking the pipeline end to end without a real run.
 
 Usage:
-    python3 scripts/run_diffusion_nft_krea2_pickscore.py
-    MILES_SCRIPT_SMOKE=1 python3 scripts/run_diffusion_nft_krea2_pickscore.py
+    python3 scripts/run_diffusion_nft_krea2.py
+    python3 scripts/run_diffusion_nft_krea2.py --reward pickscore
+    MILES_SCRIPT_SMOKE=1 python3 scripts/run_diffusion_nft_krea2.py
 """
 
 import os
@@ -23,7 +27,7 @@ import miles.utils.external_utils.command_utils as U
 
 MODEL = "krea/Krea-2-Raw"
 DATASET = "rockdu/miles-diffusion-datasets"
-WANDB_PROJECT = "miles-diffusion-nft"
+WANDB_PROJECT = "diffusionNFT"
 
 
 @dataclass
@@ -31,11 +35,20 @@ class ScriptArgs(U.ExecuteTrainConfig):
     num_rollout: int = 0  # 0 picks the smoke/full default
     data_dir: str = "/root/datasets"
     smoke: bool = False
+    reward: str = "ocr"  # ocr | pickscore
     extra_args: str = ""
 
 
+def _use_ocr(args: ScriptArgs) -> bool:
+    return args.smoke or args.reward == "ocr"
+
+
 def _subset(args: ScriptArgs) -> str:
-    return "flowgrpo_ocr" if args.smoke else "flowgrpo_pickscore"
+    return "flowgrpo_ocr" if _use_ocr(args) else "flowgrpo_pickscore"
+
+
+def _num_gpus(args: ScriptArgs) -> int:
+    return 2 if _use_ocr(args) else 3
 
 
 def prepare(args: ScriptArgs) -> str:
@@ -44,7 +57,7 @@ def prepare(args: ScriptArgs) -> str:
 
 
 def execute(args: ScriptArgs, data_dir: str) -> None:
-    run_name = f"diffusion_nft_krea2_pickscore_{U.create_run_id()}"
+    run_name = f"diffusion_nft_krea2_{args.reward}_{U.create_run_id()}"
     num_rollout = args.num_rollout or (1 if args.smoke else 100)
 
     ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
@@ -61,6 +74,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--diffusion-sde-type ode "
         "--diffusion-height 1024 "
         "--diffusion-width 1024 "
+        "--diffusion-debug-mode "
         "--rollout-microgroup-size 1 "
     ) + (
         "--rollout-batch-size 2 --n-samples-per-prompt 2 "
@@ -69,7 +83,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
     )
 
     eval_args = "--diffusion-eval-num-steps 52 --skip-eval-before-train " + (
-        "" if args.smoke else f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl --eval-interval 30 "
+        "" if args.smoke else f"--eval-prompt-data {args.reward}_test {data_dir}/test.jsonl --eval-interval 30 "
     )
 
     grpo_args = (
@@ -96,7 +110,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
 
     reward_args = (
         "--rm-type ocr "
-        if args.smoke
+        if _use_ocr(args)
         else (
             "--rm-type pickscore "
             "--pickscore-num-workers 1 "
@@ -127,7 +141,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--actor-num-gpus-per-node 2 "
         "--rollout-num-gpus 2 "
         "--rollout-num-gpus-per-engine 1 "
-        f"--num-gpus-per-node {2 if args.smoke else 3} "
+        f"--num-gpus-per-node {_num_gpus(args)} "
         "--colocate "
         "--deterministic-mode "
     )
@@ -138,7 +152,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
             f"{optimizer_args} {lora_args} {reward_args} {wandb_args} {sglang_args} "
             f"{train_backend_args} {perf_args} {misc_args} {args.extra_args}"
         ),
-        num_gpus_per_node=2 if args.smoke else 3,
+        num_gpus_per_node=_num_gpus(args),
         config=args,
         extra_env_vars={
             "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",

--- a/scripts/run_diffusion_nft_krea2_pickscore.py
+++ b/scripts/run_diffusion_nft_krea2_pickscore.py
@@ -1,0 +1,157 @@
+"""Krea-2-Raw DiffusionNFT training with PickScore.
+
+Same NFT shape as run_diffusion_nft_sd3_pickscore.py: EMA reference (--ref-mode ema),
+rollout under pi_old (--ema-rollout-policy ema), deterministic ODE rollout
+(noise_level=0, sde_type=ode) with no CFG. Krea-2 specifics: bf16, 1024px, and one
+sample per rollout request (the engine's krea2 pipeline has no per-request output
+expansion).
+
+Smoke mode swaps in the small OCR dataset and a tiny batch, for checking the pipeline
+end to end without a real run.
+
+Usage:
+    python3 scripts/run_diffusion_nft_krea2_pickscore.py
+    MILES_SCRIPT_SMOKE=1 python3 scripts/run_diffusion_nft_krea2_pickscore.py
+"""
+
+import os
+from dataclasses import dataclass
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+MODEL = "krea/Krea-2-Raw"
+DATASET = "rockdu/miles-diffusion-datasets"
+WANDB_PROJECT = "miles-diffusion-nft"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    num_rollout: int = 0  # 0 picks the smoke/full default
+    data_dir: str = "/root/datasets"
+    smoke: bool = False
+    extra_args: str = ""
+
+
+def _subset(args: ScriptArgs) -> str:
+    return "flowgrpo_ocr" if args.smoke else "flowgrpo_pickscore"
+
+
+def prepare(args: ScriptArgs) -> str:
+    local_dir = U.hf_download_dataset(DATASET, include=f"{_subset(args)}/**", data_dir=args.data_dir)
+    return f"{local_dir}/{_subset(args)}"
+
+
+def execute(args: ScriptArgs, data_dir: str) -> None:
+    run_name = f"diffusion_nft_krea2_pickscore_{U.create_run_id()}"
+    num_rollout = args.num_rollout or (1 if args.smoke else 100)
+
+    ckpt_args = f"--hf-checkpoint {MODEL} --save {args.output_dir}/{run_name}/ckpt --save-interval 20 "
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_dir}/train.jsonl "
+        "--input-key input "
+        f"--num-rollout {num_rollout} "
+        "--num-steps-per-rollout 1 "
+        "--diffusion-num-steps 10 "
+        "--diffusion-guidance-scale 1.0 "
+        "--diffusion-noise-level 0.0 "
+        "--diffusion-sde-type ode "
+        "--diffusion-height 1024 "
+        "--diffusion-width 1024 "
+        "--rollout-microgroup-size 1 "
+    ) + (
+        "--rollout-batch-size 2 --n-samples-per-prompt 2 "
+        if args.smoke
+        else "--rollout-batch-size 8 --n-samples-per-prompt 8 "
+    )
+
+    eval_args = "--diffusion-eval-num-steps 52 --skip-eval-before-train " + (
+        "" if args.smoke else f"--eval-prompt-data pickscore_test {data_dir}/test.jsonl --eval-interval 30 "
+    )
+
+    grpo_args = (
+        "--loss-type nft "
+        "--diffusion-nft-beta 1.0 "
+        "--diffusion-nft-timestep-fraction 0.99 "
+        "--advantage-estimator grpo "
+        "--globalize-reward-std "
+    )
+
+    ema_args = (
+        "--ref-mode ema "
+        "--use-ema "
+        "--ema-rollout-policy ema "
+        "--ema-decay-init 0.001 "
+        "--ema-decay-ramp 0.001 "
+        "--ema-decay-max 0.5 "
+        "--ema-decay-flat-steps 0 "
+    )
+
+    optimizer_args = "--lr 3e-4 --adam-beta2 0.999 --weight-decay 1e-4 --clip-grad 1.0 "
+
+    lora_args = "--use-lora --lora-ipc-weight-sync --lora-rank 32 --lora-alpha 64 --lora-init-weights gaussian "
+
+    reward_args = (
+        "--rm-type ocr "
+        if args.smoke
+        else (
+            "--rm-type pickscore "
+            "--pickscore-num-workers 1 "
+            "--pickscore-num-gpus-per-worker 1.0 "
+            "--pickscore-batch-size 8 "
+            "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+            "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+        )
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=8, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 8 "
+        "--sglang-dit-precision bf16 "
+        "--sglang-vae-slicing "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = "--train-backend fsdp --diffusion-forward-dtype bf16 "
+
+    perf_args = "--gradient-checkpointing " + ("--micro-batch-size 1 " if args.smoke else "--micro-batch-size 2 ")
+
+    misc_args = (
+        "--actor-num-gpus-per-node 2 "
+        "--rollout-num-gpus 2 "
+        "--rollout-num-gpus-per-engine 1 "
+        f"--num-gpus-per-node {2 if args.smoke else 3} "
+        "--colocate "
+        "--deterministic-mode "
+    )
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {eval_args} {grpo_args} {ema_args} "
+            f"{optimizer_args} {lora_args} {reward_args} {wandb_args} {sglang_args} "
+            f"{train_backend_args} {perf_args} {misc_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=2 if args.smoke else 3,
+        config=args,
+        extra_env_vars={
+            "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+            "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
+        },
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    data_dir = prepare(args)
+    execute(args, data_dir)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/fast/backends/fsdp_utils/configs/test_krea2_cond.py
+++ b/tests/fast/backends/fsdp_utils/configs/test_krea2_cond.py
@@ -1,0 +1,77 @@
+"""Krea2 cond plumbing: layer-stacked text embeds, position_ids rebuild, key-padding mask."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+from safetensors.torch import save
+
+from miles.backends.fsdp_utils.configs.krea2 import Krea2TrainPipelineConfig
+from miles.utils.diffusion_rollout_response import _default_deserialize_func, _parse_cond_kwargs
+from miles.utils.types import CondKwargs
+
+CPU = torch.device("cpu")
+LAYERS, DIM, IMG_LEN = 3, 5, 4
+
+
+def _cond(seq_len: int, img_len: int = IMG_LEN) -> CondKwargs:
+    img_rows = torch.arange(img_len * 3, dtype=torch.float32).reshape(img_len, 3)
+    return CondKwargs(
+        encoder_hidden_states=[torch.randn(seq_len, LAYERS, DIM)],
+        encoder_attention_mask=[torch.ones(seq_len, dtype=torch.bool)],
+        pos=torch.cat([torch.zeros(seq_len, 3), img_rows]),
+    )
+
+
+def test_prepare_shapes():
+    kw = Krea2TrainPipelineConfig().prepare_cond_kwargs(_cond(7), CPU)
+    assert kw["encoder_hidden_states"].shape == (1, 7, LAYERS, DIM)
+    assert kw["encoder_attention_mask"].shape == (1, 7)
+    assert kw["position_ids"].shape == (7 + IMG_LEN, 3)
+
+
+def test_collate_pads_ragged_text_and_rebuilds_position_ids():
+    cfg = Krea2TrainPipelineConfig()
+    kws = [cfg.prepare_cond_kwargs(_cond(5), CPU), cfg.prepare_cond_kwargs(_cond(7), CPU)]
+    out = cfg.collate_cond_for_sample_batch(kws, CPU)
+    assert out["encoder_hidden_states"].shape == (2, 7, LAYERS, DIM)
+    assert out["encoder_attention_mask"].tolist() == [[True] * 5 + [False] * 2, [True] * 7]
+    assert torch.equal(out["position_ids"][:7], torch.zeros(7, 3))
+    assert torch.equal(out["position_ids"][7:], kws[1]["position_ids"][7:])
+
+
+def test_collate_uniform_lengths_drop_the_mask():
+    cfg = Krea2TrainPipelineConfig()
+    kws = [cfg.prepare_cond_kwargs(_cond(6), CPU) for _ in range(2)]
+    assert cfg.collate_cond_for_sample_batch(kws, CPU)["encoder_attention_mask"] is None
+
+
+def test_collate_honors_pad_to_len():
+    cfg = Krea2TrainPipelineConfig()
+    out = cfg.collate_cond_for_sample_batch([cfg.prepare_cond_kwargs(_cond(5), CPU)], CPU, pad_to_len=9)
+    assert out["encoder_hidden_states"].shape == (1, 9, LAYERS, DIM)
+    assert out["encoder_attention_mask"].tolist() == [[True] * 5 + [False] * 4]
+
+
+def test_collate_rejects_mixed_resolutions():
+    cfg = Krea2TrainPipelineConfig()
+    kws = [cfg.prepare_cond_kwargs(_cond(5, img_len=4), CPU), cfg.prepare_cond_kwargs(_cond(5, img_len=6), CPU)]
+    with pytest.raises(ValueError, match="one image resolution"):
+        cfg.collate_cond_for_sample_batch(kws, CPU)
+
+
+def test_parse_cond_kwargs_reads_krea2_env_keys():
+    ser = lambda t: {"__tensor__": True, "data": save({"t": t})}  # noqa: E731
+    cond = _parse_cond_kwargs(
+        {
+            "encoder_hidden_states": ser(torch.randn(7, LAYERS, DIM)),
+            "encoder_hidden_states_mask": ser(torch.ones(7, dtype=torch.bool)),
+            "pos": ser(torch.zeros(7 + IMG_LEN, 3)),
+        },
+        deserialize_func=_default_deserialize_func,
+    )
+    assert cond.encoder_hidden_states[0].shape == (7, LAYERS, DIM)
+    assert cond.encoder_attention_mask[0].dtype == torch.bool
+    assert cond.pos.shape == (7 + IMG_LEN, 3)

--- a/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
+++ b/tests/fast/backends/fsdp_utils/configs/test_train_pipeline_config_registry.py
@@ -5,6 +5,7 @@ register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
 import pytest
 import torch
 
+from miles.backends.fsdp_utils.configs.krea2 import Krea2TrainPipelineConfig
 from miles.backends.fsdp_utils.configs.qwen_image import QwenImageTrainPipelineConfig
 from miles.backends.fsdp_utils.configs.sd3 import SD3TrainPipelineConfig
 from miles.backends.fsdp_utils.configs.train_pipeline_config import TrainPipelineConfig, resolve_diffusion_model_family
@@ -20,6 +21,7 @@ class TestFamilyResolution:
             ("Qwen/Qwen-Image", "qwen_image"),
             ("Wan-AI/Wan2.2-T2V-A14B", "wan2_2"),
             ("/data/ckpts/SD3.5-Medium-Finetune", "sd3"),
+            ("krea/Krea-2-Raw", "krea2"),
         ],
     )
     def test_known_patterns(self, ref, family):
@@ -94,11 +96,13 @@ class TestProcessTimestepAsInput:
     # What a family hands its DiT as the timestep, given the trajectory's t and the
     # scheduler range N. Each family must reproduce the arithmetic its sglang-d DiT runs.
     #
-    #   sd3, wan2_2   t         the DiT takes the trajectory timestep unchanged
-    #   qwen_image    t / 1000  the model's own normalizer, which Timesteps(scale=1000) undoes
+    #   sd3, wan2_2, krea2   t         the DiT takes the trajectory timestep unchanged
+    #   qwen_image           t / 1000  the model's own normalizer, which Timesteps(scale=1000) undoes
     TIMESTEPS = torch.tensor([978.2581787109375, 500.0])
 
-    @pytest.mark.parametrize("config_cls", [SD3TrainPipelineConfig, Wan2_2TrainPipelineConfig])
+    @pytest.mark.parametrize(
+        "config_cls", [SD3TrainPipelineConfig, Wan2_2TrainPipelineConfig, Krea2TrainPipelineConfig]
+    )
     def test_raw_trajectory_timestep(self, config_cls):
         out = config_cls.process_timestep_as_input(config_cls, self.TIMESTEPS)
         assert torch.equal(out, self.TIMESTEPS)
@@ -122,11 +126,14 @@ class TestProcessSigmaAsTimestepsInput:
         )
         assert torch.equal(out, self.SIGMAS * float(self.NUM_TRAIN_TIMESTEPS))
 
-    def test_qwen_image_passes_the_sigma_through(self):
-        out = QwenImageTrainPipelineConfig.process_sigma_as_timesteps_input(
-            QwenImageTrainPipelineConfig, self.SIGMAS, num_train_timesteps=self.NUM_TRAIN_TIMESTEPS
+    @pytest.mark.parametrize("config_cls", [QwenImageTrainPipelineConfig, Krea2TrainPipelineConfig])
+    def test_passes_the_sigma_through(self, config_cls):
+        out = config_cls.process_sigma_as_timesteps_input(
+            config_cls, self.SIGMAS, num_train_timesteps=self.NUM_TRAIN_TIMESTEPS
         )
         assert torch.equal(out, self.SIGMAS)
+
+    def test_qwen_image_round_trip_is_not_identity(self):
         # Asserted so the equal() above keeps its teeth.
         round_tripped = QwenImageTrainPipelineConfig.process_timestep_as_input(
             QwenImageTrainPipelineConfig, self.SIGMAS * float(self.NUM_TRAIN_TIMESTEPS)


### PR DESCRIPTION
- `Krea2TrainPipelineConfig`: layer-stacked text conditioning (4-D `encoder_hidden_states` + `position_ids` + key-padding mask), sigma pass-through timestep hook, empty FSDP plan
- `CondKwargs.pos` + rollout-response parsing for the krea2 env keys
- recipe: `scripts/run_diffusion_nft_krea2.py` (NFT, bf16, 1024px, one sample per rollout request, rollout debug on; OCR reward default, `--reward pickscore` optional)
- CPU tests: family resolution, timestep hooks, cond prepare/collate/parse


Note: 
- Krea2 RL is also supported; but some optimizations/parity improvements are needed; will be implemented in future PRs if needed.