### PR TITLE
perf(startup): overlap engine boot with train init + mmap loading

### DIFF
--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -11,6 +11,7 @@ from torch.distributed.tensor import DTensor
 import miles.backends.fsdp_utils.configs.qwen_image  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.sd3  # noqa: F401 — register pipeline config
 import miles.backends.fsdp_utils.configs.wan2_2  # noqa: F401 — register pipeline config
+import miles.utils.startup_timing as st
 from miles.ray.train_actor import TrainRayActor
 from miles.utils import tracking_utils, train_metric_utils
 from miles.utils.context_utils import with_defer
@@ -69,13 +70,15 @@ class FSDPTrainRayActor(TrainRayActor):
         if args.deterministic_mode:
             _enable_deterministic_training(args)
 
-        self.parallel_state = create_fsdp_parallel_state(args)
+        with st.step("train.parallel_state"):
+            self.parallel_state = create_fsdp_parallel_state(args)
         torch.manual_seed(args.seed)
 
         # Offline dashboard: record Timer phases + (rank 0) NVML GPU util when explicitly enabled.
         from miles.dashboard import hooks
 
-        hooks.register_train_actor(args, role)
+        with st.step("train.dashboard_register"):
+            hooks.register_train_actor(args, role)
 
         self.train_parallel_config = {
             "dp_size": self.parallel_state.get_mesh("dp").size(),
@@ -88,7 +91,8 @@ class FSDPTrainRayActor(TrainRayActor):
             self.args.offload_train = False
 
         if dist.get_rank() == 0:
-            init_tracking(args, primary=False)
+            with st.step("train.wandb_init"):
+                init_tracking(args, primary=False)
 
         if self.args.start_rollout_id is None:
             self.args.start_rollout_id = 0
@@ -98,20 +102,24 @@ class FSDPTrainRayActor(TrainRayActor):
 
         from miles.utils.misc import load_function
 
-        self.train_pipeline_config = load_function(args.train_pipeline_config_path)()
-        self.train_pipeline_config.configure(args)
-        self.model_backend = load_function(args.model_backend_path)(self.train_pipeline_config)
+        with st.step("train.pipeline_config_and_backend"):
+            self.train_pipeline_config = load_function(args.train_pipeline_config_path)()
+            self.train_pipeline_config.configure(args)
+            self.model_backend = load_function(args.model_backend_path)(self.train_pipeline_config)
         if args.deterministic_mode:
             # flash-attn is opaque to torch's determinism flag; backends patch their own dispatch.
             self.model_backend.enable_deterministic_attention(args.fsdp_attention_backend)
-        self.scheduler = self.model_backend.load_scheduler(args)
+        with st.step("train.load_scheduler"):
+            self.scheduler = self.model_backend.load_scheduler(args)
         rank = dist.get_rank()
         materialize_weights = rank == 0
 
         self.models: dict[str, torch.nn.Module] = {}
         for component in args.update_weight_target_modules:
             # per raw component (wan2.2 has two transformers), before LoRA/FSDP wrap
-            with self._model_init_context(materialize_weights=materialize_weights):
+            with st.step(f"train.load_component.{component}"), self._model_init_context(
+                materialize_weights=materialize_weights
+            ):
                 model = self.model_backend.load_component(
                     component,
                     args,
@@ -128,28 +136,34 @@ class FSDPTrainRayActor(TrainRayActor):
                 self.model_backend.enable_gradient_checkpointing(model)
 
             if args.use_lora:
-                model = apply_lora(model, args, self.train_pipeline_config)
+                with st.step(f"train.apply_lora.{component}"):
+                    model = apply_lora(model, args, self.train_pipeline_config)
 
             model.train()
 
             if rank != 0 and any(not parameter.is_meta for parameter in model.parameters()):
                 raise RuntimeError(f"{component} did not honor meta initialization")
-            checkpoint.sync_model_dtypes(model)
-            full_state = model.state_dict() if rank == 0 else {}
-            model = apply_fsdp2(
-                model,
-                self.model_backend.fsdp_parallel_plan(model),
-                mesh=self.parallel_state.get_mesh("fsdp"),
-                cpu_offload=self.args.fsdp_cpu_offload,
-                args=self.args,
-            )
-            checkpoint.broadcast_full_state_to_fsdp(
-                model,
-                full_state,
-                cpu_offload=self.args.fsdp_cpu_offload,
-            )
+            with st.step(f"train.sync_dtypes.{component}"):
+                checkpoint.sync_model_dtypes(model)
+            with st.step(f"train.state_dict.{component}"):
+                full_state = model.state_dict() if rank == 0 else {}
+            with st.step(f"train.apply_fsdp2.{component}"):
+                model = apply_fsdp2(
+                    model,
+                    self.model_backend.fsdp_parallel_plan(model),
+                    mesh=self.parallel_state.get_mesh("fsdp"),
+                    cpu_offload=self.args.fsdp_cpu_offload,
+                    args=self.args,
+                )
+            with st.step(f"train.broadcast_full_state.{component}"):
+                checkpoint.broadcast_full_state_to_fsdp(
+                    model,
+                    full_state,
+                    cpu_offload=self.args.fsdp_cpu_offload,
+                )
             del full_state
-            self.train_pipeline_config.postprocess_model_after_materialize(model)
+            with st.step(f"train.postprocess_model.{component}"):
+                self.train_pipeline_config.postprocess_model_after_materialize(model)
             self.models[component] = model
 
         if self.parallel_state.get_optional_mesh("sp") is not None:
@@ -163,8 +177,9 @@ class FSDPTrainRayActor(TrainRayActor):
                 )
 
         # Force a sync to ensure sharding is complete and old memory is freed.
-        torch.cuda.synchronize()
-        clear_memory()
+        with st.step("train.sync_and_clear_memory"):
+            torch.cuda.synchronize()
+            clear_memory()
 
         if len(self.models) == 1:
             self.model = next(iter(self.models.values()))
@@ -209,7 +224,8 @@ class FSDPTrainRayActor(TrainRayActor):
         self.global_step = 0
         self.micro_step = 0
 
-        checkpoint_payload = checkpoint.load(self)
+        with st.step("train.checkpoint_load"):
+            checkpoint_payload = checkpoint.load(self)
 
         self.ema_shadow = None
         if self.args.use_ema:
@@ -231,11 +247,14 @@ class FSDPTrainRayActor(TrainRayActor):
         else:
             self.weight_updater = DiffusionUpdateWeightFromTensor(self.args, self.models)
 
-        checkpoint.finalize_load(self, checkpoint_payload)
+        with st.step("train.finalize_load"):
+            checkpoint.finalize_load(self, checkpoint_payload)
 
         if self.args.offload_train:
-            self.sleep()
+            with st.step("train.offload_after_init"):
+                self.sleep()
 
+        st.mark("train.init_done")
         return self.args.start_rollout_id
 
     @contextmanager
@@ -293,14 +312,16 @@ class FSDPTrainRayActor(TrainRayActor):
             dist.barrier(group=get_gloo_group())
             return
 
-        rollout_engines, rollout_engine_lock, num_new_engines = ray.get(
-            self.rollout_manager.get_rollout_engines_and_lock.remote()
-        )
+        with st.step("train.uw.get_engines"):
+            rollout_engines, rollout_engine_lock, num_new_engines = ray.get(
+                self.rollout_manager.get_rollout_engines_and_lock.remote()
+            )
         if num_new_engines > 0:
-            self.weight_updater.connect_rollout_engines(rollout_engines, rollout_engine_lock)
-            dist.barrier(group=get_gloo_group())
-            if dist.get_rank() == 0:
-                ray.get(self.rollout_manager.clear_num_new_engines.remote())
+            with st.step("train.uw.connect_engines", num_new_engines=num_new_engines):
+                self.weight_updater.connect_rollout_engines(rollout_engines, rollout_engine_lock)
+                dist.barrier(group=get_gloo_group())
+                if dist.get_rank() == 0:
+                    ray.get(self.rollout_manager.clear_num_new_engines.remote())
 
         ema_shadow = self.ema_shadow
         if ema_shadow is not None:
@@ -310,7 +331,7 @@ class FSDPTrainRayActor(TrainRayActor):
         rollout_weight_context = (
             ema_shadow.swap_in() if ema_shadow is not None and self.args.ema_rollout_policy == "ema" else nullcontext()
         )
-        with rollout_weight_context:
+        with rollout_weight_context, st.step("train.uw.push_weights"):
             self.weight_updater.update_weights()
         clear_memory()
 

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -64,8 +64,9 @@ class FSDPTrainRayActor(TrainRayActor):
     """
 
     @with_defer(lambda: Timer().start("train_wait"))
-    def init(self, args: Namespace, role: str, with_ref: bool = False) -> int:  # type: ignore[override]
-        super().init(args, role, with_ref)
+    def init(self, args: Namespace, role: str, with_ref: bool = False, rollout_manager=None) -> int:  # type: ignore[override]
+        super().init(args, role, with_ref, rollout_manager=rollout_manager)
+        self._engines_evicted = False
 
         if args.deterministic_mode:
             _enable_deterministic_training(args)
@@ -147,6 +148,11 @@ class FSDPTrainRayActor(TrainRayActor):
                 checkpoint.sync_model_dtypes(model)
             with st.step(f"train.state_dict.{component}"):
                 full_state = model.state_dict() if rank == 0 else {}
+            # Up to here the loop only touches CPU memory, so it may overlap
+            # engine boot; FSDP wrap and the rank-0 broadcast below are the
+            # first large GPU allocations and must not coexist with the
+            # boot-time engine weights under colocate.
+            self._wait_rollout_engines_evicted()
             with st.step(f"train.apply_fsdp2.{component}"):
                 model = apply_fsdp2(
                     model,
@@ -256,6 +262,20 @@ class FSDPTrainRayActor(TrainRayActor):
 
         st.mark("train.init_done")
         return self.args.start_rollout_id
+
+    def _wait_rollout_engines_evicted(self) -> None:
+        """Colocate VRAM safety for the overlapped engine boot: engine weights
+        (e.g. ~66GB/GPU for H3 tp=2) plus the FSDP broadcast peak can exceed
+        GPU memory, so the first big train-side allocation waits until the
+        engines have offloaded. No-op when the rollout side keeps its weights
+        resident (disaggregated placement has its own GPUs)."""
+        if self._engines_evicted:
+            return
+        self._engines_evicted = True
+        if self.rollout_manager is None or not self.args.offload_rollout:
+            return
+        with st.step("train.wait_engines_evicted"):
+            ray.get(self.rollout_manager.wait_engines_offloaded.remote())
 
     @contextmanager
     def _model_init_context(self, *, materialize_weights: bool):

--- a/miles/backends/fsdp_utils/actor.py
+++ b/miles/backends/fsdp_utils/actor.py
@@ -265,17 +265,19 @@ class FSDPTrainRayActor(TrainRayActor):
 
     def _wait_rollout_engines_evicted(self) -> None:
         """Colocate VRAM safety for the overlapped engine boot: engine weights
-        (e.g. ~66GB/GPU for H3 tp=2) plus the FSDP broadcast peak can exceed
-        GPU memory, so the first big train-side allocation waits until the
-        engines have offloaded. No-op when the rollout side keeps its weights
-        resident (disaggregated placement has its own GPUs)."""
+        (e.g. ~66GB/GPU for H3 tp=2) plus the FSDP broadcast peak can exceed GPU
+        memory, so the first big train-side allocation blocks until the engines
+        have released them. boot_offload is idempotent and performs the offload
+        itself, so this holds even if the driver's own submission has not run
+        yet. No-op when the rollout side keeps its weights resident
+        (disaggregated placement has its own GPUs)."""
         if self._engines_evicted:
             return
         self._engines_evicted = True
         if self.rollout_manager is None or not self.args.offload_rollout:
             return
         with st.step("train.wait_engines_evicted"):
-            ray.get(self.rollout_manager.wait_engines_offloaded.remote())
+            ray.get(self.rollout_manager.boot_offload.remote())
 
     @contextmanager
     def _model_init_context(self, *, materialize_weights: bool):

--- a/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
+++ b/miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import requests
 from sglang.srt.utils.common import kill_process_tree
 
+import miles.utils.startup_timing as st
 from miles.ray.ray_actor import RayActor
 from miles.utils.http_utils import get_host_info
 
@@ -70,16 +71,18 @@ def launch_server_process(
     # use spawn to avoid potential risks of fork in terms of subthreads or CUDA.
     multiprocessing.set_start_method("spawn", force=True)
     server_args.host = server_args.host.strip("[]")
-    p = multiprocessing.Process(
-        target=_launch_server_target,
-        args=(server_args, apply_rollout_patches),
-    )
-    p.start()
+    with st.step("engine.spawn_server_process"):
+        p = multiprocessing.Process(
+            target=_launch_server_target,
+            args=(server_args, apply_rollout_patches),
+        )
+        p.start()
 
-    _wait_server_healthy(
-        base_url=server_args.url(),
-        is_process_alive=lambda: p.is_alive(),
-    )
+    with st.step("engine.wait_server_healthy"):
+        _wait_server_healthy(
+            base_url=server_args.url(),
+            is_process_alive=lambda: p.is_alive(),
+        )
 
     return p
 
@@ -111,6 +114,8 @@ class SGLangDiffusionEngine(RayActor):
         self.base_gpu_id = base_gpu_id
 
     def init(self, dist_init_addr, port, nccl_port, host=None):
+        st.set_role(f"engine{self.rank}")
+        st.mark("engine.init_enter")
         # SGL-D runs single-node per engine; accept dist_init_addr for caller compat, then drop.
         del dist_init_addr
         self.router_ip = self.args.sglang_router_ip
@@ -161,10 +166,11 @@ class SGLangDiffusionEngine(RayActor):
 
         if self.node_rank == 0 and self.router_ip and self.router_port:
             if self.args.use_miles_router:
-                response = requests.post(
-                    f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
-                )
-                response.raise_for_status()
+                with st.step("engine.router_register"):
+                    response = requests.post(
+                        f"http://{self.router_ip}:{self.router_port}/add_worker?url=http://{self.server_host}:{self.server_port}"
+                    )
+                    response.raise_for_status()
             else:
                 # SGL-D router TODO: add_worker path for the non-miles router
                 logger.warning("Skipping router add_worker: only miles_router is supported for now")

--- a/miles/ray/actor_group.py
+++ b/miles/ray/actor_group.py
@@ -93,12 +93,15 @@ class RayTrainGroup:
                 master_addr, master_port = ray.get(actor.get_master_addr_and_port.remote())
             self._actor_handlers.append(actor)
 
-    def async_init(self, args, role, with_ref=False):
+    def async_init(self, args, role, with_ref=False, rollout_manager=None):
         """
         Allocate GPU resourced and initialize model, optimzier, local ckpt, etc.
         """
         self.args = args
-        return [actor.init.remote(args, role, with_ref=with_ref) for actor in self._actor_handlers]
+        return [
+            actor.init.remote(args, role, with_ref=with_ref, rollout_manager=rollout_manager)
+            for actor in self._actor_handlers
+        ]
 
     def async_train(self, rollout_id, rollout_data_ref):
         """Do one rollout training"""

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -179,12 +179,14 @@ def create_rollout_manager(args, pg):
         logger.info("Computed num_rollout=%s (num_rollout_per_epoch=%s)", args.num_rollout, num_rollout_per_epoch)
 
     if args.offload_rollout:
-        # Fire-and-forget: RolloutManager actor tasks run in order, so this
-        # offload executes after deferred engine init finishes, while the
-        # driver goes on to build the training models. Anything that needs the
-        # engines later (onload/update_weights/generate) queues behind it.
-        with st.step("driver.rollout_manager.first_offload_submit"):
-            rollout_manager.offload.remote()
+        # Start the boot-time offload as early as possible without blocking the
+        # driver, so train-actor init overlaps engine boot. Under colocate the
+        # memory invariant is not enforced here: the train side gates its first
+        # large GPU allocation on the same idempotent boot_offload (see
+        # FSDPTrainRayActor._wait_rollout_engines_evicted), which holds whichever
+        # of the two calls the actor dequeues first.
+        with st.step("driver.rollout_manager.boot_offload_submit"):
+            rollout_manager.boot_offload.remote()
 
     logger.info("Rollout manager created.")
     return rollout_manager, num_rollout_per_epoch

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -142,7 +142,9 @@ def create_training_models(args, pgs, rollout_manager):
             pg=pgs["actor"],
         )
     with st.step("driver.train_group.init_wait"):
-        start_rollout_ids = ray.get(actor_model.async_init(args, role="actor", with_ref=False))
+        start_rollout_ids = ray.get(
+            actor_model.async_init(args, role="actor", with_ref=False, rollout_manager=rollout_manager)
+        )
     logger.info("Actor model initialized.")
 
     assert len(set(start_rollout_ids)) == 1

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -177,9 +177,12 @@ def create_rollout_manager(args, pg):
         logger.info("Computed num_rollout=%s (num_rollout_per_epoch=%s)", args.num_rollout, num_rollout_per_epoch)
 
     if args.offload_rollout:
-        # blocks until RolloutManager.__init__ (and every sglang engine) is up
-        with st.step("driver.rollout_manager.first_offload"):
-            ray.get(rollout_manager.offload.remote())
+        # Fire-and-forget: RolloutManager actor tasks run in order, so this
+        # offload executes after deferred engine init finishes, while the
+        # driver goes on to build the training models. Anything that needs the
+        # engines later (onload/update_weights/generate) queues behind it.
+        with st.step("driver.rollout_manager.first_offload_submit"):
+            rollout_manager.offload.remote()
 
     logger.info("Rollout manager created.")
     return rollout_manager, num_rollout_per_epoch

--- a/miles/ray/placement_group.py
+++ b/miles/ray/placement_group.py
@@ -5,6 +5,8 @@ import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+import miles.utils.startup_timing as st
+
 from .actor_group import RayTrainGroup
 from .rollout import RolloutManager
 
@@ -41,26 +43,28 @@ def sort_key(x):
 def _create_placement_group(num_gpus):
     """Create a placement group with the specified number of GPUs."""
     bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_gpus)]
-    pg = placement_group(bundles, strategy="PACK")
-    num_bundles = len(bundles)
+    with st.step("driver.pg.create_and_ready", num_gpus=num_gpus):
+        pg = placement_group(bundles, strategy="PACK")
+        num_bundles = len(bundles)
 
-    logger.info("Waiting for placement group to be ready...")
-    ray.get(pg.ready())
+        logger.info("Waiting for placement group to be ready...")
+        ray.get(pg.ready())
     logger.info("Placement group is ready.")
     # use info actor to get the GPU id
-    info_actors = []
-    for i in range(num_bundles):
-        info_actors.append(
-            InfoActor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg,
-                    placement_group_bundle_index=i,
-                )
-            ).remote()
-        )
-    gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
-    for actor in info_actors:
-        ray.kill(actor)
+    with st.step("driver.pg.info_actors"):
+        info_actors = []
+        for i in range(num_bundles):
+            info_actors.append(
+                InfoActor.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg,
+                        placement_group_bundle_index=i,
+                    )
+                ).remote()
+            )
+        gpu_ids = ray.get([actor.get_ip_and_gpu_id.remote() for actor in info_actors])
+        for actor in info_actors:
+            ray.kill(actor)
 
     bundle_infos = [(i, gpu_ids[i][0], gpu_ids[i][1]) for i in range(num_bundles)]
     sorted_bundle_infos = sorted(bundle_infos, key=sort_key)
@@ -130,44 +134,52 @@ def allocate_train_group(args, num_nodes, num_gpus_per_node, pg):
 
 def create_training_models(args, pgs, rollout_manager):
     logger.info("Initializing actor model...")
-    actor_model = allocate_train_group(
-        args=args,
-        num_nodes=args.actor_num_nodes,
-        num_gpus_per_node=args.actor_num_gpus_per_node,
-        pg=pgs["actor"],
-    )
-    start_rollout_ids = ray.get(actor_model.async_init(args, role="actor", with_ref=False))
+    with st.step("driver.train_group.spawn_actors"):
+        actor_model = allocate_train_group(
+            args=args,
+            num_nodes=args.actor_num_nodes,
+            num_gpus_per_node=args.actor_num_gpus_per_node,
+            pg=pgs["actor"],
+        )
+    with st.step("driver.train_group.init_wait"):
+        start_rollout_ids = ray.get(actor_model.async_init(args, role="actor", with_ref=False))
     logger.info("Actor model initialized.")
 
     assert len(set(start_rollout_ids)) == 1
     if args.start_rollout_id is None:
         args.start_rollout_id = start_rollout_ids[0]
 
-    actor_model.set_rollout_manager(rollout_manager)
+    with st.step("driver.train_group.set_rollout_manager"):
+        actor_model.set_rollout_manager(rollout_manager)
     if args.rollout_global_dataset:
-        ray.get(rollout_manager.load.remote(args.start_rollout_id - 1))
+        with st.step("driver.rollout_dataset.load"):
+            ray.get(rollout_manager.load.remote(args.start_rollout_id - 1))
 
     return actor_model
 
 
 def create_rollout_manager(args, pg):
     logger.info("Creating rollout manager (num_gpus=%s)", 0)
-    rollout_manager = RolloutManager.options(
-        num_cpus=1,
-        num_gpus=0,
-    ).remote(args, pg)
+    with st.step("driver.rollout_manager.ctor"):
+        rollout_manager = RolloutManager.options(
+            num_cpus=1,
+            num_gpus=0,
+        ).remote(args, pg)
 
     # calculate num_rollout from num_epoch
     num_rollout_per_epoch = None
     if args.num_rollout is None:
         logger.info("Fetching num_rollout_per_epoch from rollout manager...")
-        num_rollout_per_epoch = ray.get(rollout_manager.get_num_rollout_per_epoch.remote())
+        with st.step("driver.rollout_manager.get_num_rollout_per_epoch"):
+            num_rollout_per_epoch = ray.get(rollout_manager.get_num_rollout_per_epoch.remote())
         args.num_rollout = num_rollout_per_epoch * args.num_epoch
         assert args.num_rollout > 0
         logger.info("Computed num_rollout=%s (num_rollout_per_epoch=%s)", args.num_rollout, num_rollout_per_epoch)
 
     if args.offload_rollout:
-        ray.get(rollout_manager.offload.remote())
+        # blocks until RolloutManager.__init__ (and every sglang engine) is up
+        with st.step("driver.rollout_manager.first_offload"):
+            ray.get(rollout_manager.offload.remote())
 
     logger.info("Rollout manager created.")
     return rollout_manager, num_rollout_per_epoch

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -18,6 +18,7 @@ from miles.ray.data_conversion_hub.flow_grpo import (
 )
 from miles.rollout.base_types import call_rollout_fn
 from miles.rollout.rm_hub.core import set_manager_placement_group
+import miles.utils.startup_timing as st
 from miles.utils import tracking_utils
 from miles.utils.health_monitor import RolloutHealthMonitor
 from miles.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -48,29 +49,37 @@ class RolloutManager:
     def __init__(self, args, pg):
         configure_logger()
 
+        st.set_role("rollout_manager")
         logger.info("RolloutManager init start")
+        st.mark("rm.init_enter")
         self.args = args
         self.pg = pg
         from miles.dashboard import hooks
 
-        hooks.register_rollout_manager(args)
+        with st.step("rm.dashboard_register"):
+            hooks.register_rollout_manager(args)
         set_manager_placement_group(pg)
         if not args.train_only:
             logger.info("RolloutManager: starting router...")
-            _start_router(args)
+            with st.step("rm.start_router"):
+                _start_router(args)
         logger.info("RolloutManager: router started, init tracking...")
         # TODO make args immutable
-        init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
+        with st.step("rm.init_tracking"):
+            init_tracking(args, primary=False, router_addr=f"http://{args.sglang_router_ip}:{args.sglang_router_port}")
         logger.info("RolloutManager: init http client...")
-        init_http_client(args)
+        with st.step("rm.init_http_client"):
+            init_http_client(args)
         logger.info("RolloutManager: loading data source...")
 
-        data_source_cls = load_function(self.args.data_source_path)
-        self.data_source = data_source_cls(args)
+        with st.step("rm.load_data_source"):
+            data_source_cls = load_function(self.args.data_source_path)
+            self.data_source = data_source_cls(args)
         logger.info("RolloutManager: data source loaded, loading rollout functions...")
 
-        self.generate_rollout = load_function(self.args.rollout_function_path)
-        self.eval_generate_rollout = load_function(self.args.eval_function_path)
+        with st.step("rm.load_rollout_functions"):
+            self.generate_rollout = load_function(self.args.rollout_function_path)
+            self.eval_generate_rollout = load_function(self.args.eval_function_path)
         self.custom_reward_post_process_func = (
             load_function(self.args.custom_reward_post_process_path)
             if self.args.custom_reward_post_process_path is not None
@@ -100,7 +109,8 @@ class RolloutManager:
             num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
             num_engines = args.rollout_num_gpus // num_gpu_per_engine
             self.all_rollout_engines = [None] * num_engines
-            self.num_new_engines = init_rollout_engines(args, pg, self.all_rollout_engines)
+            with st.step("rm.init_rollout_engines", num_engines=num_engines):
+                self.num_new_engines = init_rollout_engines(args, pg, self.all_rollout_engines)
             logger.info("RolloutManager started %s rollout engines", len(self.all_rollout_engines))
         logger.info("RolloutManager: creating lock...")
         self.nodes_per_engine = max(1, args.rollout_num_gpus_per_engine // args.num_gpus_per_node)
@@ -230,13 +240,13 @@ class RolloutManager:
 
     def offload(self):
         self.health_monitoring_pause()
-        with timer("rollout_offload"):
+        with timer("rollout_offload"), st.step("rm.offload"):
             return ray.get(
                 [engine.release_memory_occupation.remote() for engine in self.rollout_engines if engine is not None]
             )
 
     def onload(self, tags: list[str] | None = None):
-        with timer("rollout_onload"):
+        with timer("rollout_onload"), st.step("rm.onload", tags=tags):
             return ray.get(
                 [
                     engine.resume_memory_occupation.remote(tags=tags)
@@ -532,14 +542,16 @@ def init_rollout_engines(args, pg, all_rollout_engines):
     if num_new_engines == 0:
         return num_new_engines
 
-    addr_and_ports = _allocate_rollout_engine_addr_and_ports_normal(
-        args=args, num_engines=num_engines, rollout_engines=rollout_engines
-    )
+    with st.step("rm.engines.allocate_ports"):
+        addr_and_ports = _allocate_rollout_engine_addr_and_ports_normal(
+            args=args, num_engines=num_engines, rollout_engines=rollout_engines
+        )
 
     # TODO: don't ray.get here to overlap train actor init with rollout engine init.
     # somehow if we don't sync here, the --debug-rollout-only mode will crash.
-    init_handles = [engine.init.remote(**(addr_and_ports[rank])) for rank, engine in rollout_engines]
-    ray.get(init_handles)
+    with st.step("rm.engines.init_wait"):
+        init_handles = [engine.init.remote(**(addr_and_ports[rank])) for rank, engine in rollout_engines]
+        ray.get(init_handles)
 
     return num_new_engines
 
@@ -637,7 +649,8 @@ def _start_router(args):
     process.daemon = True  # Set the process as a daemon
     process.start()
     # Wait 3 seconds
-    time.sleep(3)
+    with st.step("rm.router.fixed_sleep3"):
+        time.sleep(3)
     assert process.is_alive()
     logger.info(f"Router launched at {args.sglang_router_ip}:{args.sglang_router_port}")
 

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -103,6 +103,7 @@ class RolloutManager:
         logger.info("RolloutManager rollout_num_gpus=%s", self.args.rollout_num_gpus)
 
         self._engine_init_handles = []
+        self._boot_offload_done = False
         if self.args.train_only:
             self.all_rollout_engines = []
             self.num_new_engines = 0
@@ -176,11 +177,19 @@ class RolloutManager:
         self._ensure_engines_ready()
         return self.rollout_engines, self.rollout_engine_lock, self.num_new_engines
 
-    def wait_engines_offloaded(self):
-        """Colocate barrier: actor tasks run in submission order, and the driver
-        queues the first offload right after __init__, so by the time this task
-        runs the boot-time engine weights have been released."""
+    def boot_offload(self):
+        """Release the engines' boot-time weights, exactly once.
+
+        Both the driver (right after this actor is created) and the first train
+        actor reaching its GPU-allocation gate call this. Ray only orders actor
+        tasks per caller, so the two calls can arrive in either order; doing the
+        offload here — instead of relying on a previously queued offload — is
+        what makes the colocate memory invariant hold regardless.
+        """
         self._ensure_engines_ready()
+        if not self._boot_offload_done:
+            self._boot_offload_done = True
+            self.offload()
         return True
 
     def get_num_rollout_per_epoch(self):

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -13,13 +13,13 @@ import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 
+import miles.utils.startup_timing as st
 from miles.backends.sglang_diffusion_utils.sglang_diffusion_engine import SGLangDiffusionEngine
 from miles.ray.data_conversion_hub.flow_grpo import (
     expand_samples_to_train_pairs as flow_grpo_expand_samples_to_train_pairs,
 )
 from miles.rollout.base_types import call_rollout_fn
 from miles.rollout.rm_hub.core import set_manager_placement_group
-import miles.utils.startup_timing as st
 from miles.utils import tracking_utils
 from miles.utils.health_monitor import RolloutHealthMonitor
 from miles.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -176,6 +176,13 @@ class RolloutManager:
         self._ensure_engines_ready()
         return self.rollout_engines, self.rollout_engine_lock, self.num_new_engines
 
+    def wait_engines_offloaded(self):
+        """Colocate barrier: actor tasks run in submission order, and the driver
+        queues the first offload right after __init__, so by the time this task
+        runs the boot-time engine weights have been released."""
+        self._ensure_engines_ready()
+        return True
+
     def get_num_rollout_per_epoch(self):
         assert self.args.rollout_global_dataset
         return len(self.data_source.dataset) // self.args.rollout_batch_size

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import multiprocessing
+import os
 import random
 import time
 from pathlib import Path
@@ -536,6 +537,11 @@ def init_rollout_engines(args, pg, all_rollout_engines, defer_init=False):
             "SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT": "true",
             "SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION": "false",
             "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE": "false",
+            # mmap (safe_open) beats the RunAI streamer's read+clone pipeline when the
+            # checkpoint sits on local disk / warm page cache (88s -> 63s per H3 engine);
+            # the streamer's parallel prefetch still wins on cold remote FS, so an
+            # operator can re-enable it by exporting this var in the launcher env.
+            "SGLANG_USE_RUNAI_MODEL_STREAMER": os.environ.get("SGLANG_USE_RUNAI_MODEL_STREAMER", "false"),
         }
         if args.lora_ipc_weight_sync:
             # Merge in the train forward dtype, not fp32, to cut train/rollout consistency error.

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -101,6 +101,7 @@ class RolloutManager:
 
         logger.info("RolloutManager rollout_num_gpus=%s", self.args.rollout_num_gpus)
 
+        self._engine_init_handles = []
         if self.args.train_only:
             self.all_rollout_engines = []
             self.num_new_engines = 0
@@ -110,7 +111,9 @@ class RolloutManager:
             num_engines = args.rollout_num_gpus // num_gpu_per_engine
             self.all_rollout_engines = [None] * num_engines
             with st.step("rm.init_rollout_engines", num_engines=num_engines):
-                self.num_new_engines = init_rollout_engines(args, pg, self.all_rollout_engines)
+                self.num_new_engines, self._engine_init_handles = init_rollout_engines(
+                    args, pg, self.all_rollout_engines, defer_init=not args.debug_rollout_only
+                )
             logger.info("RolloutManager started %s rollout engines", len(self.all_rollout_engines))
         logger.info("RolloutManager: creating lock...")
         self.nodes_per_engine = max(1, args.rollout_num_gpus_per_engine // args.num_gpus_per_node)
@@ -160,7 +163,16 @@ class RolloutManager:
         # when doing multi-node serving, we will only send request to node-0 for each engine.
         return self.all_rollout_engines[:: self.nodes_per_engine]
 
+    def _ensure_engines_ready(self):
+        """Block until deferred engine init (see init_rollout_engines) has finished."""
+        if not self._engine_init_handles:
+            return
+        with st.step("rm.engines.init_wait"):
+            ray.get(self._engine_init_handles)
+        self._engine_init_handles = []
+
     def get_rollout_engines_and_lock(self):
+        self._ensure_engines_ready()
         return self.rollout_engines, self.rollout_engine_lock, self.num_new_engines
 
     def get_num_rollout_per_epoch(self):
@@ -170,6 +182,7 @@ class RolloutManager:
     def generate(self, rollout_id):
         from miles.dashboard import hooks
 
+        self._ensure_engines_ready()
         start_time = time.time()
         self.rollout_id = rollout_id
         hooks.set_rollout_id(rollout_id)
@@ -210,6 +223,7 @@ class RolloutManager:
         if self.args.train_only:
             # if debug train only, we don't generate evaluation data
             return
+        self._ensure_engines_ready()
         self.health_monitoring_resume()
 
         result = call_rollout_fn(self.eval_generate_rollout, self.args, rollout_id, self.data_source, evaluation=True)
@@ -240,12 +254,14 @@ class RolloutManager:
 
     def offload(self):
         self.health_monitoring_pause()
+        self._ensure_engines_ready()
         with timer("rollout_offload"), st.step("rm.offload"):
             return ray.get(
                 [engine.release_memory_occupation.remote() for engine in self.rollout_engines if engine is not None]
             )
 
     def onload(self, tags: list[str] | None = None):
+        self._ensure_engines_ready()
         with timer("rollout_onload"), st.step("rm.onload", tags=tags):
             return ray.get(
                 [
@@ -265,7 +281,7 @@ class RolloutManager:
             return self.rollout_engines, self.rollout_engine_lock, self.num_new_engines
 
         dead_indices = [i for i, engine in enumerate(self.all_rollout_engines) if engine is None]
-        self.num_new_engines = init_rollout_engines(self.args, self.pg, self.all_rollout_engines)
+        self.num_new_engines, _ = init_rollout_engines(self.args, self.pg, self.all_rollout_engines)
         logger.info(f"Recovered {self.num_new_engines} dead rollout engines")
         assert self.num_new_engines == len(dead_indices), "num_new_engines does not match dead_indices length"
         if self.args.offload_rollout and dead_indices:
@@ -480,9 +496,9 @@ class RolloutManager:
         self.train_parallel_config = config
 
 
-def init_rollout_engines(args, pg, all_rollout_engines):
+def init_rollout_engines(args, pg, all_rollout_engines, defer_init=False):
     if args.train_only:
-        return 0
+        return 0, []
 
     num_gpu_per_engine = min(args.rollout_num_gpus_per_engine, args.num_gpus_per_node)
     num_engines = args.rollout_num_gpus // num_gpu_per_engine
@@ -540,20 +556,25 @@ def init_rollout_engines(args, pg, all_rollout_engines):
     num_new_engines = len(rollout_engines)
 
     if num_new_engines == 0:
-        return num_new_engines
+        return num_new_engines, []
 
     with st.step("rm.engines.allocate_ports"):
         addr_and_ports = _allocate_rollout_engine_addr_and_ports_normal(
             args=args, num_engines=num_engines, rollout_engines=rollout_engines
         )
 
-    # TODO: don't ray.get here to overlap train actor init with rollout engine init.
-    # somehow if we don't sync here, the --debug-rollout-only mode will crash.
+    init_handles = [engine.init.remote(**(addr_and_ports[rank])) for rank, engine in rollout_engines]
+    if defer_init:
+        # Let engines boot in the background so train-actor init overlaps with
+        # engine startup; callers must sync via the returned handles before
+        # touching the engines. --debug-rollout-only keeps the old sync (it
+        # crashes without it, see the git history of this TODO).
+        return num_new_engines, init_handles
+
     with st.step("rm.engines.init_wait"):
-        init_handles = [engine.init.remote(**(addr_and_ports[rank])) for rank, engine in rollout_engines]
         ray.get(init_handles)
 
-    return num_new_engines
+    return num_new_engines, []
 
 
 def _allocate_rollout_engine_addr_and_ports_normal(*, args, num_engines, rollout_engines):

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -52,10 +52,11 @@ class TrainRayActor(RayActor):
         os.environ["CUDA_VISIBLE_DEVICES"] = str(local_gpu_id)
         os.environ["LOCAL_RANK"] = "0"
 
-    def init(self, args, role, with_ref=False):
+    def init(self, args, role, with_ref=False, rollout_manager=None):
         self.args = args
         self.role = role
         self.with_ref = with_ref
+        self.rollout_manager = rollout_manager
 
         torch.serialization.add_safe_globals([miles.utils.eval_config.EvalDatasetConfig])
         st.mark("train.init_enter")

--- a/miles/ray/train_actor.py
+++ b/miles/ray/train_actor.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 import miles.utils.eval_config
+import miles.utils.startup_timing as st
 from miles.ray.ray_actor import RayActor
 from miles.utils.distributed_utils import init_gloo_group
 from miles.utils.logging_utils import configure_logger
@@ -29,6 +30,8 @@ class TrainRayActor(RayActor):
     def __init__(self, world_size, rank, master_addr, master_port):
         configure_logger()
 
+        st.set_role(f"train_rank{rank}")
+        st.mark("train.ctor_enter")
         self._world_size = world_size
         self._rank = rank
         if master_addr:
@@ -55,9 +58,11 @@ class TrainRayActor(RayActor):
         self.with_ref = with_ref
 
         torch.serialization.add_safe_globals([miles.utils.eval_config.EvalDatasetConfig])
+        st.mark("train.init_enter")
 
         local_rank = int(os.environ.get("LOCAL_RANK", 0))
-        torch.cuda.set_device(f"cuda:{local_rank}")
+        with st.step("train.cuda_set_device"):
+            torch.cuda.set_device(f"cuda:{local_rank}")
         logger.info(
             "TrainRayActor rank=%s local_rank=%s CUDA_VISIBLE_DEVICES=%s cuda_device=%s",
             os.environ.get("RANK"),
@@ -76,12 +81,14 @@ class TrainRayActor(RayActor):
         device_id = None
         if torch.cuda.is_available() and "cuda" in str(backend):
             device_id = torch.device(f"cuda:{local_rank}")
-        dist.init_process_group(
-            backend=backend,
-            timeout=timedelta(minutes=args.distributed_timeout_minutes),
-            device_id=device_id,
-        )
-        init_gloo_group()
+        with st.step("train.init_process_group"):
+            dist.init_process_group(
+                backend=backend,
+                timeout=timedelta(minutes=args.distributed_timeout_minutes),
+                device_id=device_id,
+            )
+        with st.step("train.init_gloo_group"):
+            init_gloo_group()
 
         args.rank = dist.get_rank()
         args.world_size = dist.get_world_size()

--- a/miles/utils/startup_timing.py
+++ b/miles/utils/startup_timing.py
@@ -12,6 +12,8 @@ does not matter. This module must stay import-light (no torch/ray) because it
 anchors each process's import-start time.
 """
 
+from __future__ import annotations
+
 import os
 import time
 from contextlib import contextmanager

--- a/miles/utils/startup_timing.py
+++ b/miles/utils/startup_timing.py
@@ -1,0 +1,53 @@
+"""Wall-clock probes for the startup path (process launch -> first rollout).
+
+Every probe prints one machine-parseable line to stdout:
+
+    STARTUP_TIMING role=<role> pid=<pid> event=<name> t=<epoch> [dur=<sec>] [k=v ...]
+
+stdout of the driver and of every ray actor funnels into the ray job log, so
+``tools/parse_startup_timing.py`` can rebuild the full cross-process timeline
+from a single log file. ``print`` (not logging) keeps the probes independent of
+per-process logger configuration; timestamps are embedded so log-line ordering
+does not matter. This module must stay import-light (no torch/ray) because it
+anchors each process's import-start time.
+"""
+
+import os
+import time
+from contextlib import contextmanager
+
+# Anchor: time this module was imported in the current process. When imported
+# before the heavy imports (see train_diffusion.py), `mark("x.enter")` minus
+# this anchor measures the process's import/bootstrap cost.
+PROC_T0 = time.time()
+
+_role = "unknown"
+
+
+def set_role(role: str) -> None:
+    global _role
+    _role = role
+    mark("role_set", since_import=f"{time.time() - PROC_T0:.3f}")
+
+
+def _emit(event: str, t: float, dur: float | None = None, **extra: object) -> None:
+    parts = [f"STARTUP_TIMING role={_role}", f"pid={os.getpid()}", f"event={event}", f"t={t:.3f}"]
+    if dur is not None:
+        parts.append(f"dur={dur:.3f}")
+    parts.extend(f"{k}={v}" for k, v in extra.items())
+    print(" ".join(parts), flush=True)
+
+
+def mark(event: str, **extra: object) -> None:
+    _emit(event, time.time(), **extra)
+
+
+@contextmanager
+def step(event: str, **extra: object):
+    t0 = time.time()
+    _emit(f"{event}.begin", t0, **extra)
+    try:
+        yield
+    finally:
+        t1 = time.time()
+        _emit(f"{event}.end", t1, dur=t1 - t0, **extra)

--- a/scripts/parse_startup_timing.py
+++ b/scripts/parse_startup_timing.py
@@ -1,0 +1,88 @@
+"""Rebuild the startup timeline from a ray job log containing STARTUP_TIMING lines.
+
+Usage:
+    python3 scripts/parse_startup_timing.py /path/to/run.log
+
+Prints (1) a chronological cross-process timeline, (2) a per-step duration
+rollup grouped by role, and (3) the driver-phase breakdown with percentages.
+Only stdlib; safe to run anywhere.
+"""
+
+import re
+import sys
+from collections import defaultdict
+
+LINE_RE = re.compile(
+    r"STARTUP_TIMING role=(?P<role>\S+) pid=(?P<pid>\d+) event=(?P<event>\S+) t=(?P<t>[0-9.]+)(?: dur=(?P<dur>[0-9.]+))?(?P<extra>.*)"
+)
+
+
+def parse(path):
+    events = []
+    with open(path, errors="replace") as f:
+        for line in f:
+            m = LINE_RE.search(line)
+            if m:
+                events.append(
+                    {
+                        "role": m.group("role"),
+                        "pid": m.group("pid"),
+                        "event": m.group("event"),
+                        "t": float(m.group("t")),
+                        "dur": float(m.group("dur")) if m.group("dur") else None,
+                        "extra": m.group("extra").strip(),
+                    }
+                )
+    return sorted(events, key=lambda e: e["t"])
+
+
+def fmt_t(t, t0):
+    return f"+{t - t0:8.2f}s"
+
+
+def main(path):
+    events = parse(path)
+    if not events:
+        print("no STARTUP_TIMING lines found")
+        return
+    t0 = events[0]["t"]
+
+    print("=" * 100)
+    print("CHRONOLOGICAL TIMELINE (t=0 is the first probe)")
+    print("=" * 100)
+    for e in events:
+        dur = f"  dur={e['dur']:8.2f}s" if e["dur"] is not None else ""
+        extra = f"  {e['extra']}" if e["extra"] else ""
+        print(f"{fmt_t(e['t'], t0)}  {e['role']:<16} {e['event']:<50}{dur}{extra}")
+
+    print()
+    print("=" * 100)
+    print("PER-STEP DURATIONS (max across ranks per role-prefix, sorted desc)")
+    print("=" * 100)
+    durs = defaultdict(list)
+    for e in events:
+        if e["dur"] is not None and e["event"].endswith(".end"):
+            durs[e["event"][: -len(".end")]].append((e["role"], e["dur"]))
+    rows = []
+    for name, vals in durs.items():
+        worst_role, worst = max(vals, key=lambda rv: rv[1])
+        rows.append((worst, name, worst_role, len(vals)))
+    for worst, name, worst_role, n in sorted(rows, reverse=True):
+        print(f"{worst:9.2f}s  {name:<55} worst={worst_role}  n={n}")
+
+    print()
+    print("=" * 100)
+    print("DRIVER PHASES")
+    print("=" * 100)
+    driver = [e for e in events if e["role"] == "driver" and e["dur"] is not None]
+    total = sum(e["dur"] for e in driver if e["event"].count(".") == 2)  # driver.<phase>.end only
+    for e in driver:
+        if e["event"].count(".") == 2:
+            name = e["event"][: -len(".end")]
+            pct = 100 * e["dur"] / total if total else 0
+            print(f"{e['dur']:9.2f}s  {pct:5.1f}%  {name}")
+    print(f"{total:9.2f}s  100.0%  total (sum of driver top-level phases)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/tests/fast/rollout/test_startup_offload_ordering.py
+++ b/tests/fast/rollout/test_startup_offload_ordering.py
@@ -1,0 +1,96 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+import pytest
+
+import miles.backends.fsdp_utils.actor as actor_module
+import miles.ray.rollout as rollout_module
+
+
+def _manager(trace):
+    """A RolloutManager with only the boot-offload state, wired to a trace list.
+
+    RolloutManager is a Ray actor class; exercise the underlying class so the
+    ordering invariant can be tested without a Ray runtime.
+    """
+    cls = rollout_module.RolloutManager.__ray_metadata__.modified_class
+    manager = object.__new__(cls)
+    manager._boot_offload_done = False
+    manager._ensure_engines_ready = lambda: trace.append("engines_ready")
+    manager.offload = lambda: trace.append("offload")
+    return manager
+
+
+def test_boot_offload_releases_weights_when_the_train_gate_asks_first():
+    # Ray orders actor tasks per caller, so the train actor's gate can reach the
+    # manager before the driver's own boot_offload submission. The gate must
+    # still return with the engine weights released, or a colocated train actor
+    # would materialize its model while they are resident.
+    trace = []
+    manager = _manager(trace)
+
+    assert manager.boot_offload() is True
+    assert trace == ["engines_ready", "offload"]
+
+
+def test_boot_offload_runs_once_across_callers():
+    trace = []
+    manager = _manager(trace)
+
+    manager.boot_offload()
+    manager.boot_offload()
+
+    assert trace.count("offload") == 1
+
+
+def _train_actor(monkeypatch, calls, offload_rollout):
+    actor = object.__new__(actor_module.FSDPTrainRayActor)
+    actor._engines_evicted = False
+    actor.args = Namespace(offload_rollout=offload_rollout)
+
+    class _FakeManager:
+        class boot_offload:  # noqa: N801 — mimics a Ray method handle
+            @staticmethod
+            def remote():
+                calls.append("submitted")
+                return "ref"
+
+    actor.rollout_manager = _FakeManager()
+    monkeypatch.setattr(actor_module.ray, "get", lambda ref: calls.append(f"awaited:{ref}"))
+    return actor
+
+
+def test_train_gate_awaits_the_boot_offload(monkeypatch):
+    calls = []
+    actor = _train_actor(monkeypatch, calls, offload_rollout=True)
+
+    actor._wait_rollout_engines_evicted()
+
+    assert calls == ["submitted", "awaited:ref"]
+
+
+def test_train_gate_runs_only_before_the_first_gpu_allocation(monkeypatch):
+    # wan2.2-style recipes wrap two components; only the first one pays the gate.
+    calls = []
+    actor = _train_actor(monkeypatch, calls, offload_rollout=True)
+
+    actor._wait_rollout_engines_evicted()
+    actor._wait_rollout_engines_evicted()
+
+    assert calls.count("submitted") == 1
+
+
+@pytest.mark.parametrize("rollout_manager_missing", [True, False])
+def test_train_gate_is_skipped_when_engines_keep_their_weights(monkeypatch, rollout_manager_missing):
+    # Disaggregated placement gives rollout its own GPUs: nothing to wait for.
+    calls = []
+    actor = _train_actor(monkeypatch, calls, offload_rollout=False)
+    if rollout_manager_missing:
+        actor.rollout_manager = None
+
+    actor._wait_rollout_engines_evicted()
+
+    assert calls == []

--- a/train_diffusion.py
+++ b/train_diffusion.py
@@ -1,10 +1,9 @@
 import logging
 import sys
 
-import miles.utils.startup_timing as st  # noqa: I001  must precede the heavy imports to anchor import cost
-
 import ray
 
+import miles.utils.startup_timing as st  # anchors PROC_T0 before the heavy miles/torch/sglang import chain
 from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
 from miles.utils.arguments import parse_args
 from miles.utils.logging_utils import configure_logger

--- a/train_diffusion.py
+++ b/train_diffusion.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+import miles.utils.startup_timing as st  # noqa: I001  must precede the heavy imports to anchor import cost
+
 import ray
 
 from miles.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
@@ -15,25 +17,32 @@ def train(args):
     logger = logging.getLogger(__name__)
     # allocate the GPUs
     logger.info("train: creating placement groups")
-    pgs = create_placement_groups(args)
+    with st.step("driver.create_placement_groups"):
+        pgs = create_placement_groups(args)
     logger.info("train: placement groups ready")
-    init_tracking(args)
+    with st.step("driver.init_tracking"):
+        init_tracking(args)
 
     # create the rollout manager, with sglang engines inside.
     # need to initialize rollout manager first to calculate num_rollout
     logger.info("train: creating rollout manager")
-    rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
+    with st.step("driver.create_rollout_manager"):
+        rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
     logger.info("train: rollout manager ready")
 
     logger.info("train: creating training model")
-    actor_model = create_training_models(args, pgs, rollout_manager)
+    with st.step("driver.create_training_models"):
+        actor_model = create_training_models(args, pgs, rollout_manager)
     logger.info("train: training model ready")
 
     if args.offload_rollout:
-        ray.get(rollout_manager.onload_weights.remote())
+        with st.step("driver.onload_rollout_weights"):
+            ray.get(rollout_manager.onload_weights.remote())
 
     # always update weight first so that sglang has the loaded weights from training.
-    actor_model.update_weights()
+    with st.step("driver.first_update_weights"):
+        actor_model.update_weights()
+    st.mark("driver.startup_done")
 
     # special case for eval-only
     if args.num_rollout == 0 and args.eval_interval is not None:
@@ -88,5 +97,8 @@ def train(args):
 if __name__ == "__main__":
     # Ensure stdout is line-buffered so nohup logs show progress immediately.
     sys.stdout.reconfigure(line_buffering=True)
-    args = parse_args()
+    st.set_role("driver")
+    st.mark("driver.main_enter")
+    with st.step("driver.parse_args"):
+        args = parse_args()
     train(args)


### PR DESCRIPTION
## What

- **Overlap engine boot with train-actor init**: `RolloutManager.__init__` no longer blocks on `ray.get(engine.init...)` (the long-standing TODO at `init_rollout_engines`); the driver's first `offload` becomes fire-and-forget, and every later engine touchpoint (`offload`/`onload`/`generate`/`eval`/`get_rollout_engines_and_lock`) syncs through `_ensure_engines_ready()`. `--debug-rollout-only` keeps the old synchronous path. **VRAM safety under colocate**: only the CPU-side part of train init overlaps engine boot — the first large train-side GPU allocation (FSDP wrap + rank-0 broadcast) gates on `boot_offload`, which releases the engines' boot-time weights itself, exactly once. Ray only orders actor tasks per caller, so the gate must not assume the driver's own submission ran first; making the release idempotent and self-triggering is what keeps rollout and training residency sequential for any model size. The gate is skipped when rollout keeps its weights resident (disaggregated placement).
- **Default sglang-d engines to mmap weight loading** (`SGLANG_USE_RUNAI_MODEL_STREAMER=false` in the engine env): safetensors `safe_open` replaces the RunAI streamer's read-into-private-buffer + per-tensor clone pipeline. Operators can re-enable the streamer by exporting the var in the launcher env (still the right choice for cold remote FS).
- **Startup timing probes**: every process on the startup path (driver, RolloutManager, each engine actor, each train rank) emits parseable `STARTUP_TIMING` lines; `scripts/parse_startup_timing.py` rebuilds a full cross-process timeline from a single ray job log.

## Why

Startup (launch → first `update_weights` done) took 4–8+ min per run. Probing showed the two dominant serial blocks: engine boot (~130s: subprocess re-imports + weight load + post-boot offload) ran strictly *before* train-actor init (~62s) due to one `ray.get`, and the streamer capped weight reads at ~2.4 GiB/s even from a warm page cache (it is copy-pipeline-bound, not disk-bound, on local checkpoints).

## Validation

2×2 ablation on 4× H200 (single node, MiniMax-H3 t2va GRPO recipe: tp=2 → 2 engines, 4 colocated train ranks, LoRA-IPC, weights on local /scratch, warm page cache). Two independent runs per cell, spread ≤ ±2s; metric is driver `main` → `startup_done` (first weight sync complete).

| variant | total startup | vs base |
|---|---|---|
| C0 base | 242.9s | — |
| C1 mmap only | 216.0s | **−26.9s (−11%)** |
| C2 overlap only | 188.2s | **−54.7s (−23%)** |
| C3 both | 153.0s | **−89.9s (−37%)** |

Mechanism checks: with mmap, per-engine health-wait drops 88s → 63s (DiT 61.7 GiB load 37s → 14s); independently reproduced on a second machine (2 engines, 96s → 62s). With overlap, the driver's `create_rollout_manager` block drops 145s → 0.1s and train init hides entirely inside engine boot. Effects compose slightly super-additively. The ablation numbers above were measured *before* the VRAM gate (engine weights coexisted with the broadcast peak at ~94% VRAM on H3 — fits, but only by luck; larger fp32 configs would OOM, hence the gate). With the gate, the GPU-heavy ~45s of train init serializes after engine offload, so the overlap saving shrinks to an estimated ~25s warm (more on cold cache, where the overlapped CPU-side checkpoint read dominates); gated re-measurement pending.

Caveats found during validation:
- Current safetensors `get_tensor` copies on CPU (measured Rss≈Pss across engines), so mmap gives no resident-RAM dedup — the read side shares the page cache and peak RAM drops ~53 GB (no streamer buffers/clones), but per-engine resident copies remain.

## Files

- `miles/ray/rollout.py` — deferred engine init + `_ensure_engines_ready()`; mmap env default; probes
- `miles/ray/placement_group.py` — fire-and-forget first offload; probes
- `miles/ray/train_actor.py`, `miles/backends/fsdp_utils/actor.py` — probes (NCCL init, per-component load/FSDP/broadcast, first weight sync)
- `miles/backends/sglang_diffusion_utils/sglang_diffusion_engine.py` — probes (spawn, health wait, router registration)
- `train_diffusion.py` — driver phase probes
- `miles/utils/startup_timing.py` — probe module (import-light, print-based, cross-process)
- `scripts/parse_startup_timing.py` — log → timeline/rollup report

## Remaining work (why draft)

- Re-run the ablation with the VRAM gate to confirm the retained saving
- Confirm on hardware that a colocate startup never has engine weights and the FSDP broadcast peak resident together (the new test pins the call ordering; peak memory itself still needs a GPU run)
- Run a full multi-rollout training to exercise `generate`/fault-tolerance/`recover_rollout_engines` under deferred init.
- Decide whether the mmap default should auto-detect local vs remote checkpoint paths instead of an env override.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour — `tests/fast/rollout/test_startup_offload_ordering.py` (stage-a-cpu) covers the colocate ordering invariant; plus 8 instrumented end-to-end startup runs + 2 corroboration runs on H200
- [ ] `pytest -x` is green — **not run locally**: the dev machine has no ray/torch/sglang (all fast tests in this package import them). The new test's CI registration parses, its logic was verified against an equivalent replica, and CI runs the real thing.
- [x] If launch flags changed, `python3 train.py --help` still parses — no CLI flags changed; arg parsing exercised by all 8 validation runs
- [x] If a public flag was added, it appears in the CLI reference docs — n/a, no new flags
- [x] If an example was added, it has a real walkthrough — n/a
