### PR TITLE
perf(rollout): request only the SDE-window trajectory latents

### DIFF
--- a/miles/ray/data_conversion_hub/flow_grpo.py
+++ b/miles/ray/data_conversion_hub/flow_grpo.py
@@ -100,22 +100,40 @@ def _build_per_timestep_features(
     rollout_log_probs: torch.Tensor,
     device: torch.device,
 ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
-    """Fields with one row per selected denoising step."""
-    all_latents = traj.latents.to(device, dtype=torch.float32)
-    latents = all_latents[:-1]
-    next_latents = all_latents[1:]
-    timesteps = traj.timesteps.to(device, dtype=torch.float32)
-    # The terminal next timestep is zero.
-    next_timesteps = torch.cat([timesteps[1:], timesteps.new_zeros(1)])
+    """Fields with one row per selected denoising step.
 
+    ``traj.latents`` is either the full 0..T trajectory or the filtered window
+    the rollout requested; ``latent_step_indices`` maps original step numbers
+    to array positions, so pairing never assumes the array is contiguous.
+    Timesteps are the full [T+1] schedule (terminal included) and log_probs
+    the full [T]; both are indexed by original step number.
+    """
     sde_idx = (sample.train_metadata or {}).get("sde_step_indices")
     assert sde_idx is not None, "SDE step indices are required for training"
+    # Keep producer dtype: the train actor casts on consumption (loss_hub _stack_pair_field).
+    all_latents = traj.latents.to(device)
+    timesteps = traj.timesteps.to(device)
+
+    if traj.latent_step_indices is None:
+        position = {step: step for step in range(int(all_latents.shape[0]))}
+    else:
+        position = {int(step): pos for pos, step in enumerate(traj.latent_step_indices.tolist())}
+    needed = sorted({int(s) for s in sde_idx} | {int(s) + 1 for s in sde_idx})
+    missing = [step for step in needed if step not in position]
+    if missing:
+        raise ValueError(
+            f"trajectory lacks latents for steps {missing} (have {sorted(position)}); "
+            "the rollout's return_step_indices and the SDE window disagree"
+        )
+
     idx = torch.as_tensor(sde_idx, dtype=torch.long)
+    latent_pos = torch.as_tensor([position[int(s)] for s in sde_idx], dtype=torch.long)
+    next_pos = torch.as_tensor([position[int(s) + 1] for s in sde_idx], dtype=torch.long)
     return {
-        "latent": latents[idx],
-        "next_latent": next_latents[idx],
+        "latent": all_latents[latent_pos],
+        "next_latent": all_latents[next_pos],
         "timestep": timesteps[idx],
-        "next_timestep": next_timesteps[idx],
+        "next_timestep": timesteps[idx + 1],
         "log_prob_old": rollout_log_probs[idx],
     }, idx
 

--- a/miles/ray/data_conversion_hub/flow_grpo.py
+++ b/miles/ray/data_conversion_hub/flow_grpo.py
@@ -24,7 +24,6 @@ def _expand_samples_to_train_pairs(
     raw_rewards: list[float],
 ) -> tuple[list[dict[str, Any]], dict[str, torch.Tensor]]:
     """Flat train pairs in sample-major order (all pairs for sample 0, then sample 1, ...)."""
-    device = torch.device("cpu")
     train_data: list[dict[str, Any]] = []
     scheduler_meta = scheduler_meta_from_samples(samples)
 
@@ -40,7 +39,6 @@ def _expand_samples_to_train_pairs(
             sample,
             traj=traj,
             rollout_log_probs=rollout_log_probs,
-            device=device,
         )
         pair_debug_steps = None
         if sample.rollout_debug_tensors is not None:
@@ -98,7 +96,6 @@ def _build_per_timestep_features(
     *,
     traj,
     rollout_log_probs: torch.Tensor,
-    device: torch.device,
 ) -> tuple[dict[str, torch.Tensor], torch.Tensor]:
     """Fields with one row per selected denoising step.
 
@@ -111,8 +108,8 @@ def _build_per_timestep_features(
     sde_idx = (sample.train_metadata or {}).get("sde_step_indices")
     assert sde_idx is not None, "SDE step indices are required for training"
     # Keep producer dtype: the train actor casts on consumption (loss_hub _stack_pair_field).
-    all_latents = traj.latents.to(device)
-    timesteps = traj.timesteps.to(device)
+    all_latents = traj.latents
+    timesteps = traj.timesteps
 
     if traj.latent_step_indices is None:
         position = {step: step for step in range(int(all_latents.shape[0]))}

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -181,9 +181,10 @@ async def generate_microgroup(
             int(sampling_params["num_inference_steps"]),
             int(sampling_params["seed"]),
         )
-        # Keep return_step_indices None: sgl-d only filters trajectory latents by it, not
-        # log_probs, and the trainer needs the full trajectory for (x_i, x_{i+1}) pairs.
-        assert return_indices is None, "rollout_return_step_indices must be None for now"
+        # The trainer consumes (x_i, x_{i+1}, log_prob_i) per SDE step, so the
+        # engine only needs the window latents plus their boundary: S U (S+1).
+        if return_indices is None and sde_indices is not None:
+            return_indices = sorted({int(i) for i in sde_indices} | {int(i) + 1 for i in sde_indices})
         sampling_params["rollout_sde_step_indices"] = sde_indices
         sampling_params["rollout_return_step_indices"] = return_indices
     else:

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -166,6 +166,7 @@ def _parse_dit_trajectory(
         latents=deserialize_func(data.get("latents")),
         timesteps=deserialize_func(data.get("timesteps")),
         sigmas=deserialize_func(data.get("sigmas")),
+        latent_step_indices=deserialize_func(data.get("latent_step_indices")),
     )
 
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -54,10 +54,9 @@ class DenoisingEnv:
 class DiTTrajectory:
     latents: torch.Tensor | None = None
     timesteps: torch.Tensor | None = None
-    # Rollout's scheduler.sigmas snapshot [T+1] (post-shift, includes terminal 0).
-    # Required for training — converters raise if missing; recomputing from
-    # `timesteps / num_train_timesteps` drifts 1-2 ULPs (~3e-5 log_prob diff).
     sigmas: torch.Tensor | None = None
+    # [K] original step index of each latent; None means the full 0..T trajectory.
+    latent_step_indices: torch.Tensor | None = None
 
 
 @dataclass

--- a/tests/fast/rollout/test_traj_window_convert.py
+++ b/tests/fast/rollout/test_traj_window_convert.py
@@ -1,0 +1,94 @@
+"""Windowed trajectory -> train pairs: provenance mapping in the converter.
+
+Mental model (10-step rollout, SDE window S=[2,3]):
+
+    engine ships latents for L = S U (S+1) = [2,3,4]     (was: all 11)
+           echoes latent_step_indices=[2,3,4]
+           timesteps / log_probs stay full-length
+    converter pairs latent[s] with latent[s+1] BY PROVENANCE, never by
+           array adjacency
+
+Covered: the windowed trajectory yields bitwise the same train-pair tensors as
+the full trajectory (1), full trajectories without provenance keep the legacy
+behaviour (2), a missing window latent raises instead of mispairing (3), and a
+non-contiguous kept set still pairs correctly (4).
+"""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="stage-a-cpu", labels=[])
+
+import pytest
+import torch
+
+from miles.ray.data_conversion_hub.flow_grpo import _build_per_timestep_features
+from miles.utils.types import DiTTrajectory, Sample
+
+T = 10
+SDE = [2, 3]
+
+
+def _full_traj() -> DiTTrajectory:
+    g = torch.Generator().manual_seed(7)
+    return DiTTrajectory(
+        latents=torch.randn(T + 1, 4, 6, generator=g),
+        timesteps=torch.linspace(1000.0, 0.0, T + 1),
+        sigmas=torch.linspace(1.0, 0.0, T + 1),
+    )
+
+
+def _windowed(traj: DiTTrajectory, kept: list[int]) -> DiTTrajectory:
+    return DiTTrajectory(
+        latents=traj.latents[kept],
+        timesteps=traj.timesteps,
+        sigmas=traj.sigmas,
+        latent_step_indices=torch.tensor(kept, dtype=torch.long),
+    )
+
+
+def _sample(sde=SDE) -> Sample:
+    return Sample(index=0, prompt="p", train_metadata={"sde_step_indices": list(sde)})
+
+
+def _build(traj, sde=SDE):
+    log_probs = torch.linspace(-1.0, -2.0, T)
+    return _build_per_timestep_features(
+        _sample(sde), traj=traj, rollout_log_probs=log_probs, device=torch.device("cpu")
+    )
+
+
+def test_windowed_matches_full_bitwise():
+    full = _full_traj()
+    feats_full, idx_full = _build(full)
+    feats_win, idx_win = _build(_windowed(full, [2, 3, 4]))
+    assert torch.equal(idx_full, idx_win)
+    assert feats_full.keys() == feats_win.keys()
+    for key in feats_full:
+        assert torch.equal(feats_full[key], feats_win[key]), key
+
+
+def test_full_trajectory_without_provenance_is_legacy():
+    feats, idx = _build(_full_traj())
+    assert idx.tolist() == SDE
+    full = _full_traj()
+    assert torch.equal(feats["latent"], full.latents[SDE])
+    assert torch.equal(feats["next_latent"], full.latents[[s + 1 for s in SDE]])
+    assert torch.equal(feats["log_prob_old"], torch.linspace(-1.0, -2.0, T)[SDE])
+
+
+def test_terminal_step_next_timestep_is_zero():
+    feats, _ = _build(_full_traj(), sde=[T - 1])
+    assert feats["next_timestep"].item() == 0.0
+
+
+def test_missing_window_latent_raises():
+    with pytest.raises(ValueError, match="lacks latents"):
+        _build(_windowed(_full_traj(), [2, 3]))  # boundary latent 4 missing
+
+
+def test_non_contiguous_kept_set_pairs_by_provenance():
+    full = _full_traj()
+    win = _windowed(full, [2, 3, 4, 7, 8])
+    feats, _ = _build(win, sde=[2, 3, 7])
+    assert torch.equal(feats["latent"], full.latents[[2, 3, 7]])
+    assert torch.equal(feats["next_latent"], full.latents[[3, 4, 8]])

--- a/tests/fast/rollout/test_traj_window_convert.py
+++ b/tests/fast/rollout/test_traj_window_convert.py
@@ -52,9 +52,7 @@ def _sample(sde=SDE) -> Sample:
 
 def _build(traj, sde=SDE):
     log_probs = torch.linspace(-1.0, -2.0, T)
-    return _build_per_timestep_features(
-        _sample(sde), traj=traj, rollout_log_probs=log_probs, device=torch.device("cpu")
-    )
+    return _build_per_timestep_features(_sample(sde), traj=traj, rollout_log_probs=log_probs)
 
 
 def test_windowed_matches_full_bitwise():

--- a/tests/fast/utils/test_grouping_parity.py
+++ b/tests/fast/utils/test_grouping_parity.py
@@ -110,7 +110,7 @@ def _mk_sample(index: int, num_steps: int, sde_idx, chan: int = 4, with_debug=Tr
     # fixed seed (not the per-sample one) -- the converter now verifies this; a per-sample
     # seed here would (correctly) raise.
     sigmas = torch.randn(num_steps + 1, generator=torch.Generator().manual_seed(7)) if with_sigmas else None
-    traj = SimpleNamespace(latents=latents, timesteps=timesteps, sigmas=sigmas)
+    traj = SimpleNamespace(latents=latents, timesteps=timesteps, sigmas=sigmas, latent_step_indices=None)
     rollout_log_probs = torch.randn(num_steps, generator=g)  # (T,)
     dbg = None
     if with_debug:


### PR DESCRIPTION
## What

- The rollout now asks the engine for only the SDE-window trajectory latents (`rollout_return_step_indices = S ∪ (S+1)`) instead of the full 0..T trajectory, and the converter pairs `(x_i, x_{i+1})` by the engine-echoed `latent_step_indices` provenance instead of assuming a contiguous array.
- Trajectory schedule contract tightened with the sglang side: `timesteps` is always the full `[T+1]` schedule (terminal included, aligned with `sigmas`), `log_probs` the full `[T]`; only latents — the payload weight — are filtered. `next_timestep` becomes a plain `timesteps[s+1]` lookup.
- A follow-up commit drops the constant-cpu `device` parameter threaded through train-pair building.

## Why

A 10-step H3 rollout with a 2-step SDE window shipped 11 fp32 latents per sample; training consumes 3 (`x_s, x_{s+1}` per window step). With the video already uint8-compressed, these latents dominate the response body — the filter cuts trajectory bytes ~3.6x with bitwise-identical train pairs. Provenance mapping (instead of positional tricks) also keeps non-contiguous SDE index sets correct by construction, and any request/response disagreement raises instead of silently mispairing.

Converter dtype note: the fp32 cast moved out of the converter entirely — pairs cross plasma in producer dtype and the train actor casts on consumption (`loss_hub._stack_pair_field`), so a future compressed-latent transport only needs an engine-side change.

## Validation

- `pytest tests/fast`: 239 passed; new `tests/fast/rollout/test_traj_window_convert.py` (stage-a-cpu) proves the windowed trajectory yields bitwise the same train-pair tensors as the full one, legacy full-trajectory behaviour is unchanged, a missing window latent raises, and a non-contiguous kept set still pairs correctly.
- Engine-side filter behaviour verified against the real sglang code (H3 collector and generic mixin) with synthetic batches: exact index keep, full-length timesteps/log_probs, full mode unchanged.
- Not yet run: a live A/B on the 34-GPU cluster (windowed vs full first step; response-size and `log_prob_mean_abs_diff` checks) — reason for draft status.

Coverage note: cosmos3 collects its trajectory through the same shared mixin hook and uses the same non-contiguous candidate sets as ltx23/wan22, so the filtering applies to it identically — but it has no e2e today, so that equivalence is by shared code path, not measurement. A separate PR adds cosmos3 coverage.

## Files

- `miles/rollout/sglang_diffusion_rollout.py` — request `S ∪ (S+1)`; the `return_step_indices must be None` assert retires.
- `miles/ray/data_conversion_hub/flow_grpo.py` — provenance-mapped pairing; producer-dtype passthrough; `timesteps[s+1]` lookup.
- `miles/utils/types.py`, `miles/utils/diffusion_rollout_response.py` — `latent_step_indices` field and parsing.
- `tests/fast/rollout/test_traj_window_convert.py` — new; `tests/fast/utils/test_grouping_parity.py` — fake gains the new field.

## Checklist

- [x] `pre-commit run --all-files` passes
- [x] Added/updated tests for new behaviour — `test_traj_window_convert.py`, registered to stage-a-cpu
- [x] `pytest -x` is green — tests/fast, 239 passed
- [ ] If launch flags changed, `python3 train_diffusion.py --help` still parses — **no flag changes**
- [ ] If a public flag was added, it appears in the CLI reference docs — n/a
- [ ] If an example was added, it has a real walkthrough — n/a


ci-sglang-repo: Rockdu/sglang
ci-sglang-pr: rollout-traj-window

