### PR TITLE
docs: sync recipe verification levels with CI coverage

### DIFF
--- a/docs/models/cosmos/cosmos3.md
+++ b/docs/models/cosmos/cosmos3.md
@@ -56,7 +56,7 @@ From `miles/backends/fsdp_utils/configs/cosmos3.py`:
 Canonical recipe: `scripts/run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` — train, rollout,
 and PickScore colocated on 4 GPUs; T2I (832×480, 1 frame).
 
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 export SGLANG_DISABLE_COSMOS3_GUARDRAILS=1   # RL scores raw samples; skip serving-side guardrail models

--- a/docs/models/h3/h3.md
+++ b/docs/models/h3/h3.md
@@ -47,7 +47,7 @@ python3 scripts/run_diffusion_sft_h3_t2va.py   # downloads the default dataset o
 Canonical recipe: `scripts/run_diffusion_grpo_h3_t2va_2gpu.py` — train, rollout, and PickScore
 colocated on 2 GPUs; 16:9 / 4 s (with `short_edge=768` the canvas is 1344×768 / 107 frames).
 
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 # alignment diagnostic: freeze the weights, so log_prob_mean_abs_diff measures

--- a/docs/models/qwen-image/qwen-image.md
+++ b/docs/models/qwen-image/qwen-image.md
@@ -48,7 +48,7 @@ Registered in `miles/backends/fsdp_utils/configs/qwen_image.py`:
 Canonical recipe: `scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` — 4 colocate
 GPUs + 1 PickScore GPU, 512×512, PickScore reward.
 
-**Status:** [📈 V — Verified](../../user-guide/recipe-verification.md#v)
+**Status:** [🛡️ FG — Fully gated](../../user-guide/recipe-verification.md#fg)
 
 ```bash
 python3 scripts/run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py

--- a/docs/user-guide/recipe-verification.md
+++ b/docs/user-guide/recipe-verification.md
@@ -38,15 +38,16 @@ count as verification.
   - `run_diffusion_grpo_sd3_ocr_sglang.py` — SD3.5 Flow-GRPO + OCR.
   - `run_diffusion_grpo_ltx23_sglang.py` — LTX-2.3 Flow-GRPO + PickScore.
   - `run_diffusion_nft_sd3_pickscore.py` — SD3.5 DiffusionNFT + PickScore.
+  - `run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` — Cosmos3-Nano
+    Flow-GRPO + PickScore.
+  - `run_diffusion_grpo_h3_t2va_2gpu.py` — MiniMax H3 t2va Flow-GRPO + PickScore.
+  - `run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` — Qwen-Image
+    Flow-GRPO + PickScore.
 - **🧩 PG**
   - `run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py` — Wan2.2 17-GPU
     full-finetune Flow-GRPO + PickScore.
 - **📈 V**
-  - `run_diffusion_grpo_pickscore_5gpu_flowgrpo_aligned.py` — Qwen-Image
-    Flow-GRPO + PickScore.
-  - `run_diffusion_grpo_cosmos3_pickscore_t2i_4gpu.py` — Cosmos3-Nano
-    Flow-GRPO + PickScore.
-  - `run_diffusion_grpo_h3_t2va_2gpu.py` — MiniMax H3 Flow-GRPO + PickScore.
+  - `run_diffusion_sft_h3_t2va.py` — MiniMax H3 8-GPU LoRA SFT.
 - **○ NV**
   - `run_diffusion_grpo_wan22_pickscore_5gpu.py` — Wan2.2 5-GPU LoRA
     Flow-GRPO + PickScore.


### PR DESCRIPTION
Three recipes carry a deterministic e2e that runs the canonical launcher itself against a committed standard, but were still labelled Verified:

- Cosmos3-Nano t2i and MiniMax H3 t2va gained one today (#219, #217).
- Qwen-Image has had one since #108; the level index was edited afterwards without picking it up.

All three already had the training curve the V level attests, so the e2e is the remaining FG criterion. The nightly cron passes --match-all-labels, so the label-gated e2e runs meet 'at least nightly'.

Also lists run_diffusion_sft_h3_t2va.py under V, where its model page already places it -- the recipe was missing from the level index.