### PR TITLE
ci: default the sglang ref to the branch the image is built from

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -8,8 +8,8 @@ name: CI Job
 #   * PR-body magic for `ci-megatron-pr:` removed for the same reason.
 #   * sglang checkout/install preserved (miles-D imports
 #     sglang.multimodal_gen.runtime.* and sglang.srt.*), fetched from
-#     sgl-project/sglang main now that the diffusion RPCs have landed
-#     upstream (`ci-sglang-repo:` / `ci-sglang-pr:` PR-body overrides).
+#     the branch the image is built from (env: DEFAULT_SGLANG_REF), with
+#     `ci-sglang-repo:` / `ci-sglang-pr:` PR-body overrides.
 #   * GPU `run:` job uses the radixark/miles-diffusion image (not
 #     radixark/miles) and the h200 runner fleet on the dedicated CI node
 #     (labels: h200 + 3gpu/5gpu).
@@ -42,6 +42,12 @@ on:
         required: false
         default: false
         description: 'Upload tests/ci/fixtures/e2e_standards/ as a build artifact for the author to review and commit (record-e2e-standards.yml)'
+
+env:
+  # Unless you know the consequences, change this together with docker/Dockerfile's
+  # SGLANG_DIFFUSION_BRANCH.
+  DEFAULT_SGLANG_REF: sglang-miles-h3
+  DEFAULT_SGLANG_REPO: sgl-project/sglang
 
 jobs:
   run:
@@ -136,8 +142,8 @@ jobs:
             PR_SGLANG_REPO=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-repo:\s+\K\S+' || true)
             [ -z "$SGLANG_REPO" ] && [ -n "$PR_SGLANG_REPO" ] && SGLANG_REPO="$PR_SGLANG_REPO"
           fi
-          [ -z "$SGLANG_PR" ] && SGLANG_PR="main"
-          [ -z "$SGLANG_REPO" ] && SGLANG_REPO="sgl-project/sglang"
+          [ -z "$SGLANG_PR" ] && SGLANG_PR="$DEFAULT_SGLANG_REF"
+          [ -z "$SGLANG_REPO" ] && SGLANG_REPO="$DEFAULT_SGLANG_REPO"
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then
@@ -242,8 +248,8 @@ jobs:
             PR_SGLANG_REPO=$(echo "$PR_BODY" | grep -m1 -oP '^ci-sglang-repo:\s+\K\S+' || true)
             [ -z "$SGLANG_REPO" ] && [ -n "$PR_SGLANG_REPO" ] && SGLANG_REPO="$PR_SGLANG_REPO"
           fi
-          [ -z "$SGLANG_PR" ] && SGLANG_PR="main"
-          [ -z "$SGLANG_REPO" ] && SGLANG_REPO="sgl-project/sglang"
+          [ -z "$SGLANG_PR" ] && SGLANG_PR="$DEFAULT_SGLANG_REF"
+          [ -z "$SGLANG_REPO" ] && SGLANG_REPO="$DEFAULT_SGLANG_REPO"
           resolve_fetch_ref() {
             local ref="$1"
             if [[ "$ref" =~ ^#([0-9]+)$ ]]; then

--- a/miles/ray/data_conversion_hub/flow_grpo.py
+++ b/miles/ray/data_conversion_hub/flow_grpo.py
@@ -118,9 +118,10 @@ def _build_per_timestep_features(
     needed = sorted({int(s) for s in sde_idx} | {int(s) + 1 for s in sde_idx})
     missing = [step for step in needed if step not in position]
     if missing:
+        provenance = "echoed" if traj.latent_step_indices is not None else "absent (engine must echo it)"
         raise ValueError(
             f"trajectory lacks latents for steps {missing} (have {sorted(position)}); "
-            "the rollout's return_step_indices and the SDE window disagree"
+            f"latent_step_indices {provenance}"
         )
 
     idx = torch.as_tensor(sde_idx, dtype=torch.long)


### PR DESCRIPTION
## What

- CI defaulted the sglang ref to `main` when a PR body carried no `ci-sglang-pr:` pin, so it reinstalled `main` over the image's `sglang-miles-h3` engine. The default now points at the branch the image is built from, hoisted into a workflow-level `env` (both jobs had their own copy).
- The trajectory-window error now says whether `latent_step_indices` came back, so an engine/branch mismatch reads as one instead of looking like a bad index calculation.

## Why

Nightly on `main` broke this way: `main`'s engine filters trajectory latents but does not echo their step indices, so the converter read positions as step numbers — `trajectory lacks latents for steps [2] (have [0, 1])`. PR runs were green only because their bodies pinned the H3 branch.

## Validation

`pytest tests/fast`: 239 passed. The failing nightly is [run 33322653422](https://github.com/radixark/miles_diffusion/actions/runs/33322653422); this PR's own CI exercises the new default (no `ci-sglang-pr:` line below).
