### PR TITLE
perf(nft): full-trajectory opt-out and an x0-only NFT request

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -90,21 +90,26 @@ async def custom_generate(
 
 ### `--diffusion-step-strategy-path`
 
-Select which denoising steps contribute SDE log-probs / train pairs. Stock
-implementations live in `miles/rollout/step_strategy_hub.py`.
+Select which denoising steps contribute SDE log-probs / train pairs, and which
+latents the engine ships back for the trainer. Stock implementations live in
+`miles/rollout/step_strategy_hub.py`.
 
 ```python
 def strategy(args, sample, num_steps, seed) -> tuple[list[int] | None, list[int] | None]:
-    # returns (sde_step_indices, return_step_indices); return must be None today
+    # returns (sde_step_indices, return_step_indices)
+    # sde None = no SDE steps (pure ODE rollout)
+    # return None = the engine returns every step's latent
     ...
 ```
 
+`--rollout-return-full-trajectory` overrides `return_step_indices` back to all
+steps for debugging / A-B runs.
+
 | Stock | Behavior |
 |---|---|
-| `sde_window` | Random contiguous window (`--diffusion-num-sde-steps`, `--diffusion-sde-window-range`) |
-| `epoch_global_random_choice` | Per-epoch subset of `--diffusion-sde-candidate-steps` |
-
-Details: [SDE step backend](../advanced/sde-backend.md).
+| `sde_window` | Random contiguous window (`--diffusion-num-sde-steps`, `--diffusion-sde-window-range`); returns all latents its steps touch |
+| `epoch_global_random_choice` | Per-epoch subset of `--diffusion-sde-candidate-steps`; returns all latents its steps touch |
+| `ode_and_return_last` | No SDE steps, return only the final clean `x0` (DiffusionNFT) |
 
 ***
 

--- a/miles/ray/data_conversion_hub/nft.py
+++ b/miles/ray/data_conversion_hub/nft.py
@@ -18,14 +18,13 @@ def _clean_x0_from_sample(sample: Sample) -> torch.Tensor:
             "NFT needs the final clean latent x0 from rollout"
         )
     if traj.latent_step_indices is not None:
-        # x0 is the last latent only while the trajectory is unfiltered; a windowed
-        # one would hand back some x_t instead, with nothing to signal it.
+        # NFT asks the rollout for the final step alone, so the last latent must be x0.
         final_step = int(traj.latent_step_indices[-1])
         num_steps = int(traj.sigmas.shape[0]) - 1 if traj.sigmas is not None else final_step
         if final_step != num_steps:
             raise ValueError(
                 f"sample {sample.index} trajectory ends at step {final_step}, not the final "
-                f"step {num_steps}; NFT needs x0, so run with --rollout-return-full-trajectory"
+                f"step {num_steps}; NFT needs x0"
             )
     return traj.latents[-1].detach().cpu().float()
 

--- a/miles/ray/data_conversion_hub/nft.py
+++ b/miles/ray/data_conversion_hub/nft.py
@@ -17,6 +17,16 @@ def _clean_x0_from_sample(sample: Sample) -> torch.Tensor:
             f"sample {sample.index} missing dit_trajectory.latents; "
             "NFT needs the final clean latent x0 from rollout"
         )
+    if traj.latent_step_indices is not None:
+        # x0 is the last latent only while the trajectory is unfiltered; a windowed
+        # one would hand back some x_t instead, with nothing to signal it.
+        final_step = int(traj.latent_step_indices[-1])
+        num_steps = int(traj.sigmas.shape[0]) - 1 if traj.sigmas is not None else final_step
+        if final_step != num_steps:
+            raise ValueError(
+                f"sample {sample.index} trajectory ends at step {final_step}, not the final "
+                f"step {num_steps}; NFT needs x0, so run with --rollout-return-full-trajectory"
+            )
     return traj.latents[-1].detach().cpu().float()
 
 

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -189,6 +189,9 @@ async def generate_microgroup(
         sampling_params["rollout_return_step_indices"] = return_indices
     else:
         sde_indices = None
+        if args.loss_type == "nft" and not args.rollout_return_full_trajectory:
+            # NFT trains on the clean x0 alone, so the rest of the trajectory is dead weight.
+            sampling_params["rollout_return_step_indices"] = [int(sampling_params["num_inference_steps"])]
 
     payload = build_rollout_generate_payload(
         sampling_params, microgroup[0].prompt, num_outputs_per_prompt=len(microgroup)

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -183,7 +183,7 @@ async def generate_microgroup(
         )
         # The trainer consumes (x_i, x_{i+1}, log_prob_i) per SDE step, so the
         # engine only needs the window latents plus their boundary: S U (S+1).
-        if return_indices is None and sde_indices is not None:
+        if return_indices is None and sde_indices is not None and not args.rollout_return_full_trajectory:
             return_indices = sorted({int(i) for i in sde_indices} | {int(i) + 1 for i in sde_indices})
         sampling_params["rollout_sde_step_indices"] = sde_indices
         sampling_params["rollout_return_step_indices"] = return_indices

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -181,17 +181,12 @@ async def generate_microgroup(
             int(sampling_params["num_inference_steps"]),
             int(sampling_params["seed"]),
         )
-        # The trainer consumes (x_i, x_{i+1}, log_prob_i) per SDE step, so the
-        # engine only needs the window latents plus their boundary: S U (S+1).
-        if return_indices is None and sde_indices is not None and not args.rollout_return_full_trajectory:
-            return_indices = sorted({int(i) for i in sde_indices} | {int(i) + 1 for i in sde_indices})
+        if args.rollout_return_full_trajectory:
+            return_indices = None  # None asks the engine for every step
         sampling_params["rollout_sde_step_indices"] = sde_indices
         sampling_params["rollout_return_step_indices"] = return_indices
     else:
         sde_indices = None
-        if args.loss_type == "nft" and not args.rollout_return_full_trajectory:
-            # NFT trains on the clean x0 alone, so the rest of the trajectory is dead weight.
-            sampling_params["rollout_return_step_indices"] = [int(sampling_params["num_inference_steps"])]
 
     payload = build_rollout_generate_payload(
         sampling_params, microgroup[0].prompt, num_outputs_per_prompt=len(microgroup)

--- a/miles/rollout/step_strategy_hub.py
+++ b/miles/rollout/step_strategy_hub.py
@@ -1,8 +1,11 @@
 """Library of functions that fill ``rollout_sde_step_indices`` /
 ``rollout_return_step_indices`` for one sglang-diffusion rollout request.
 
-Each function has signature ``(args, sample, num_steps, seed) -> (sde, ret)``
-where ``sde`` and ``ret`` are ``list[int] | None`` (``None`` = all steps).
+Each function has signature ``(args, sample, num_steps, seed) -> (sde, ret)``,
+both ``list[int] | None``. A strategy owns both halves of the request:
+``sde`` picks the steps sampled as SDE (``None`` = no SDE steps, a pure ODE
+rollout), and ``ret`` picks the trajectory latents the engine ships back for
+the trainer (``None`` = all steps).
 Point ``--diffusion-step-strategy-path`` at any such function.
 """
 
@@ -16,14 +19,17 @@ import torch
 from miles.utils.types import Sample
 
 
+def _sde_steps_to_latent_indices(indices: list[int]) -> list[int]:
+    # The GRPO trainer consumes (x_i, x_{i+1}, log_prob_i) per SDE step, so the
+    # engine must return every latent those steps touch: S U (S+1).
+    return sorted({int(i) for i in indices} | {int(i) + 1 for i in indices})
+
+
 def sde_window(
     args: Namespace, sample: Sample, num_steps: int, seed: int
 ) -> tuple[list[int] | None, list[int] | None]:
-    """flow_grpo-style random contiguous SDE window. Returns (sde=window, return=None)
-    so sglang-d returns the full trajectory and log_probs; the trainer then slices
-    to the window for loss / backprop. Keeping the full trajectory avoids the
-    sglang-d-side trailing ``x_final`` aliasing issue when the window ends before
-    the last denoising step."""
+    """flow_grpo-style random contiguous SDE window; the engine returns all
+    latents the window's steps touch (x_i and x_{i+1} for each step i)."""
     window_size = int(args.diffusion_num_sde_steps)
     if window_size <= 0:
         raise ValueError("sde_window requires --diffusion-num-sde-steps > 0")
@@ -42,7 +48,7 @@ def sde_window(
     rng = np.random.default_rng(seed)
     start = int(rng.integers(lo, hi - window_size + 1))
     indices = list(range(start, start + window_size))
-    return indices, None
+    return indices, _sde_steps_to_latent_indices(indices)
 
 
 def epoch_global_random_choice(
@@ -56,11 +62,21 @@ def epoch_global_random_choice(
     if num_sde_steps <= 0:
         raise ValueError("epoch_global_random_choice requires --diffusion-num-sde-steps > 0")
     if num_sde_steps >= len(candidates):
-        return sorted(candidates), None
-    epoch = int(sample.group_index or 0) // int(args.rollout_batch_size)
-    generator = torch.Generator().manual_seed(epoch + int(args.rollout_seed))
-    selected = torch.randperm(len(candidates), generator=generator)[:num_sde_steps]
-    return sorted(candidates[i] for i in selected.tolist()), None
+        indices = sorted(candidates)
+    else:
+        epoch = int(sample.group_index or 0) // int(args.rollout_batch_size)
+        generator = torch.Generator().manual_seed(epoch + int(args.rollout_seed))
+        selected = torch.randperm(len(candidates), generator=generator)[:num_sde_steps]
+        indices = sorted(candidates[i] for i in selected.tolist())
+    return indices, _sde_steps_to_latent_indices(indices)
+
+
+def ode_and_return_last(
+    args: Namespace, sample: Sample, num_steps: int, seed: int
+) -> tuple[list[int] | None, list[int] | None]:
+    """DiffusionNFT-style request: no SDE steps (pure ODE rollout) and only
+    the final clean x0 shipped back."""
+    return None, [num_steps]
 
 
 def _sde_candidate_steps(args: Namespace, num_steps: int) -> list[int]:

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1277,8 +1277,8 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 action="store_true",
                 default=False,
                 help=(
-                    "Ask the engine for the whole denoising trajectory instead of just the "
-                    "SDE window the trainer consumes. The train pairs are identical either "
+                    "Ask the engine for the whole denoising trajectory instead of the steps "
+                    "the step strategy requests. The train tensors are identical either "
                     "way; this keeps the unfiltered path available for debugging and A/B runs."
                 ),
             )

--- a/miles/utils/arguments.py
+++ b/miles/utils/arguments.py
@@ -1273,6 +1273,16 @@ def get_miles_extra_args_provider(add_custom_arguments=None):
                 ),
             )
             parser.add_argument(
+                "--rollout-return-full-trajectory",
+                action="store_true",
+                default=False,
+                help=(
+                    "Ask the engine for the whole denoising trajectory instead of just the "
+                    "SDE window the trainer consumes. The train pairs are identical either "
+                    "way; this keeps the unfiltered path available for debugging and A/B runs."
+                ),
+            )
+            parser.add_argument(
                 "--pickscore-num-gpus-per-worker",
                 type=float,
                 default=1.0,

--- a/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
+++ b/scripts/run_diffusion_grpo_sd3_ocr_sglang.py
@@ -64,6 +64,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.sde_window "
         "--diffusion-num-sde-steps 10 "
         "--diffusion-sde-window-range 0,10 "
+        "--rollout-return-full-trajectory "
     )
 
     eval_args = "--diffusion-eval-num-steps 40 "

--- a/scripts/run_diffusion_nft_sd3_pickscore.py
+++ b/scripts/run_diffusion_nft_sd3_pickscore.py
@@ -60,6 +60,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
         "--diffusion-guidance-scale 1.0 "
         "--diffusion-noise-level 0.0 "
         "--diffusion-sde-type ode "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.ode_and_return_last "
         "--diffusion-height 512 "
         "--diffusion-width 512 "
     ) + (

--- a/tests/fast/backends/fsdp_utils/test_loss_hub_nft.py
+++ b/tests/fast/backends/fsdp_utils/test_loss_hub_nft.py
@@ -60,6 +60,7 @@ class TestNftHooks:
                 self.timesteps = torch.tensor([999.0, 500.0, 0.0])
                 self.sigmas = torch.tensor([1.0, 0.5, 0.0])
                 self.latents = torch.zeros(3, 2, 2)
+                self.latent_step_indices = None
 
         class _Env:
             pos_cond_kwargs = {}
@@ -86,6 +87,7 @@ class TestNftHooks:
                 self.timesteps = torch.tensor([999.0, 500.0, 0.0])
                 self.sigmas = torch.tensor([1.0, 0.5, 0.0])
                 self.latents = torch.zeros(3, 2, 2)
+                self.latent_step_indices = None
 
         class _Env:
             pos_cond_kwargs = {}
@@ -110,6 +112,7 @@ class TestNftHooks:
                 self.timesteps = torch.tensor([999.0, 500.0, 0.0])
                 self.sigmas = None
                 self.latents = torch.zeros(3, 2, 2)
+                self.latent_step_indices = None
 
         class _Env:
             pos_cond_kwargs = {}
@@ -214,6 +217,7 @@ class TestNftDeterminism:
                 self.timesteps = torch.tensor([999.0, 750.0, 500.0, 250.0, 0.0])
                 self.sigmas = torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0])
                 self.latents = torch.zeros(5, 2, 2)
+                self.latent_step_indices = None
 
         return _Traj()
 

--- a/tests/fast/rollout/test_step_strategy_hub.py
+++ b/tests/fast/rollout/test_step_strategy_hub.py
@@ -1,0 +1,36 @@
+"""Step strategies own both halves of the rollout request: the SDE step subset
+and the return latents its trainer consumes."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+from argparse import Namespace
+
+from miles.rollout.step_strategy_hub import epoch_global_random_choice, ode_and_return_last, sde_window
+from miles.utils.types import Sample
+
+
+def test_sde_window_returns_window_plus_boundary():
+    args = Namespace(diffusion_num_sde_steps=3, diffusion_sde_window_range="0,10")
+    sde, ret = sde_window(args, Sample(), num_steps=10, seed=7)
+
+    assert sde == list(range(sde[0], sde[0] + 3))
+    assert ret == sorted(set(sde) | {i + 1 for i in sde})
+
+
+def test_epoch_global_random_choice_returns_subset_plus_boundary():
+    args = Namespace(
+        diffusion_sde_candidate_steps="1,3,5,7",
+        diffusion_num_sde_steps=2,
+        rollout_batch_size=4,
+        rollout_seed=0,
+    )
+    sde, ret = epoch_global_random_choice(args, Sample(group_index=0), num_steps=10, seed=7)
+
+    assert len(sde) == 2 and set(sde) <= {1, 3, 5, 7}
+    assert ret == sorted(set(sde) | {i + 1 for i in sde})
+
+
+def test_ode_and_return_last_requests_only_x0():
+    assert ode_and_return_last(Namespace(), Sample(), num_steps=10, seed=7) == (None, [10])

--- a/tests/fast/rollout/test_traj_window_convert.py
+++ b/tests/fast/rollout/test_traj_window_convert.py
@@ -11,8 +11,8 @@ Mental model (10-step rollout, SDE window S=[2,3]):
 Covered: the windowed trajectory yields bitwise the same train-pair tensors as
 the full trajectory (1), full trajectories without provenance keep the legacy
 behaviour (2), a missing window latent raises instead of mispairing (3), a
-non-contiguous kept set still pairs correctly (4), and NFT refuses a windowed
-trajectory rather than reading some x_t as its x0 (5).
+non-contiguous kept set still pairs correctly (4), and NFT reads x0 off a
+final-step-only trajectory but rejects one ending anywhere else (5).
 """
 
 from tests.ci.ci_register import register_cpu_ci
@@ -93,8 +93,8 @@ def test_non_contiguous_kept_set_pairs_by_provenance():
     assert torch.equal(feats["next_latent"], full.latents[[3, 4, 8]])
 
 
-def test_nft_refuses_a_windowed_trajectory():
-    """NFT reads x0 as the last latent, which a window would silently replace."""
+def test_nft_x0_comes_from_the_final_step():
+    """NFT requests the final step alone; a tail from any other step is not x0."""
     from miles.ray.data_conversion_hub.nft import _clean_x0_from_sample
 
     full = _full_traj()

--- a/tests/fast/rollout/test_traj_window_convert.py
+++ b/tests/fast/rollout/test_traj_window_convert.py
@@ -10,8 +10,9 @@ Mental model (10-step rollout, SDE window S=[2,3]):
 
 Covered: the windowed trajectory yields bitwise the same train-pair tensors as
 the full trajectory (1), full trajectories without provenance keep the legacy
-behaviour (2), a missing window latent raises instead of mispairing (3), and a
-non-contiguous kept set still pairs correctly (4).
+behaviour (2), a missing window latent raises instead of mispairing (3), a
+non-contiguous kept set still pairs correctly (4), and NFT refuses a windowed
+trajectory rather than reading some x_t as its x0 (5).
 """
 
 from tests.ci.ci_register import register_cpu_ci
@@ -90,3 +91,17 @@ def test_non_contiguous_kept_set_pairs_by_provenance():
     feats, _ = _build(win, sde=[2, 3, 7])
     assert torch.equal(feats["latent"], full.latents[[2, 3, 7]])
     assert torch.equal(feats["next_latent"], full.latents[[3, 4, 8]])
+
+
+def test_nft_refuses_a_windowed_trajectory():
+    """NFT reads x0 as the last latent, which a window would silently replace."""
+    from miles.ray.data_conversion_hub.nft import _clean_x0_from_sample
+
+    full = _full_traj()
+    sample = _sample()
+    sample.dit_trajectory = full
+    assert torch.equal(_clean_x0_from_sample(sample), full.latents[-1].float())
+
+    sample.dit_trajectory = _windowed(full, [2, 3, 4])
+    with pytest.raises(ValueError, match="needs x0"):
+        _clean_x0_from_sample(sample)


### PR DESCRIPTION
## What

- Step strategies now own both halves of the rollout request: `sde_step_indices` (which steps are sampled as SDE; `None` = no SDE steps, pure ODE) and `return_step_indices` (which trajectory latents the engine ships back; `None` = all steps).
  - `sde_window` and `epoch_global_random_choice` return every latent their SDE steps touch, `S ∪ (S+1)`, explicitly.
  - New `ode_and_return_last`: no SDE steps, return only the final clean `x0`. The NFT recipe declares it via `--diffusion-step-strategy-path`.
- `generate_microgroup` no longer derives or special-cases return indices; it forwards the strategy's answer with one override: `--rollout-return-full-trajectory` (new flag) resets `return_step_indices` to `None` for debugging / A-B runs. The SD3 OCR recipe passes it, so its e2e keeps covering the full-trajectory path.
- The NFT converter checks that the trajectory it received actually ends at the final step before reading `latents[-1]` as `x0`.

## Why

#216 narrowed the flowGRPO request to `S ∪ (S+1)` inside `generate_microgroup`, keyed on the strategy returning `return_step_indices=None`. That left two problems:

1. No way back to the full trajectory for A/B runs and debugging.
2. NFT stayed on the unfiltered path, where `traj.latents[-1]` is `x0` only by position — a windowed trajectory would have handed it some `x_t` with nothing to signal the swap.

Fixing them exposed the contract smell underneath: the strategy signature always had a `return_step_indices` slot, but every stock strategy returned `None`, and the real decision lived in the caller as a growing ladder of special cases. `None` was also overloaded — "all steps" to the engine, "derive for me" to the caller. What to return is a function of what the trainer consumes, which is exactly what a step strategy encodes, so the decision moved into the strategies and `None` means one thing again.

## Validation

- `tests/fast/rollout/test_step_strategy_hub.py` (3 new contract tests) and `tests/fast/rollout/test_traj_window_convert.py` (6, including the new NFT `x0` case) pass locally.
- pre-commit passes.
- e2e (`test_sd3_ocr_grpo_2xGPU` with the full-trajectory override, `test_sd3_nft_pickscore_3xGPU` on the `x0`-only strategy) is the real check and runs in this PR's CI.

## Files

- `miles/rollout/step_strategy_hub.py` — strategies return `S ∪ (S+1)` explicitly via `_sde_steps_to_latent_indices`; new `ode_and_return_last`; contract docstring.
- `miles/rollout/sglang_diffusion_rollout.py` — drop the caller-side derivation; apply the full-trajectory override.
- `miles/utils/arguments.py` — `--rollout-return-full-trajectory`.
- `miles/ray/data_conversion_hub/nft.py` — reject a trajectory whose last latent is not the final step.
- `scripts/run_diffusion_grpo_sd3_ocr_sglang.py` — pass the full-trajectory flag.
- `scripts/run_diffusion_nft_sd3_pickscore.py` — declare `ode_and_return_last`.
- `docs/user-guide/customization.md` — strategy contract (`None` semantics per field), the stock table, drop the unrelated SDE-step-backend link.
- `tests/fast/rollout/test_step_strategy_hub.py` — new; `tests/fast/rollout/test_traj_window_convert.py` — NFT `x0` case; `tests/fast/backends/fsdp_utils/test_loss_hub_nft.py` — fakes gain `latent_step_indices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FxEmRysrrXzWUiQxxDR9k
