### PR TITLE
docs(streaming-reward): diagnose the pipeline from the queue-depth metrics

### DIFF
--- a/docs/advanced/streaming-reward.md
+++ b/docs/advanced/streaming-reward.md
@@ -69,19 +69,26 @@ overlaps with generation and deserialization of the others.
 
 ## 4. Diagnosing the pipeline
 
-The miles dashboard visualizes the lifetime of every request — the generate / deserialize / reward spans of each
-microgroup on one timeline, so overlap (or the lack of it) is visible directly. Launch with `--use-miles-dashboard`
-(telemetry lands under `--miles-dashboard-workspace`), then render:
+Both actor pools report how deep their backlog was, which is what tells you whether a stage is keeping up. When a
+microgroup is dispatched, the pool records how many calls that worker already had in flight and keeps the largest value
+seen over the rollout:
 
-```bash
-python -m miles.dashboard.viewer --workspace ./miles_dashboard --out dash.html
-```
+| Metric | Meaning |
+|---|---|
+| `perf/parser_max_queue_depth` | Deepest backlog on a parser actor when a response was handed to it |
+| `perf/reward_max_queue_depth` | Deepest backlog on a reward actor when a batch was handed to it |
 
-For quick triage from `perf/*` metrics alone:
+`0` means every dispatch found its worker idle — that stage never made anything wait. A number that climbs with the
+number of concurrent microgroups means the stage is saturated and requests are lining up behind it.
 
-| Symptom                                                 | Look at                  | Likely fix                                                                 |
-| ------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------- |
-| `perf/rollout_time` high, engines idle between requests | `deserialize` stage time | Raise `--rollout-parser-num-workers`                                       |
-| Rollout stalls at the end of each iteration             | `reward` stage time      | More reward workers, or a dedicated reward GPU                             |
-| Event loop warnings / slow heartbeat                    | main-process CPU         | Confirm parsing is going through the actor pool (it always does on `main`) |
+Read them together with `perf/rollout_time`:
+
+| Symptom | Look at | Likely fix |
+|---|---|---|
+| `perf/rollout_time` high | `perf/parser_max_queue_depth` > 0 | Deserialization is the bottleneck; raise `--rollout-parser-num-workers` |
+| `perf/rollout_time` high | `perf/reward_max_queue_depth` > 0 | Scoring is the bottleneck; add reward workers, or give them a dedicated GPU |
+| `perf/rollout_time` high, both depths `0` | Neither pool is holding anything up | The engines themselves are the limit — check `--rollout-microgroup-size` and `--sglang-server-concurrency` |
+
+Both metrics are emitted only when the corresponding pool ran, so a reward with no actor pool leaves
+`perf/reward_max_queue_depth` absent rather than zero.
 


### PR DESCRIPTION
## What

Rewrites the "Diagnosing the pipeline" section of the streaming-reward page around the two queue-depth metrics the rollout already logs:

- `perf/parser_max_queue_depth`
- `perf/reward_max_queue_depth`

Each actor pool records how many calls its worker already had in flight at the moment a microgroup was dispatched, and the rollout logs the largest value it saw. `0` means that stage never made anything wait; a value that grows with concurrency means requests are queueing behind it.

The triage table now pairs each metric with `perf/rollout_time`, so a slow rollout can be attributed to deserialization, to reward scoring, or to the engines themselves — the case where both depths sit at `0`.

## Why

The old section asked the reader to compare per-stage span timings, which are not among the logged metrics, and its suggested fixes were not tied to anything a run actually reports. The queue depths answer the same question from data every run already produces, and they discriminate between the three causes rather than describing symptoms.

## Verified against `main`

- Both metrics reach W&B under `perf/` (`compute_perf_metrics_from_samples` → `dict_add_prefix(..., "perf/")` in `miles/ray/rollout.py`)
- Aggregation is `max()` over the rollout's samples
- Depth is the in-flight count observed at dispatch (`state.parser_inflight[i]` in `sglang_diffusion_rollout.py`; `self._inflight[i]` in `rm_hub/core.py`)
- Each metric is emitted only when its pool ran, so it is absent rather than zero otherwise
- Every flag named in the table exists

## Files

- `docs/advanced/streaming-reward.md` (+19/−12)

## Checklist

- [ ] `pre-commit run --all-files` — **not run** (docs-only)
- [x] Claims cross-checked against source
- [x] No launch flags changed / no public flag added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXZMxrjDB2V88kSJEGa2cj
