### PR TITLE
feat(diffusion): support Wan2.2 TI2V Flow-GRPO training

### DIFF
--- a/miles/backends/fsdp_utils/configs/wan2_2_ti2v.py
+++ b/miles/backends/fsdp_utils/configs/wan2_2_ti2v.py
@@ -1,0 +1,114 @@
+"""Wan2.2-TI2V-5B single-DiT training configuration."""
+
+from __future__ import annotations
+
+import torch
+
+from miles.utils.types import CondKwargs
+
+from .train_pipeline_config import TrainPipelineConfig, register_train_pipeline_config
+
+
+@register_train_pipeline_config("wan2_2_ti2v")
+class Wan2_2_TI2VTrainPipelineConfig(TrainPipelineConfig):
+    """Reproduce Wan2.2 TI2V's masked, sequence-expanded timestep input."""
+
+    hf_ckpt_name_patterns = ("wan2.2-ti2v", "wan2_2_ti2v", "ti2v-5b")
+    cfg_batching = False
+    lora_target_modules = [
+        "attn1.to_q",
+        "attn1.to_k",
+        "attn1.to_v",
+        "attn1.to_out.0",
+        "attn2.to_q",
+        "attn2.to_k",
+        "attn2.to_v",
+        "attn2.to_out.0",
+        "ffn.net.0.proj",
+        "ffn.net.2",
+    ]
+
+    def prepare_cond_kwargs(self, cond: CondKwargs | None, device: torch.device) -> dict:
+        if cond is None:
+            return {}
+        result: dict = {}
+        if cond.encoder_hidden_states:
+            enc = torch.cat(cond.encoder_hidden_states).to(device)
+            if enc.ndim == 2:
+                enc = enc.unsqueeze(0)
+            result["encoder_hidden_states"] = enc
+        if cond.wan_ti2v_reserved_frames_mask is not None:
+            mask = cond.wan_ti2v_reserved_frames_mask.to(device=device, dtype=torch.float32)
+            # The rollout mask is repeated across latent channels. Keep one
+            # mask per sample before collating the training batch.
+            if mask.ndim == 5:
+                mask = mask[:, 0]
+            elif mask.ndim == 4:
+                mask = mask[:1]
+            if mask.ndim == 3:
+                mask = mask.unsqueeze(0)
+            if mask.ndim != 4 or mask.shape[0] != 1:
+                raise ValueError(
+                    "Wan TI2V reserved-frames mask must normalize to [1,T,H,W], "
+                    f"got {tuple(mask.shape)}"
+                )
+            result["wan_ti2v_reserved_frames_mask"] = mask
+        if cond.wan_ti2v_patch_size is not None:
+            result["wan_ti2v_patch_size"] = tuple(cond.wan_ti2v_patch_size)
+        return result
+
+    def collate_cond_for_sample_batch(
+        self, per_sample_cond_kwargs: list[dict], device: torch.device, pad_to_len: int | None = None
+    ) -> dict:
+        result: dict = {}
+        encs = [kw["encoder_hidden_states"] for kw in per_sample_cond_kwargs]
+        result["encoder_hidden_states"] = torch.cat(encs, dim=0).to(device)
+        masks = [kw["wan_ti2v_reserved_frames_mask"] for kw in per_sample_cond_kwargs]
+        result["wan_ti2v_reserved_frames_mask"] = torch.cat(masks, dim=0).to(device)
+        result["wan_ti2v_patch_size"] = per_sample_cond_kwargs[0]["wan_ti2v_patch_size"]
+        return result
+
+    def compute_noise_pred(
+        self,
+        *,
+        model,
+        latents_input,
+        timesteps_input,
+        pos_cond,
+        neg_cond,
+        joint_cond,
+        use_cfg,
+        cfg_batching,
+        guidance_scale,
+        true_cfg_scale,
+    ) -> torch.Tensor:
+        def _forward(cond: dict) -> torch.Tensor:
+            cond = dict(cond)
+            mask = cond.pop("wan_ti2v_reserved_frames_mask")
+            patch_size = cond.pop("wan_ti2v_patch_size")
+            _, ph, pw = patch_size
+            t = timesteps_input.reshape(-1, 1, 1, 1).to(mask.dtype)
+            timestep = (mask[:, :, ::ph, ::pw] * t).flatten(1)
+            output = model(
+                hidden_states=latents_input,
+                timestep=timestep,
+                return_dict=False,
+                **cond,
+            )[0]
+            if output.shape != latents_input.shape:
+                raise ValueError(
+                    "Wan TI2V noise prediction must match the latent layout: "
+                    f"output={tuple(output.shape)}, latents={tuple(latents_input.shape)}, "
+                    f"timestep={tuple(timestep.shape)}"
+                )
+            return output
+
+        if not use_cfg:
+            return _forward(pos_cond)
+        pos = _forward(pos_cond)
+        neg = _forward(neg_cond)
+        return self.cfg_combine(pos, neg, guidance_scale, true_cfg_scale=true_cfg_scale)
+
+    def cfg_combine(self, noise_pred_pos, noise_pred_neg, guidance_scale, true_cfg_scale=None):
+        scale = true_cfg_scale if true_cfg_scale is not None else guidance_scale
+        return noise_pred_neg + scale * (noise_pred_pos - noise_pred_neg)

--- a/miles/backends/fsdp_utils/models/diffusers/wan2_2_ti2v/__init__.py
+++ b/miles/backends/fsdp_utils/models/diffusers/wan2_2_ti2v/__init__.py
@@ -1,0 +1,1 @@
+"""Wan2.2-TI2V FSDP model package marker."""

--- a/miles/backends/fsdp_utils/models/diffusers/wan2_2_ti2v/parallel_plan.py
+++ b/miles/backends/fsdp_utils/models/diffusers/wan2_2_ti2v/parallel_plan.py
@@ -1,0 +1,6 @@
+from miles.backends.fsdp_utils.models.parallel_plan import FSDPParallelPlan
+
+
+FSDP_PARALLEL_PLAN = FSDPParallelPlan(
+    param_dtype_patterns={"*.norm2.*": "fp32"},
+)

--- a/miles/rollout/sglang_diffusion_rollout.py
+++ b/miles/rollout/sglang_diffusion_rollout.py
@@ -193,6 +193,13 @@ async def generate_microgroup(
     payload = build_rollout_generate_payload(
         sampling_params, microgroup[0].prompt, num_outputs_per_prompt=len(microgroup)
     )
+    image_path = (microgroup[0].metadata or {}).get("image_path")
+    if image_path is not None:
+        # A request group shares one conditioning input across its outputs.
+        if isinstance(image_path, str):
+            payload["image_path"] = [image_path]
+        else:
+            payload["image_path"] = image_path
 
     st = hooks.StageTimer()
     if args.rollout_fetch_in_parser:

--- a/miles/utils/diffusion_rollout_response.py
+++ b/miles/utils/diffusion_rollout_response.py
@@ -113,6 +113,12 @@ def _parse_cond_kwargs(
         text_ids=deserialize_func(data.get("text_ids")),
         text_mask=deserialize_func(data.get("text_mask")),
         fps=data.get("fps"),
+        wan_ti2v_reserved_frames_mask=_deserialize_optional_tensor(
+            data.get("wan_ti2v_reserved_frames_mask"), deserialize_func=deserialize_func
+        ),
+        wan_ti2v_patch_size=tuple(data["wan_ti2v_patch_size"])
+        if data.get("wan_ti2v_patch_size") is not None
+        else None,
     )
 
 

--- a/miles/utils/types.py
+++ b/miles/utils/types.py
@@ -40,6 +40,9 @@ class CondKwargs:
     text_ids: torch.Tensor | None = None
     text_mask: torch.Tensor | None = None
     fps: float | None = None
+    # Optional replay metadata for masked, patch-based conditioning.
+    wan_ti2v_reserved_frames_mask: torch.Tensor | None = None
+    wan_ti2v_patch_size: tuple[int, int, int] | None = None
 
 
 @dataclass

--- a/scripts/run_diffusion_grpo_wan22_ti2v.py
+++ b/scripts/run_diffusion_grpo_wan22_ti2v.py
@@ -1,0 +1,247 @@
+"""Train Wan2.2-TI2V-5B with Flow-GRPO, FSDP, and LoRA.
+
+The recipe runs SGLang rollout and the FSDP trainer on the same GPUs in
+colocated mode. PickScore evaluates uniformly sampled video frames, GRPO
+normalizes rewards within each prompt group, and only LoRA parameters are
+optimized and synchronized back to the rollout engine.
+
+Prerequisites:
+    - Install the project environment and activate it.
+    - Make the model available as a Hugging Face model ID or local Diffusers
+      directory. The default is ``Wan-AI/Wan2.2-TI2V-5B-Diffusers``.
+    - Make the PickScore processor and model available from Hugging Face, or
+      override their paths through ``--extra-args`` when using local copies.
+    - Use at least two samples per prompt so GRPO can compare generations.
+
+Dataset format:
+    The input is JSONL. Each row contains a prompt under ``input`` and a
+    conditioning image under ``metadata.image_path``. Image paths should be
+    absolute paths visible to every Ray worker.
+
+    {"input": "A camera moves around the subject.",
+     "metadata": {"image_path": "/data/images/frame.jpg"}}
+
+Two-GPU training with the default Hugging Face model:
+    python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
+        --data-jsonl /data/train.jsonl \
+        --num-gpus 2 \
+        --cuda-visible-devices 0,1
+
+Training from a local model directory:
+    python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
+        --model /models/Wan2.2-TI2V-5B-Diffusers \
+        --data-jsonl /data/train.jsonl \
+        --num-gpus 2 \
+        --cuda-visible-devices 0,1
+
+Enable periodic evaluation with a separate JSONL file:
+    python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
+        --data-jsonl /data/train.jsonl \
+        --eval-data-jsonl /data/validation.jsonl \
+        --eval-interval 20
+
+Lower-cost configuration for checking a new installation:
+    python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
+        --model /models/Wan2.2-TI2V-5B-Diffusers \
+        --data-jsonl /data/train.jsonl \
+        --num-gpus 2 \
+        --cuda-visible-devices 0,1 \
+        --num-rollout 1 \
+        --rollout-batch-size 1 \
+        --n-samples-per-prompt 2 \
+        --num-steps-per-rollout 1 \
+        --height 256 --width 448 --num-frames 5 \
+        --num-diffusion-steps 3 \
+        --lora-rank 4 --lora-alpha 4 \
+        --extra-args "--diffusion-guidance-scale 1.0 --diffusion-num-sde-steps 1"
+
+Operational notes:
+    - ``--num-gpus`` controls both FSDP world size and SGLang tensor parallel
+      size. Use two or more GPUs for actual parameter sharding.
+    - Checkpoints are written below ``--output-dir`` every ``--save-interval``
+      rollout iterations and once at the end.
+    - Set ``WANDB_API_KEY`` to enable W&B; otherwise tracking is skipped.
+    - ``--extra-args`` appends native ``train_diffusion.py`` options and can be
+      used for scheduler, reward-model, resume, or performance overrides.
+    - Run the script with ``--help`` for all recipe-level options.
+"""
+
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+import miles.utils.external_utils.command_utils as U
+
+
+MODEL = "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+WANDB_PROJECT = "miles-diffusion-grpo"
+
+
+@dataclass
+class ScriptArgs(U.ExecuteTrainConfig):
+    model: str = MODEL
+    data_jsonl: str = ""
+    eval_data_jsonl: str = ""
+    input_key: str = "input"
+    num_gpus: int = 2
+    num_rollout: int = 1000
+    rollout_batch_size: int = 2
+    n_samples_per_prompt: int = 8
+    num_steps_per_rollout: int = 2
+    save_interval: int = 10
+    eval_interval: int = 20
+    height: int = 480
+    width: int = 832
+    num_frames: int = 49
+    num_diffusion_steps: int = 20
+    lora_rank: int = 64
+    lora_alpha: int = 128
+    extra_args: str = ""
+
+
+def _validate_args(args: ScriptArgs) -> None:
+    if not args.data_jsonl:
+        raise SystemExit("set --data-jsonl to a JSONL file containing a prompt and metadata.image_path")
+    if not Path(args.data_jsonl).is_file():
+        raise FileNotFoundError(args.data_jsonl)
+    if args.eval_data_jsonl and not Path(args.eval_data_jsonl).is_file():
+        raise FileNotFoundError(args.eval_data_jsonl)
+    if args.num_gpus < 1:
+        raise ValueError("--num-gpus must be at least 1")
+
+
+def execute(args: ScriptArgs) -> None:
+    _validate_args(args)
+    run_name = f"diffusion_grpo_wan22_ti2v_{U.create_run_id()}"
+    model = shlex.quote(args.model)
+    data_jsonl = shlex.quote(args.data_jsonl)
+    input_key = shlex.quote(args.input_key)
+    save_dir = shlex.quote(f"{args.output_dir}/{run_name}/ckpt")
+
+    ckpt_args = (
+        f"--hf-checkpoint {model} "
+        "--diffusion-model-family wan2_2_ti2v "
+        f"--save {save_dir} "
+        f"--save-interval {args.save_interval} "
+    )
+
+    rollout_args = (
+        "--rollout-function-path miles.rollout.sglang_diffusion_rollout.generate_rollout "
+        f"--prompt-data {data_jsonl} "
+        f"--input-key {input_key} "
+        f"--rollout-batch-size {args.rollout_batch_size} "
+        f"--n-samples-per-prompt {args.n_samples_per_prompt} "
+        f"--num-steps-per-rollout {args.num_steps_per_rollout} "
+        f"--num-rollout {args.num_rollout} "
+        "--rollout-microgroup-size 1 "
+        "--micro-batch-size-sample 1 "
+        "--micro-batch-size-tstep 1 "
+        "--diffusion-train-iter-order sample_major "
+    )
+
+    diffusion_args = (
+        f"--diffusion-num-steps {args.num_diffusion_steps} "
+        f"--diffusion-output-num-frames {args.num_frames} "
+        f"--diffusion-height {args.height} "
+        f"--diffusion-width {args.width} "
+        "--diffusion-fps 24 "
+        "--diffusion-guidance-scale 5.0 "
+        "--diffusion-flow-shift 5.0 "
+        "--diffusion-noise-level 0.7 "
+        "--diffusion-sde-type sde "
+        "--diffusion-step-strategy-path miles.rollout.step_strategy_hub.sde_window "
+        "--diffusion-num-sde-steps 2 "
+        f"--diffusion-sde-window-range 1,{args.num_diffusion_steps} "
+    )
+
+    eval_args = ""
+    if args.eval_data_jsonl and args.eval_interval > 0:
+        eval_data_jsonl = shlex.quote(args.eval_data_jsonl)
+        eval_args = (
+            f"--eval-prompt-data pickscore_val {eval_data_jsonl} "
+            f"--eval-interval {args.eval_interval} "
+            "--n-samples-per-eval-prompt 1 "
+            f"--diffusion-eval-num-steps {args.num_diffusion_steps} "
+            "--skip-eval-before-train "
+        )
+
+    grpo_args = (
+        "--advantage-estimator grpo "
+        "--globalize-reward-std "
+        "--diffusion-clip-range 1e-4 "
+        "--diffusion-kl-beta 0.0 "
+    )
+
+    optimizer_args = "--lr 1e-4 --adam-beta2 0.999 --weight-decay 1e-4 "
+
+    lora_args = (
+        "--use-lora "
+        "--lora-ipc-weight-sync "
+        f"--lora-rank {args.lora_rank} "
+        f"--lora-alpha {args.lora_alpha} "
+        "--lora-init-weights gaussian "
+    )
+
+    reward_args = (
+        "--rm-type pickscore "
+        "--pickscore-processor-path laion/CLIP-ViT-H-14-laion2B-s32B-b79K "
+        "--pickscore-model-path yuvalkirstain/PickScore_v1 "
+        "--pickscore-num-frames 8 "
+        "--pickscore-num-workers 1 "
+        "--pickscore-num-gpus-per-worker 0 "
+        "--pickscore-batch-size 8 "
+    )
+
+    wandb_args = U.get_default_wandb_args(
+        __file__, run_id=run_name, project=WANDB_PROJECT, wandb_log_num_images=4, wandb_log_image_interval=10
+    )
+
+    sglang_args = (
+        "--use-miles-router "
+        "--sglang-server-concurrency 2 "
+        f"--sglang-tp-size {args.num_gpus} "
+        "--sglang-sp-degree 1 "
+        "--sglang-dit-precision bf16 "
+        "--update-weight-buffer-size 2147483648 "
+    )
+
+    train_backend_args = (
+        "--train-backend fsdp "
+        "--fsdp-master-dtype bf16 "
+        "--fsdp-reduce-dtype bf16 "
+        "--diffusion-forward-dtype bf16 "
+        "--update-weight-target-module transformer "
+    )
+
+    perf_args = "--gradient-checkpointing --rollout-parser-num-workers 2 "
+
+    placement_args = (
+        "--actor-num-nodes 1 "
+        f"--actor-num-gpus-per-node {args.num_gpus} "
+        f"--rollout-num-gpus {args.num_gpus} "
+        f"--rollout-num-gpus-per-engine {args.num_gpus} "
+        f"--num-gpus-per-node {args.num_gpus} "
+        "--colocate "
+        "--colocate-reward "
+    )
+
+    U.execute_train(
+        train_args=(
+            f"{ckpt_args} {rollout_args} {diffusion_args} {eval_args} {grpo_args} "
+            f"{optimizer_args} {lora_args} {reward_args} {wandb_args} {sglang_args} "
+            f"{train_backend_args} {perf_args} {placement_args} {args.extra_args}"
+        ),
+        num_gpus_per_node=args.num_gpus,
+        config=args,
+    )
+
+
+@U.dataclass_cli
+def main(args: ScriptArgs) -> None:
+    execute(args)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/tests/fast/backends/fsdp_utils/test_wan22_ti2v_config.py
+++ b/tests/fast/backends/fsdp_utils/test_wan22_ti2v_config.py
@@ -1,0 +1,51 @@
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-cpu", labels=[])
+
+import torch
+
+from miles.backends.fsdp_utils.configs.wan2_2_ti2v import Wan2_2_TI2VTrainPipelineConfig
+from miles.utils.types import CondKwargs
+
+
+class _EchoWan(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.timestep_shape = None
+
+    def forward(self, hidden_states, timestep, **_kwargs):
+        self.timestep_shape = tuple(timestep.shape)
+        return (hidden_states,)
+
+
+def test_wan_ti2v_channel_mask_does_not_become_batch_dimension():
+    config = Wan2_2_TI2VTrainPipelineConfig()
+    channel_mask = torch.ones(48, 2, 16, 28)
+    channel_mask[:, 0] = 0
+    cond = CondKwargs(
+        encoder_hidden_states=[torch.zeros(1, 512, 4)],
+        wan_ti2v_reserved_frames_mask=channel_mask,
+        wan_ti2v_patch_size=(1, 2, 2),
+    )
+
+    per_sample = config.prepare_cond_kwargs(cond, torch.device("cpu"))
+    assert per_sample["wan_ti2v_reserved_frames_mask"].shape == (1, 2, 16, 28)
+
+    collated = config.collate_cond_for_sample_batch([per_sample, per_sample], torch.device("cpu"))
+    model = _EchoWan()
+    latents = torch.zeros(2, 48, 2, 16, 28)
+    output = config.compute_noise_pred(
+        model=model,
+        latents_input=latents,
+        timesteps_input=torch.tensor([500.0, 250.0]),
+        pos_cond=collated,
+        neg_cond=None,
+        joint_cond=None,
+        use_cfg=False,
+        cfg_batching=False,
+        guidance_scale=1.0,
+        true_cfg_scale=None,
+    )
+
+    assert model.timestep_shape == (2, 224)
+    assert output.shape == latents.shape


### PR DESCRIPTION

  # Add Wan2.2-TI2V Flow-GRPO Training with FSDP and LoRA

  ## Summary

  This PR adds a general Wan2.2-TI2V-5B training recipe based on the existing Miles training framework.

  Supported features:

  - Flow-GRPO training
  - FSDP distributed training
  - LoRA fine-tuning
  - SGLang TI2V rollout
  - Image-conditioned video generation
  - PickScore frame-based reward
  - Optional evaluation
  - Checkpoint saving and resuming through native training arguments

  ## Main Changes

  - Add the wan2_2_ti2v training pipeline configuration.
  - Add TI2V masked timestep construction for video latent tokens.
  - Add the Wan2.2-TI2V FSDP precision plan.
  - Forward conditioning image paths from dataset metadata to SGLang rollout.
  - Parse and preserve TI2V rollout metadata required by the training forward pass.
  - Add a complete training script:

    scripts/run_diffusion_grpo_wan22_ti2v.py

  - Add a regression test for TI2V mask normalization and timestep shape handling.

  ## Dataset Format

  The training data uses the existing Miles metadata format:

  {
    "input": "A camera moves around the subject.",
    "metadata": {
      "image_path": "/data/images/frame.jpg"
    }
  }

  The image path must be available to all Ray workers.

  ## Training Example

  python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
      --model /models/Wan2.2-TI2V-5B-Diffusers \
      --data-jsonl /data/train.jsonl \
      --num-gpus 2 \
      --cuda-visible-devices 0,1

  The script enables the following training components by default:

  - FSDP training backend
  - LoRA adapter training
  - LoRA weight synchronization
  - Flow-SDE rollout
  - GRPO advantage estimation
  - PickScore reward
  - SGLang rollout
  - Checkpoint saving

  ## Evaluation Example

  python3 scripts/run_diffusion_grpo_wan22_ti2v.py \
      --model /models/Wan2.2-TI2V-5B-Diffusers \
      --data-jsonl /data/train.jsonl \
      --eval-data-jsonl /data/validation.jsonl \
      --eval-interval 20 \
      --num-gpus 2

  ## Validation Results

  Unit and configuration tests:

  7 passed
  git diff --check passed

  The complete training recipe was also passed through the native train_diffusion.py argument validation.

  A real two-GPU execution validated the following path:

  - SGLang tensor parallelism: TP=2
  - FSDP data parallelism: DP=2
  - FSDP-wrapped Wan transformer blocks: 30
  - LoRA trainable parameters: 10,076,160 / 5,009,863,872
  - LoRA synchronization: 600 tensors across 300 layer prefixes
  - GRPO reward calculation
  - GRPO advantage calculation
  - Flow-GRPO loss
  - Backward pass
  - Optimizer update
  - Distributed checkpoint saving

  The real execution also confirmed that:

  - Standard CUDA IPC LoRA synchronization works.
  - All 600 LoRA tensors were synchronized successfully.
  - No layer prefixes were unmapped.
  - Image-conditioned Wan2.2-TI2V rollout completed successfully.
  - Generated videos were decoded successfully.
  - FSDP initialization completed with DP=2.

  ## Scope

  This PR only contains the general Wan2.2-TI2V training support and its required tests.

  It does not include:

  - Environment-specific CPU weight-sync fallback code
  - Smoke-only reward implementations
  - Fixed local model paths
  - Fixed local datasets
  - Unrelated H3 or Wan2.1 validation code

  The existing training paths for other model families are unchanged.