### PR TITLE
ci: pin the hosted CPU suite's sglang runtime deps

### DIFF
--- a/.github/workflows/_run-ci.yml
+++ b/.github/workflows/_run-ci.yml
@@ -276,22 +276,11 @@ jobs:
           UV_SYSTEM_PYTHON: "1"
         run: |
           SGLANG_BUILD_RUST_EXTS=none uv pip install -e sglang/python --no-deps
-          uv pip install -r requirements.txt
+          # sglang is installed --no-deps; its pinned pure-python runtime deps
+          # live in requirements-ci-cpu.txt (same pattern as radixark/miles).
+          # One resolve for both files so neither can move the other's pins.
+          uv pip install -r requirements.txt -r tests/ci/requirements-ci-cpu.txt
           uv pip install -e . --no-deps
-          # sglang is installed --no-deps above, but miles-D's import chain
-          # loads many sglang modules. Install sglang's pure-python runtime
-          # deps upfront; skip GPU-only ones (cuda-python, flashinfer,
-          # flash-attn-4, sglang-kernel, torchao, torchcodec,
-          # torch_memory_saver, quack-kernels, nvidia-cutlass-dsl,
-          # apache-tvm-ffi, kernels, decord2, av). torch itself comes via
-          # accelerate (in requirements.txt).
-          uv pip install \
-            IPython aiohttp anthropic build compressed-tensors einops fastapi \
-            gguf interegular jsonschema llguidance mistral_common modelscope \
-            msgspec ninja nvidia-ml-py openai openai-harmony orjson outlines \
-            partial_json_parser prometheus-client psutil py-spy pybase64 pydantic \
-            python-multipart pyzmq scipy sentencepiece setproctitle soundfile \
-            tiktoken timm torchvision==0.26.0 uvicorn uvloop watchfiles xgrammar
           # sglang's memory_pool_host.py unconditionally imports sgl_kernel
           # on non-NPU/XPU/MPS hardware. sgl_kernel is GPU-only. multimodal_gen
           # similarly hard-imports cache_dit at package load. Install local

--- a/tests/ci/requirements-ci-cpu.txt
+++ b/tests/ci/requirements-ci-cpu.txt
@@ -1,0 +1,52 @@
+# SGLang runtime imports reached by the hosted CPU suite (same pattern as
+# radixark/miles tests/ci/requirements-ci-cpu.txt). GPU runners get these from
+# the miles-diffusion image; sglang itself is installed --no-deps because its
+# full dependency set includes GPU-only packages that cannot install on
+# ubuntu-latest (cuda-python, flashinfer, flash-attn-4, sgl-kernel, torchao,
+# torchcodec, torch_memory_saver, quack-kernels, nvidia-cutlass-dsl,
+# apache-tvm-ffi, kernels, decord2, av). torch itself comes via accelerate
+# (in requirements.txt).
+#
+# Everything here is pinned so a PyPI release can never move the resolve —
+# xgrammar 0.2.5.post1 (transformers<5) silently downgraded transformers
+# 5.12.1 -> 4.57.6 and broke the sglang import chain in the 2026-09-03
+# nightly. xgrammar mirrors sglang's own pyproject pin.
+aiohttp==3.14.3
+anthropic==1.3.0
+build==1.6.0
+compressed-tensors==0.18.0
+einops==0.8.2
+fastapi==0.128.8
+gguf==0.19.0
+interegular==0.3.3
+ipython==9.17.1
+jsonschema==4.26.0
+llguidance==1.8.0
+mistral-common==1.11.7
+modelscope==1.39.1
+msgspec==0.21.1
+ninja==1.13.2
+nvidia-ml-py==13.595.45
+openai==2.6.1
+openai-harmony==0.0.8
+orjson==3.12.0
+outlines==1.3.3
+partial-json-parser==0.2.1.1.post7
+prometheus-client==0.26.0
+psutil==7.2.2
+py-spy==0.4.2
+pybase64==1.5.0
+pydantic==2.12.5
+python-multipart==0.0.32
+pyzmq==27.2.0
+scipy==1.17.1
+sentencepiece==0.2.2
+setproctitle==1.3.7
+soundfile==0.14.0
+tiktoken==0.14.0
+timm==1.0.29
+torchvision==0.26.0
+uvicorn==0.39.0
+uvloop==0.22.1
+watchfiles==1.2.0
+xgrammar==0.2.1


### PR DESCRIPTION
## What

- Move the hosted CPU suite's hand-installed sglang runtime deps from bare names inlined in `_run-ci.yml` into `tests/ci/requirements-ci-cpu.txt`, with every package pinned — the same pattern radixark/miles uses (`_run-cpu-ci.yml` + `tests/ci/requirements-ci-cpu.txt`).
- Install it in the same `uv pip install` resolve as `requirements.txt`, so neither file can move the other's pins.

## Why

The 2026-09-03 nightly failed at stage-a-cpu: xgrammar released `0.2.5.post1` that morning adding a `transformers<5` constraint, and the unpinned install line let uv downgrade transformers `5.12.1 -> 4.57.6` (and huggingface-hub `1.30.0 -> 0.36.2`). sglang's import chain then died on `from transformers.configuration_utils import PreTrainedConfig` — a transformers-v5-only name — aborting the whole suite at collection (run [33779342513](https://github.com/radixark/miles_diffusion/actions/runs/33779342513)).

Root cause of the root cause: when the CPU job was ported from radixark/miles, the pinned `requirements-ci-cpu.txt` was inlined as bare package names, dropping every pin except `torchvision`. This restores the upstream pattern.

Pin sources:
- every version comes from the last green resolve (2026-09-02 nightly, run [33655750001](https://github.com/radixark/miles_diffusion/actions/runs/33655750001));
- except `xgrammar==0.2.1`, which mirrors sglang's own `python/pyproject.toml` pin on `sglang-miles-h3` (the unpinned CI happened to resolve 0.2.3, which was never what the GPU image runs).

## Validation

- `uv pip compile --python-version 3.12 --python-platform linux` over `requirements.txt` + `tests/ci/requirements-ci-cpu.txt` resolves cleanly to `transformers==5.12.1`, `huggingface-hub==1.30.0`, `xgrammar==0.2.1` — the pre-drift green state.
- `pre-commit run --all-files` passes (including `requirements-txt-fixer` on the new file).
- This PR's own stage-a-cpu run exercises the changed install path end-to-end.

## Files

- `tests/ci/requirements-ci-cpu.txt` — new: pinned sglang pure-python runtime deps for the hosted CPU suite.
- `.github/workflows/_run-ci.yml` — run-cpu install step: bare-name list replaced by `-r tests/ci/requirements-ci-cpu.txt` in the same resolve as `requirements.txt`.

## Checklist

- [x] `pre-commit run --all-files` passes
- [ ] Added/updated tests for new behaviour — **no tests added**: CI-config-only change, validated by this PR's own CPU suite run
- [ ] `pytest -x` is green — **not run locally**: no code under `miles/` touched; stage-a-cpu on this PR is the real check
- [x] If launch flags changed, `python3 train.py --help` still parses — n/a, no launch flags changed
- [x] If a public flag was added, it appears in the CLI reference docs — n/a
- [x] If an example was added, it has a real walkthrough — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FxEmRysrrXzWUiQxxDR9k
