### PR TITLE
ci: gate the H3 e2e behind run-ci-e2e and make the SD3 NFT e2e always-on

### DIFF
--- a/tests/e2e/short/test_h3_t2va_grpo_2xGPU.py
+++ b/tests/e2e/short/test_h3_t2va_grpo_2xGPU.py
@@ -12,6 +12,7 @@ from tests.ci.e2e_metrics_registry import register_e2e_ci
 register_e2e_ci(
     est_time=3000,
     suite="stage-c-3-gpu-h200",
+    labels=["e2e"],
     script="scripts/run_diffusion_grpo_h3_t2va_2gpu.py",
     args=["--num-rollout", "2", "--n-samples-per-prompt", "4", "--eval-interval", "0"],
     metrics=[

--- a/tests/e2e/short/test_sd3_nft_pickscore_3xGPU.py
+++ b/tests/e2e/short/test_sd3_nft_pickscore_3xGPU.py
@@ -22,7 +22,6 @@ register_e2e_ci(
     suite="stage-c-3-gpu-h200",
     script="scripts/run_diffusion_nft_sd3_pickscore.py",
     args=["--num-rollout", "4"],
-    labels=["e2e"],
     metrics=[
         "rollout/reward/raw_num_samples",
         "rollout/reward/raw_mean",


### PR DESCRIPTION
<img width="1110" height="334" alt="image" src="https://github.com/user-attachments/assets/da984d43-0708-4b1d-b987-3924ab561813" />
Now basic CI covers NFT
