### PR TITLE
refactor(rollout): seat colocated actor pools from the manager, not module state

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -55,6 +55,12 @@ def generate_rollout(
 Legacy list/dict returns are still wrapped into the corresponding output dataclass by
 `miles.rollout.base_types.call_rollout_fn`.
 
+A rollout function that seats its own GPU actors on the rollout GPUs (e.g. the SFT
+encode pool) declares an extra `placement_group=None` keyword; `call_rollout_fn`
+passes the manager's `(pg, bundle_indices, gpu_ids)` only to signatures that take it.
+The colocated reward pool is seated by `RolloutManager` itself, not by the rollout
+function.
+
 ### `--eval-function-path`
 
 Same shape as the rollout function. Defaults to `--rollout-function-path` when

--- a/miles/ray/rollout.py
+++ b/miles/ray/rollout.py
@@ -18,7 +18,7 @@ from miles.ray.data_conversion_hub.flow_grpo import (
     expand_samples_to_train_pairs as flow_grpo_expand_samples_to_train_pairs,
 )
 from miles.rollout.base_types import call_rollout_fn
-from miles.rollout.rm_hub.core import set_manager_placement_group
+from miles.rollout.rm_hub import create_reward_pool
 from miles.utils import tracking_utils
 from miles.utils.health_monitor import RolloutHealthMonitor
 from miles.utils.http_utils import _wrap_ipv6, find_available_port, get_host_info, init_http_client
@@ -55,7 +55,6 @@ class RolloutManager:
         from miles.dashboard import hooks
 
         hooks.register_rollout_manager(args)
-        set_manager_placement_group(pg)
         if not args.train_only:
             logger.info("RolloutManager: starting router...")
             _start_router(args)
@@ -103,6 +102,8 @@ class RolloutManager:
             self.all_rollout_engines = [None] * num_engines
             self.num_new_engines = init_rollout_engines(args, pg, self.all_rollout_engines)
             logger.info("RolloutManager started %s rollout engines", len(self.all_rollout_engines))
+        # The pool outlives every rollout call, so the manager seats it; rm_hub's singleton lookup then finds it.
+        self.reward_pool = create_reward_pool(args, pg) if args.colocate_reward else None
         logger.info("RolloutManager: creating lock...")
         self.nodes_per_engine = max(1, args.rollout_num_gpus_per_engine // args.num_gpus_per_node)
         self.rollout_engine_lock = Lock.options(num_cpus=1, num_gpus=0).remote()
@@ -203,7 +204,14 @@ class RolloutManager:
             return
         self.health_monitoring_resume()
 
-        result = call_rollout_fn(self.eval_generate_rollout, self.args, rollout_id, self.data_source, evaluation=True)
+        result = call_rollout_fn(
+            self.eval_generate_rollout,
+            self.args,
+            rollout_id,
+            self.data_source,
+            evaluation=True,
+            placement_group=self.pg,
+        )
         data = result.data
         self._save_debug_rollout_data(data, rollout_id=rollout_id, evaluation=True)
         metrics = _log_eval_rollout_data(rollout_id, self.args, data, result.metrics)
@@ -297,7 +305,14 @@ class RolloutManager:
                 )
             metrics = None
         else:
-            data = call_rollout_fn(self.generate_rollout, self.args, rollout_id, self.data_source, evaluation=False)
+            data = call_rollout_fn(
+                self.generate_rollout,
+                self.args,
+                rollout_id,
+                self.data_source,
+                evaluation=False,
+                placement_group=self.pg,
+            )
             metrics = data.metrics
             data = data.samples
             # flatten the data if it is a list of lists

--- a/miles/rollout/base_types.py
+++ b/miles/rollout/base_types.py
@@ -1,3 +1,4 @@
+import inspect
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,7 +17,10 @@ class RolloutFnEvalOutput:
     metrics: dict[str, Any] = None
 
 
-def call_rollout_fn(fn, *args, evaluation: bool, **kwargs):
+def call_rollout_fn(fn, *args, evaluation: bool, placement_group=None, **kwargs):
+    # custom rollout functions predate this kwarg, so it is passed only to signatures that take it
+    if "placement_group" in inspect.signature(fn).parameters:
+        kwargs["placement_group"] = placement_group
     output = fn(*args, **kwargs, evaluation=evaluation)
 
     # compatibility for legacy version

--- a/miles/rollout/rm_hub/__init__.py
+++ b/miles/rollout/rm_hub/__init__.py
@@ -24,6 +24,15 @@ async def async_rm(args, sample: Sample, **kwargs):
         raise NotImplementedError(f"Rule-based RM for {rm_type!r} is not implemented.")
 
 
+def create_reward_pool(args, placement_group):
+    """Seat the GPU reward pool for ``--rm-type`` on the rollout placement group."""
+    if args.rm_type == "pickscore":
+        from .pickscore import AsyncPickScorePool
+
+        return AsyncPickScorePool(args, placement_group=placement_group)
+    raise ValueError(f"--colocate-reward needs a GPU reward pool, but --rm-type {args.rm_type!r} has none.")
+
+
 async def batched_async_rm(
     args,
     samples: list[Sample],

--- a/miles/rollout/rm_hub/core.py
+++ b/miles/rollout/rm_hub/core.py
@@ -8,26 +8,15 @@ import logging
 import ray
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-_manager_placement_group = None
 logger = logging.getLogger(__name__)
 
 
-def set_manager_placement_group(pg) -> None:
-    """Publish the manager's (pg, bundle_indices, gpu_ids) for colocated actor pools."""
-    global _manager_placement_group
-    _manager_placement_group = pg
-
-
-def get_manager_placement_group():
-    return _manager_placement_group
-
-
-set_reward_placement_group = set_manager_placement_group
-get_reward_placement_group = get_manager_placement_group
-
-
 class AsyncRewardActorPool:
-    """Round-robin pool for Ray reward actors exposing ``score_batch``."""
+    """Round-robin pool for Ray reward actors exposing ``score_batch``.
+
+    ``placement_group`` is the rollout manager's ``(pg, bundle_indices, gpu_ids)``;
+    a colocated pool seats one worker per bundle on it.
+    """
 
     def __init__(
         self,
@@ -38,10 +27,16 @@ class AsyncRewardActorPool:
         batch_size: int,
         num_gpus_per_worker: float,
         colocate: bool,
+        placement_group=None,
         name: str,
     ) -> None:
         if colocate:
-            pg, bundle_indices, _ = get_reward_placement_group()
+            if placement_group is None:
+                raise RuntimeError(
+                    f"--colocate-reward: the {name} pool must be seated on the rollout placement group "
+                    "before the first reward call; mixed GPU reward types need dedicated reward GPUs."
+                )
+            pg, bundle_indices, _ = placement_group
             # bundle_indices is sorted by (node, gpu); stride so workers spread across nodes
             # instead of stacking onto the first node's GPUs.
             stride = max(1, len(bundle_indices) // num_workers)

--- a/miles/rollout/rm_hub/pickscore.py
+++ b/miles/rollout/rm_hub/pickscore.py
@@ -118,7 +118,7 @@ class PickScoreRewardActor:
 class AsyncPickScorePool(AsyncRewardActorPool, metaclass=SingletonMeta):
     """Ray actor pool for GPU PickScore reward inference."""
 
-    def __init__(self, args) -> None:
+    def __init__(self, args, placement_group=None) -> None:
         super().__init__(
             actor_cls=PickScoreRewardActor,
             actor_kwargs={
@@ -129,6 +129,7 @@ class AsyncPickScorePool(AsyncRewardActorPool, metaclass=SingletonMeta):
             batch_size=args.pickscore_batch_size,
             num_gpus_per_worker=args.pickscore_num_gpus_per_worker,
             colocate=args.colocate_reward,
+            placement_group=placement_group,
             name="PickScore",
         )
 

--- a/miles/rollout/sft_rollout.py
+++ b/miles/rollout/sft_rollout.py
@@ -19,10 +19,9 @@ import torch
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from miles.rollout.base_types import RolloutFnTrainOutput
-from miles.rollout.rm_hub.core import get_manager_placement_group
 from miles.utils import tracking_utils
 from miles.utils.metric_utils import compute_rollout_step
-from miles.utils.misc import load_function
+from miles.utils.misc import SingletonMeta, load_function
 from miles.utils.types import Sample
 
 logger = logging.getLogger(__name__)
@@ -187,16 +186,15 @@ class SftEncodeActor:
         return len(items)
 
 
-_encode_actors: list | None = None
 _scheduler_grid: tuple[torch.Tensor, torch.Tensor] | None = None
 
 
-def _encode_pool(args) -> list:
-    global _encode_actors
-    if _encode_actors is None:
-        # Encode is SFT's rollout: the pool takes the rollout placement seats sglang engines use in RL.
-        pg, bundle_indices, _ = get_manager_placement_group()
-        _encode_actors = [
+class SftEncodePool(metaclass=SingletonMeta):
+    """One encode actor per rollout placement-group bundle: encode is SFT's rollout."""
+
+    def __init__(self, args, placement_group) -> None:
+        pg, bundle_indices, _ = placement_group
+        self.actors = [
             SftEncodeActor.options(
                 num_cpus=ENCODE_GPU_FRACTION,
                 num_gpus=ENCODE_GPU_FRACTION,
@@ -207,8 +205,7 @@ def _encode_pool(args) -> list:
             ).remote(args)
             for i in bundle_indices
         ]
-        logger.info("SFT encode pool: %d workers at %.2f GPU each", len(_encode_actors), ENCODE_GPU_FRACTION)
-    return _encode_actors
+        logger.info("SFT encode pool: %d workers at %.2f GPU each", len(self.actors), ENCODE_GPU_FRACTION)
 
 
 def _get_scheduler_grid(args) -> tuple[torch.Tensor, torch.Tensor]:
@@ -232,7 +229,9 @@ def _get_scheduler_grid(args) -> tuple[torch.Tensor, torch.Tensor]:
     return _scheduler_grid
 
 
-def generate_rollout(args, rollout_id, data_source, evaluation: bool = False) -> RolloutFnTrainOutput:
+def generate_rollout(
+    args, rollout_id, data_source, evaluation: bool = False, placement_group=None
+) -> RolloutFnTrainOutput:
     assert not evaluation, "sft_loss does not support eval rollouts"
     # Deterministic per epoch and idempotent; non-divisible datasets may repeat a few
     # boundary samples across an epoch wrap.
@@ -255,7 +254,7 @@ def generate_rollout(args, rollout_id, data_source, evaluation: bool = False) ->
     if missing:
         cache_dir.mkdir(parents=True, exist_ok=True)
         start = time.time()
-        actors = _encode_pool(args)
+        actors = SftEncodePool(args, placement_group).actors
         miss_items = list(missing.values())
         shards = [miss_items[i :: len(actors)] for i in range(len(actors))]
         ray.get(

--- a/tests/fast/rollout/test_rollout_placement_group.py
+++ b/tests/fast/rollout/test_rollout_placement_group.py
@@ -1,0 +1,43 @@
+"""The rollout placement group reaches actor pools as an argument, never as module state."""
+
+from tests.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-cpu", labels=[])
+
+import pytest
+
+from miles.rollout.base_types import call_rollout_fn
+from miles.rollout.rm_hub.core import AsyncRewardActorPool
+
+
+def test_call_rollout_fn_passes_the_placement_group_only_to_signatures_that_take_it():
+    """A custom rollout function written before the kwarg existed must keep working."""
+    seen = {}
+
+    def legacy(args, rollout_id, data_source, evaluation=False):
+        seen["legacy"] = "called"
+        return []
+
+    def seated(args, rollout_id, data_source, evaluation=False, placement_group=None):
+        seen["seated"] = placement_group
+        return []
+
+    pg = object()
+    call_rollout_fn(legacy, None, 0, None, evaluation=False, placement_group=pg)
+    call_rollout_fn(seated, None, 0, None, evaluation=False, placement_group=pg)
+
+    assert seen == {"legacy": "called", "seated": pg}
+
+
+def test_colocated_pool_without_seats_fails_before_creating_actors():
+    """An unplaced 0.05-GPU actor would pend in Ray forever instead of erroring."""
+    with pytest.raises(RuntimeError, match="rollout placement group"):
+        AsyncRewardActorPool(
+            actor_cls=None,
+            actor_kwargs={},
+            num_workers=1,
+            batch_size=1,
+            num_gpus_per_worker=1.0,
+            colocate=True,
+            name="PickScore",
+        )


### PR DESCRIPTION
## What

- Remove the module-level placement-group state in `miles/rollout/rm_hub/core.py` (`set_manager_placement_group` / `get_manager_placement_group` and the `set/get_reward_placement_group` aliases) and the `_encode_actors` global in `sft_rollout.py`.
- `RolloutManager` now seats the colocated reward pool itself in `__init__` (`rm_hub.create_reward_pool(args, pg)`, keyed on `--rm-type`); `pickscore_rm` keeps its `AsyncPickScorePool(args)` lookup, which hits that singleton.
- `AsyncRewardActorPool` takes `placement_group=` explicitly. A colocated pool constructed without one raises immediately — this is also the fail-fast for mixed GPU reward types under `--colocate-reward` (previously the second pool's 0.05-GPU actor pended in Ray forever).
- `call_rollout_fn` passes `placement_group=` to rollout functions whose signature declares it (same pattern as `evaluation=` on `custom_generate`); `sft_rollout.generate_rollout` uses it to build a `SftEncodePool` singleton. Rollout functions without the kwarg are untouched.

## Why

The reward pool is built lazily inside the rollout function, which has no handle on the manager, so the placement group was smuggled through a module global. The pool outlives every rollout call — its owner is the `RolloutManager`, whose `__init__` already decides where the engines sit (`init_rollout_engines`), so it is the one object that knows which bundles carry a rollout claim. #207 was about to add a second global (`_reward_slots`) on top of this one; seating pools from the manager gives that PR a place to hang its bundle accounting without any module state.

`GenerateState` was deliberately not used as the owner: its lifecycle is one rollout call (`reset()` per call), while the pool is process-lifetime.

## Validation

- `pytest tests/fast/rollout/test_rollout_placement_group.py` — 2 passed (kwarg is passed only to signatures that take it; an unseated colocated pool raises before creating actors).
- `pre-commit run` clean on the touched files.
- Not executed locally: the colocated pickscore path end-to-end. `test_h3_t2va_grpo_2xGPU` (H3 recipe, `--colocate-reward --rm-type pickscore`) covers it in this PR's CI; the three `--colocate-reward` recipes (H3, Cosmos3, Wan2.2 17-GPU) all use `--rm-type pickscore`, so `create_reward_pool` has a pool for each.

## Files

- `miles/rollout/rm_hub/core.py` — drop the globals and aliases; `placement_group=` parameter; raise when colocated without seats.
- `miles/rollout/rm_hub/__init__.py` — `create_reward_pool(args, placement_group)`.
- `miles/rollout/rm_hub/pickscore.py` — pass `placement_group` through.
- `miles/ray/rollout.py` — seat the reward pool in `__init__`; pass `placement_group=self.pg` to `call_rollout_fn`.
- `miles/rollout/base_types.py` — `call_rollout_fn` forwards `placement_group` when the signature takes it.
- `miles/rollout/sft_rollout.py` — `SftEncodePool` singleton replaces the `_encode_actors` global; `generate_rollout` declares `placement_group=`.
- `docs/user-guide/customization.md` — document the optional kwarg and who seats the reward pool.
- `tests/fast/rollout/test_rollout_placement_group.py` — new.

## Follow-ups not in scope

- `sft_rollout._scheduler_grid` is still a module-level cache (a derived constant, not placement state).
- #207 should rebase onto this and drop `_dispersal_order` / `ColocatedRewardSlots`; with the pool seated by the manager, the remaining need is one actor per bundle, which the existing stride already gives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FxEmRysrrXzWUiQxxDR9k
