### PR TITLE
fix(ci): offload the Wan proxy's text encoder so the 4-GPU e2e stops OOMing

### DIFF
--- a/scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py
+++ b/scripts/run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py
@@ -152,6 +152,7 @@ def execute(args: ScriptArgs, data_dir: str) -> None:
             "--rollout-num-gpus-per-engine 2 "
             "--rollout-parser-num-workers 16 "
             "--dp-replicate-size 1 "
+            "--sglang-text-encoder-cpu-offload "
         )
         if args.four_gpu_ci
         else (


### PR DESCRIPTION
## What

`--four-gpu-ci` on `run_diffusion_grpo_wan22_pickscore_17gpu_multinode.py` now passes `--sglang-text-encoder-cpu-offload`, so the engine parks umT5 on the host between encodes instead of keeping it resident on the training GPUs.

## Why

The stage-c-5 e2e (`test_wan22_pickscore_grpo_17xGPU_single_node_4xGPU_proxy`) OOMs intermittently in the second train step. At that point GPU 0 holds the FSDP actor (108 GB), the engine's scheduler with the parked text encoder (25 GB), one colocated PickScore worker (4.7 GB) and two engine contexts; the failing FSDP all-gather needs 672 MiB with 537 MiB free. The nightly on `main` passed the same step with 37 GB free before activations, so the margin is a few hundred MiB either way. Offloading the text encoder returns ~25 GB per GPU.

The offload goes through sglang-diffusion's component residency manager: the encoder is moved to the GPU for each encode and back afterwards, so the embeddings, and therefore the recorded e2e standards, are unchanged. The 17-GPU production branch of the script is untouched.

## Checklist

- [x] `pre-commit` passes on the touched file
- [ ] No test added: the change is a launch flag; the e2e standards check validates it (`run-ci-e2e`)
- [ ] `python3 train.py --help` not re-run (no miles flag changed)
